### PR TITLE
Add simple MPI features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/downloade
 include(autocmake_cxx)
 include(GNU.CXX)
 include(Intel.CXX)
+include(autocmake_mpi)
 include(autocmake_omp)
 include(autocmake_safeguards)
 include(autocmake_version)

--- a/cmake/autocmake.yml
+++ b/cmake/autocmake.yml
@@ -16,6 +16,7 @@ modules:
       - 'compiler_flags/Intel.CXX.cmake'
   - plugins:
     - source:
+      - '%(url_root)modules/mpi.cmake'
       - '%(url_root)modules/omp.cmake'
       - '%(url_root)modules/safeguards.cmake'
       - '%(url_root)modules/version.cmake'

--- a/config.h.in
+++ b/config.h.in
@@ -6,6 +6,8 @@
 
 #define BLAS_H "@BLAS_H@"
 
+#cmakedefine HAVE_MPI
+
 #cmakedefine HAVE_OPENMP
 
 #cmakedefine HAVE_BLAS

--- a/setup
+++ b/setup
@@ -20,6 +20,7 @@ Usage:
 Options:
   --cxx=<CXX>                            C++ compiler [default: g++].
   --extra-cxx-flags=<EXTRA_CXXFLAGS>     Extra C++ compiler flags [default: ''].
+  --mpi                                  Enable MPI parallelization [default: False].
   --omp                                  Enable OpenMP parallelization [default: False].
   --coverage                             Enable code coverage [default: False].
   --enable-tests                         Enable tests [default: False].
@@ -42,6 +43,7 @@ def gen_cmake_command(options, arguments):
     command.append('CXX={0}'.format(arguments['--cxx']))
     command.append(arguments['--cmake-executable'])
     command.append('-DEXTRA_CXXFLAGS="{0}"'.format(arguments['--extra-cxx-flags']))
+    command.append('-DENABLE_MPI={0}'.format(arguments['--mpi']))
     command.append('-DENABLE_OPENMP={0}'.format(arguments['--omp']))
     command.append('-DENABLE_CODE_COVERAGE={0}'.format(arguments['--coverage']))
     command.append('-DENABLE_TESTS={0}'.format(arguments['--enable-tests']))

--- a/src/FunctionTree.cpp
+++ b/src/FunctionTree.cpp
@@ -22,18 +22,6 @@ FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra)
     this->resetEndNodeTable();
 }
 
-/** FunctionTree constructor for Serial Tree using shared memory.
-  * */
-template<int D>
-FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory* &shMem)
-        : MWTree<D> (mra) {
-    this->serialTree_p = new SerialFunctionTree<D>(this);
-    this->serialTree_p->isShared = true;
-    this->serialTree_p->shMem = shMem;    
-    this->serialTree_p->allocRoots(*this);
-    this->resetEndNodeTable();
-}
-
 //** FunctionTree destructor. */
 template<int D>
 FunctionTree<D>::~FunctionTree() {

--- a/src/FunctionTree.cpp
+++ b/src/FunctionTree.cpp
@@ -15,9 +15,9 @@ using namespace Eigen;
 /** FunctionTree constructor for Serial Tree.
   * */
 template<int D>
-FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra)
+FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory *sh_mem)
         : MWTree<D> (mra) {
-    this->serialTree_p = new SerialFunctionTree<D>(this);
+    this->serialTree_p = new SerialFunctionTree<D>(this, sh_mem);
     this->serialTree_p->allocRoots(*this);
     this->resetEndNodeTable();
 }

--- a/src/FunctionTree.h
+++ b/src/FunctionTree.h
@@ -12,7 +12,7 @@
 template<int D>
 class FunctionTree: public MWTree<D> {
 public:
-    FunctionTree(const MultiResolutionAnalysis<D> &mra);
+    FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory *sh_mem = 0);
     virtual ~FunctionTree();
 
     void clear();

--- a/src/FunctionTree.h
+++ b/src/FunctionTree.h
@@ -9,13 +9,10 @@
 #include "MWTree.h"
 #include "SerialFunctionTree.h"
 
-class Orbital;
-
 template<int D>
 class FunctionTree: public MWTree<D> {
 public:
     FunctionTree(const MultiResolutionAnalysis<D> &mra);
-    FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory* &shMem);
     virtual ~FunctionTree();
 
     void clear();
@@ -51,8 +48,6 @@ public:
 
     template<int T>
     friend std::ostream& operator <<(std::ostream &o, FunctionTree<T> &tree);
-
-    friend void SendRcv_Orbital(Orbital* Orb, int source, int dest, int tag);
 };
 
 template<int D>

--- a/src/GenNode.h
+++ b/src/GenNode.h
@@ -49,6 +49,9 @@ protected:
     }
 
     virtual void dealloc() {
+#ifdef HAVE_OPENMP
+        omp_destroy_lock(&this->node_lock);
+#endif
         this->tree->decrementGenNodeCount();
         this->tree->getSerialTree()->deallocGenNodes(this->getSerialIx());
     }

--- a/src/OperatorNode.h
+++ b/src/OperatorNode.h
@@ -38,6 +38,9 @@ protected:
     double calcComponentNorm(int i) const;
 
     void dealloc() {
+#ifdef HAVE_OPENMP
+        omp_destroy_lock(&this->node_lock);
+#endif
         this->tree->decrementNodeCount(this->getScale());
         this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
     }

--- a/src/Printer.cpp
+++ b/src/Printer.cpp
@@ -18,8 +18,8 @@ int Printer::precision = 12;
 std::ostream *Printer::out = &std::cout;
 
 void Printer::init(int level, const char *file) {
-    int mpi_rank = mpiOrbRank;
-    int mpi_size = mpiOrbSize;
+    int mpi_rank = mpi::world.rank();
+    int mpi_size = mpi::world.size();
     if (file != 0) {
         stringstream fname;
         if (mpi_size > 1) {
@@ -53,7 +53,7 @@ void Printer::printEnvironment(int level) {
     println(level, " Linear algebra  : EIGEN");
 #endif
 
-    int nHosts = mpiOrbSize;
+    int nHosts = mpi::world.size();
     int nThreads = omp_get_max_threads();
 #ifdef HAVE_MPI
 #ifdef HAVE_OPENMP

--- a/src/Printer.cpp
+++ b/src/Printer.cpp
@@ -14,16 +14,19 @@ using namespace std;
 
 static ofstream tp_outfile;
 int Printer::printLevel = -1;
-int Printer::precision = 12;
+int Printer::printPrec = 12;
+int Printer::printRank = 0;
+int Printer::printSize = 1;
 std::ostream *Printer::out = &std::cout;
 
-void Printer::init(int level, const char *file) {
-    int mpi_rank = mpi::world.rank();
-    int mpi_size = mpi::world.size();
+void Printer::init(int level, int rank, int size, const char *file) {
+    printLevel = level;
+    printRank = rank;
+    printSize = size;
     if (file != 0) {
         stringstream fname;
-        if (mpi_size > 1) {
-            fname << file << "-" << mpi_rank << ".out";
+        if (printSize > 1) {
+            fname << file << "-" << printRank << ".out";
         } else {
             fname << file << ".out";
         }
@@ -32,15 +35,14 @@ void Printer::init(int level, const char *file) {
             setOutputStream(tp_outfile);
         }
     } else {
-        if (mpi_rank > 0) {
+        if (printRank > 0) {
             setPrintLevel(-1); // Higher ranks be quiet
         }
     }
     setScientific();
-    setPrintLevel(level);
 }
 
-void Printer::printEnvironment(int level) {
+void Printer::printEnvironment(int level, int hosts, int threads) {
     printout(level, endl);
     printSeparator(level, '-', 1);
     println(level, " MRCPP version   : " << PROGRAM_VERSION);
@@ -53,22 +55,20 @@ void Printer::printEnvironment(int level) {
     println(level, " Linear algebra  : EIGEN");
 #endif
 
-    int nHosts = mpi::world.size();
-    int nThreads = omp_get_max_threads();
 #ifdef HAVE_MPI
 #ifdef HAVE_OPENMP
     println(level, " Parallelization : MPI/OpenMP");
-    println(level, " - MPI hosts     : " << nHosts);
-    println(level, " - OMP threads   : " << nThreads);
-    println(level, " - Total cores   : " << nThreads*nHosts);
+    println(level, " - MPI hosts     : " << hosts);
+    println(level, " - OMP threads   : " << threads);
+    println(level, " - Total cores   : " << threads*hosts);
 #else
     println(level, " Parallelization : MPI");
-    println(level, " - MPI hosts     : " << nHosts);
+    println(level, " - MPI hosts     : " << hosts);
 #endif
 #else
 #ifdef HAVE_OPENMP
     println(level, " Parallelization : OpenMP");
-    println(level, " - OMP threads   : " << nThreads);
+    println(level, " - OMP threads   : " << threads);
 #else
     println(level, " Parallelization : NONE");
 #endif
@@ -138,8 +138,8 @@ int Printer::setPrintLevel(int i) {
 }
 
 int Printer::setPrecision(int i) {
-    int oldPrec = precision;
-    precision = i;
+    int oldPrec = printPrec;
+    printPrec = i;
     *out << std::setprecision(i);
     return oldPrec;
 }

--- a/src/Printer.h
+++ b/src/Printer.h
@@ -15,8 +15,8 @@ class Timer;
 
 class Printer {
 public:
-    static void init(int level = 0, const char *file = 0);
-    static void printEnvironment(int level = 0);
+    static void init(int level = 0, int rank = 0, int size = 1, const char *file = 0);
+    static void printEnvironment(int level = 0, int hosts = 1, int threads = 1);
     static void printSeparator(int level, const char &sep, int newlines = 0);
     static void printHeader(int level, const std::string &str, int newlines = 0);
     static void printFooter(int level, const Timer &t, int newlines = 0);
@@ -29,13 +29,15 @@ public:
 
     static int setPrecision(int i);
     static int setPrintLevel(int i);
-    static int getPrecision() { return precision; }
+    static int getPrecision() { return printPrec; }
     static int getPrintLevel() { return printLevel; }
 
     static std::ostream *out;
 private:
     static int printLevel;
-    static int precision;
+    static int printPrec;
+    static int printRank;
+    static int printSize;
 };
 
 #define STR_DEBUG(S,X) {std::ostringstream _str;\

--- a/src/ProjectedNode.h
+++ b/src/ProjectedNode.h
@@ -27,6 +27,9 @@ protected:
     virtual ~ProjectedNode() { assert(this->tree == 0); }
 
     void dealloc() {
+#ifdef HAVE_OPENMP
+        omp_destroy_lock(&this->node_lock);
+#endif
         this->tree->decrementNodeCount(this->getScale());
         this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
     }

--- a/src/SerialFunctionTree.cpp
+++ b/src/SerialFunctionTree.cpp
@@ -7,24 +7,21 @@ using namespace std;
 
 /** SerialTree class constructor.
  * Allocate the root FunctionNodes and fill in the empty slots of rootBox.
- * Initializes rootNodes to represent the zero function and allocate their nodes. 
+ * Initializes rootNodes to represent the zero function and allocate their nodes.
  * NOTES:
  * Serial trees are made of projected nodes, and include gennodes and loose nodes separately.
- * All created (using class creator) Projected nodes or GenNodes are loose nodes. 
- * Loose nodes have their coeff in serial Tree, but not the node part. 
- * Projected nodes and GenNodes that are created by their creator, are detroyed by destructor ~ProjectedNode and ~GenNode. 
+ * All created (using class creator) Projected nodes or GenNodes are loose nodes.
+ * Loose nodes have their coeff in serial Tree, but not the node part.
+ * Projected nodes and GenNodes that are created by their creator, are detroyed by destructor ~ProjectedNode and ~GenNode.
  * Serial tree nodes are not using the destructors, but explicitely call to deallocNodes or deallocGenNodes
  * Gen nodes and loose nodes are not counted with MWTree->[in/de]crementNodeCount()
  */
 template<int D>
-SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree)
-    : SerialTree<D>(tree),
+SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *mem)
+    : SerialTree<D>(tree, mem),
       nGenNodes(0),
       lastNode(0),
       lastGenNode(0) {
-
-    this->maxNodes = 0;
-    this->nNodes = 0;
 
     //Size for GenNodes chunks. ProjectedNodes will be 8 times larger
     this->sizeGenNodeCoeff = this->tree_p->getKp1_d();//One block
@@ -32,13 +29,13 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree)
     println(10, "SizeNode Coeff (kB) " << this->sizeNodeCoeff*sizeof(double)/1024);
     println(10, "SizeGenNode Coeff (kB) " << this->sizeGenNodeCoeff*sizeof(double)/1024);
 
-    int sizePerChunk = 2*1024*1024;// 2 MB small for no waisting place, but large enough so that latency and overhead work is negligible     
+    int sizePerChunk = 2*1024*1024;// 2 MB small for no waisting place, but large enough so that latency and overhead work is negligible
     if(D<3){
-	//define rather from number of nodes per chunk
-	this->maxNodesPerChunk = 64;
-	sizePerChunk = this->maxNodesPerChunk*this->sizeNodeCoeff;
-    }else{      
-	this->maxNodesPerChunk = (sizePerChunk/this->sizeNodeCoeff/sizeof(double)/8)*8;
+        //define rather from number of nodes per chunk
+        this->maxNodesPerChunk = 64;
+        sizePerChunk = this->maxNodesPerChunk*this->sizeNodeCoeff;
+    }else{
+        this->maxNodesPerChunk = (sizePerChunk/this->sizeNodeCoeff/sizeof(double)/8)*8;
     }
 
     this->lastNode = (ProjectedNode<D>*) this->sNodes;//position of last allocated node
@@ -63,7 +60,8 @@ template<int D>
 SerialFunctionTree<D>::~SerialFunctionTree() {
     for (int i = 0; i < this->genNodeCoeffChunks.size(); i++) delete[] this->genNodeCoeffChunks[i];
     for (int i = 0; i < this->nodeChunks.size(); i++) delete[] (char*)(this->nodeChunks[i]);
-    for (int i = 0; i < this->nodeCoeffChunks.size(); i++) delete[] this->nodeCoeffChunks[i];
+    if(not this->isShared())//if the data is shared, it must be freed by MPI_Win_free
+        for (int i = 0; i < this->nodeCoeffChunks.size(); i++) delete[] this->nodeCoeffChunks[i];
     for (int i = 0; i < this->genNodeChunks.size(); i++) delete[] (char*)(this->genNodeChunks[i]);
 
     this->nodeStackStatus.clear();
@@ -193,34 +191,34 @@ void SerialFunctionTree<D>::allocGenChildren(MWNode<D> &parent) {
 
         *(char**)(child_p) = this->cvptr_GenNode;
 
-	child_p->tree = parent.tree;
-	child_p->parent = &parent;
-	for (int i = 0; i < child_p->getTDim(); i++) {
-	    child_p->children[i] = 0;
-	}
+        child_p->tree = parent.tree;
+        child_p->parent = &parent;
+        for (int i = 0; i < child_p->getTDim(); i++) {
+            child_p->children[i] = 0;
+        }
 
-	child_p->nodeIndex = NodeIndex<D>(parent.getNodeIndex(), cIdx);
-	child_p->hilbertPath = HilbertPath<D>(parent.getHilbertPath(), cIdx);
+        child_p->nodeIndex = NodeIndex<D>(parent.getNodeIndex(), cIdx);
+        child_p->hilbertPath = HilbertPath<D>(parent.getHilbertPath(), cIdx);
 
-	child_p->n_coefs = this->sizeGenNodeCoeff;
-	child_p->coefs = coefs_p;
+        child_p->n_coefs = this->sizeGenNodeCoeff;
+        child_p->coefs = coefs_p;
 
-	child_p->serialIx = sIx;
-	child_p->parentSerialIx = parent.serialIx;
-	child_p->childSerialIx = -1;
+        child_p->serialIx = sIx;
+        child_p->parentSerialIx = parent.serialIx;
+        child_p->childSerialIx = -1;
 
-	child_p->status = 0;
+        child_p->status = 0;
 
         child_p->clearNorms();
-	child_p->setIsLeafNode();
-	child_p->setIsAllocated();
-	child_p->clearHasCoefs();
-	child_p->setIsGenNode();
+        child_p->setIsLeafNode();
+        child_p->setIsAllocated();
+        child_p->clearHasCoefs();
+        child_p->setIsGenNode();
 
-	child_p->tree->incrementGenNodeCount();
+        child_p->tree->incrementGenNodeCount();
 
 #ifdef HAVE_OPENMP
-	omp_init_lock(&child_p->node_lock);
+        omp_init_lock(&child_p->node_lock);
 #endif
 
         sIx++;
@@ -245,7 +243,18 @@ ProjectedNode<D>* SerialFunctionTree<D>::allocNodes(int nAlloc, int *serialIx, d
         //careful: nodeChunks.size() is an unsigned int
         if (chunk+1 > this->nodeChunks.size()){
             //need to allocate new chunk
-            double *sNodesCoeff = new double[this->sizeNodeCoeff*this->maxNodesPerChunk];
+            double *sNodesCoeff;
+            if (this->isShared()) {
+                //for coefficients, take from the shared memory block
+                sNodesCoeff = this->shMem->sh_end_ptr;
+                this->shMem->sh_end_ptr += (this->sizeNodeCoeff*this->maxNodesPerChunk);
+                //may increase size dynamically in the future
+                if (this->shMem->sh_max_ptr < this->shMem->sh_end_ptr) {
+                    MSG_FATAL("Shared block too small");
+                }
+            } else {
+                sNodesCoeff = new double[this->sizeNodeCoeff*this->maxNodesPerChunk];
+            }
 
             this->nodeCoeffChunks.push_back(sNodesCoeff);
             this->sNodes = (ProjectedNode<D>*) new char[this->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
@@ -256,6 +265,8 @@ ProjectedNode<D>* SerialFunctionTree<D>::allocNodes(int nAlloc, int *serialIx, d
             int newsize = oldsize + this->maxNodesPerChunk;
             for (int i = oldsize; i < newsize; i++) this->nodeStackStatus.push_back(0);
             this->maxNodes = newsize;
+
+            if (chunk%100==99 and D==3) println(10,endl<<" number of nodes "<<this->nNodes <<",number of Nodechunks now " << this->nodeChunks.size()<<", total size coeff  (MB) "<<(this->nNodes * this->sizeNodeCoeff)/1024/128);
         }
         this->lastNode = this->nodeChunks[chunk] + this->nNodes%(this->maxNodesPerChunk);
         *serialIx = this->nNodes;
@@ -268,10 +279,10 @@ ProjectedNode<D>* SerialFunctionTree<D>::allocNodes(int nAlloc, int *serialIx, d
 
     int chunk = this->nNodes/this->maxNodesPerChunk;//find the right chunk
     *coefs_p = this->nodeCoeffChunks[chunk] + chunkIx*this->sizeNodeCoeff;
- 
+
     for (int i = 0; i < nAlloc; i++) {
         if (this->nodeStackStatus[*serialIx+i] != 0)
-	    println(0, *serialIx+i<<" NodeStackStatus: not available " << this->nodeStackStatus[*serialIx+i]);
+            println(0, *serialIx+i<<" NodeStackStatus: not available " << this->nodeStackStatus[*serialIx+i]);
         this->nodeStackStatus[*serialIx+i] = 1;
         newNode_cp++;
     }
@@ -307,7 +318,7 @@ GenNode<D>* SerialFunctionTree<D>::allocGenNodes(int nAlloc, int *serialIx, doub
     omp_set_lock(&Sfunc_tree_lock);
     *serialIx = this->nGenNodes;
     int chunkIx = *serialIx%(this->maxNodesPerChunk);
-  
+
     //Not necessarily wrong, but new:
     assert(nAlloc == (1<<D));
 
@@ -321,21 +332,21 @@ GenNode<D>* SerialFunctionTree<D>::allocGenNodes(int nAlloc, int *serialIx, doub
 
         //careful: nodeChunks.size() is an unsigned int
         if(chunk+1 > this->genNodeChunks.size()){
-	    //need to allocate new chunk
-	    this->sGenNodes = (GenNode<D>*) new char[this->maxNodesPerChunk*sizeof(GenNode<D>)];
-	    this->genNodeChunks.push_back(this->sGenNodes);
-	    double *sGenNodesCoeff = new double[this->sizeGenNodeCoeff*this->maxNodesPerChunk];
-	    this->genNodeCoeffChunks.push_back(sGenNodesCoeff);
-	    //allocate new chunk in nodeStackStatus
-	    int oldsize = this->genNodeStackStatus.size();
-	    int newsize = oldsize + this->maxNodesPerChunk;
-	    for (int i = oldsize; i < newsize; i++) this->genNodeStackStatus.push_back(0);
-	    this->maxGenNodes = newsize;
+            //need to allocate new chunk
+            this->sGenNodes = (GenNode<D>*) new char[this->maxNodesPerChunk*sizeof(GenNode<D>)];
+            this->genNodeChunks.push_back(this->sGenNodes);
+            double *sGenNodesCoeff = new double[this->sizeGenNodeCoeff*this->maxNodesPerChunk];
+            this->genNodeCoeffChunks.push_back(sGenNodesCoeff);
+            //allocate new chunk in nodeStackStatus
+            int oldsize = this->genNodeStackStatus.size();
+            int newsize = oldsize + this->maxNodesPerChunk;
+            for (int i = oldsize; i < newsize; i++) this->genNodeStackStatus.push_back(0);
+            this->maxGenNodes = newsize;
 
-	    if(chunk%100==99 and D==3)println(10,endl<<" number of GenNodes "<<this->nGenNodes <<",number of GenNodechunks now " << this->genNodeChunks.size()<<", total size coeff  (MB) "<<(this->nGenNodes/1024) * this->sizeGenNodeCoeff/128);
+            if(chunk%100==99 and D==3)println(10,endl<<" number of GenNodes "<<this->nGenNodes <<",number of GenNodechunks now " << this->genNodeChunks.size()<<", total size coeff  (MB) "<<(this->nGenNodes/1024) * this->sizeGenNodeCoeff/128);
         }
         this->lastGenNode = this->genNodeChunks[chunk] + this->nGenNodes%(this->maxNodesPerChunk);
-        *serialIx = this->nGenNodes; 
+        *serialIx = this->nGenNodes;
         chunkIx = *serialIx%(this->maxNodesPerChunk);
     }
     assert((this->nGenNodes+nAlloc-1)/this->maxNodesPerChunk < this->genNodeChunks.size());
@@ -349,13 +360,13 @@ GenNode<D>* SerialFunctionTree<D>::allocGenNodes(int nAlloc, int *serialIx, doub
     for (int i = 0; i < nAlloc; i++) {
         newNode_cp->serialIx = *serialIx+i;//Until overwritten!
         if (this->genNodeStackStatus[*serialIx+i] != 0)
-	    println(0, *serialIx+i<<" NodeStackStatus: not available " << this->genNodeStackStatus[*serialIx+i]);
+            println(0, *serialIx+i<<" NodeStackStatus: not available " << this->genNodeStackStatus[*serialIx+i]);
         this->genNodeStackStatus[*serialIx+i] = 1;
         newNode_cp++;
     }
     this->nGenNodes += nAlloc;
     this->lastGenNode += nAlloc;
-    
+
     omp_unset_lock(&Sfunc_tree_lock);
     return newNode;
 }
@@ -373,10 +384,10 @@ void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
         while (this->genNodeStackStatus[topStack-1] == 0) {
             topStack--;
             if (topStack < 1) {
-		//remove all the GenNodeChunks once there are noe more genNodes
-		this->deallocGenNodeChunks();
-		break;
-	    }
+                //remove all the GenNodeChunks once there are noe more genNodes
+                this->deallocGenNodeChunks();
+                break;
+            }
         }
         this->nGenNodes = topStack;//move top of stack
         //has to redefine lastGenNode
@@ -388,6 +399,7 @@ void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
 
 template<int D>
 void SerialFunctionTree<D>::deallocGenNodeChunks() {
+    //if(mpiOrbRank==0 and (this->genNodeCoeffChunks.size()*2)*1024/8>10000)cout<<"deallocate genchunks MB "<<(this->genNodeCoeffChunks.size()*2)*1024/1024/8<<endl;
     for (int i = 0; i < this->genNodeCoeffChunks.size(); i++) delete[] this->genNodeCoeffChunks[i];
     for (int i = 0; i < this->genNodeChunks.size(); i++) delete[] (char*)(this->genNodeChunks[i]);
     this->genNodeCoeffChunks.clear();
@@ -396,11 +408,11 @@ void SerialFunctionTree<D>::deallocGenNodeChunks() {
 }
 
 /** Overwrite all pointers defined in the tree.
- * Necessary after sending the tree 
+ * Necessary after sending the tree
  * could be optimized. Should reset other counters? (GenNodes...) */
 template<int D>
 void SerialFunctionTree<D>::rewritePointers(int nChunks){
-    
+
     int depthMax = 100;
     MWNode<D>* stack[depthMax*8];
     int slen = 0, counter = 0;
@@ -408,7 +420,7 @@ void SerialFunctionTree<D>::rewritePointers(int nChunks){
     this->getTree()->nNodes = 0;
     this->getTree()->nodesAtDepth.clear();
     this->getTree()->squareNorm = 0.0;
-  
+
     //reinitialize stacks
     int nodecount = nChunks * this->maxNodesPerChunk;
     this->nodeStackStatus.resize(nodecount);
@@ -425,41 +437,41 @@ void SerialFunctionTree<D>::rewritePointers(int nChunks){
     this->maxGenNodes = 0;
 
     for(int ichunk = 0 ; ichunk < nChunks; ichunk++){
-	for(int inode = 0 ; inode < this->maxNodesPerChunk; inode++){
-	    ProjectedNode<D>* Node = (this->nodeChunks[ichunk]) + inode;
-	    if (Node->serialIx >= 0) {
-		//Node is part of tree, should be processed
-		this->getTree()->incrementNodeCount(Node->getScale());
-		if (Node->isEndNode()) this->getTree()->squareNorm += Node->getSquareNorm();
-	  
-		//normally (intel) the virtual table does not change, but we overwrite anyway
-		*(char**)(Node) = this->cvptr_ProjectedNode;
-	  
-		Node->tree = this->getTree();
+        for(int inode = 0 ; inode < this->maxNodesPerChunk; inode++){
+            ProjectedNode<D>* Node = (this->nodeChunks[ichunk]) + inode;
+            if (Node->serialIx >= 0) {
+                //Node is part of tree, should be processed
+                this->getTree()->incrementNodeCount(Node->getScale());
+                if (Node->isEndNode()) this->getTree()->squareNorm += Node->getSquareNorm();
 
-		//"adress" of coefs is the same as node, but in another array
-		Node->coefs = this->nodeCoeffChunks[ichunk]+ inode*this->sizeNodeCoeff;
-	  
-		//adress of parent and children must be corrected
-		//can be on a different chunks
-		if(Node->parentSerialIx>=0){
-		    int n_ichunk = Node->parentSerialIx/this->maxNodesPerChunk;
-		    int n_inode = Node->parentSerialIx%this->maxNodesPerChunk;
-		    Node->parent = this->nodeChunks[n_ichunk] + n_inode;
-		}else{Node->parent = 0;}
-	    
-		for (int i = 0; i < Node->getNChildren(); i++) {
-		    int n_ichunk = (Node->childSerialIx+i)/this->maxNodesPerChunk;
-		    int n_inode = (Node->childSerialIx+i)%this->maxNodesPerChunk;
-		    Node->children[i] = this->nodeChunks[n_ichunk] + n_inode;
-		}
-		this->nodeStackStatus[Node->serialIx] = 1;//occupied
+                //normally (intel) the virtual table does not change, but we overwrite anyway
+                *(char**)(Node) = this->cvptr_ProjectedNode;
+
+                Node->tree = this->getTree();
+
+                //"adress" of coefs is the same as node, but in another array
+                Node->coefs = this->nodeCoeffChunks[ichunk]+ inode*this->sizeNodeCoeff;
+
+                //adress of parent and children must be corrected
+                //can be on a different chunks
+                if(Node->parentSerialIx>=0){
+                    int n_ichunk = Node->parentSerialIx/this->maxNodesPerChunk;
+                    int n_inode = Node->parentSerialIx%this->maxNodesPerChunk;
+                    Node->parent = this->nodeChunks[n_ichunk] + n_inode;
+                }else{Node->parent = 0;}
+
+                for (int i = 0; i < Node->getNChildren(); i++) {
+                    int n_ichunk = (Node->childSerialIx+i)/this->maxNodesPerChunk;
+                    int n_inode = (Node->childSerialIx+i)%this->maxNodesPerChunk;
+                    Node->children[i] = this->nodeChunks[n_ichunk] + n_inode;
+                }
+                this->nodeStackStatus[Node->serialIx] = 1;//occupied
 #ifdef HAVE_OPENMP
-		omp_init_lock(&(Node->node_lock));
+                omp_init_lock(&(Node->node_lock));
 #endif
-	    }
+            }
 
-	}
+        }
     }
 
     //update other MWTree data
@@ -469,7 +481,7 @@ void SerialFunctionTree<D>::rewritePointers(int nChunks){
     MWNode<D> **roots = rBox.getNodes();
 
     for (int rIdx = 0; rIdx < rBox.size(); rIdx++) {
-	roots[rIdx] = (this->nodeChunks[0]) + rIdx;//adress of roots are at start of NodeChunks[0] array
+        roots[rIdx] = (this->nodeChunks[0]) + rIdx;//adress of roots are at start of NodeChunks[0] array
     }
 
     this->getTree()->resetEndNodeTable();

--- a/src/SerialFunctionTree.h
+++ b/src/SerialFunctionTree.h
@@ -21,7 +21,7 @@ template<int D> class GenNode;
 template<int D>
 class SerialFunctionTree : public SerialTree<D> {
 public:
-    SerialFunctionTree(FunctionTree<D> *tree);
+    SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *sh_mem);
     virtual ~SerialFunctionTree();
 
     virtual void allocRoots(MWTree<D> &tree);

--- a/src/SerialOperatorTree.cpp
+++ b/src/SerialOperatorTree.cpp
@@ -18,7 +18,7 @@ int NOtrees=0;
   * Gen nodes and loose nodes are not counted with MWTree->[in/de]crementNodeCount()
 */
 SerialOperatorTree::SerialOperatorTree(OperatorTree *tree)
-        : SerialTree<2>(tree),
+        : SerialTree<2>(tree, 0),
           lastNode(0) {
 
     this->maxNodes = 0;

--- a/src/SerialOperatorTree.cpp
+++ b/src/SerialOperatorTree.cpp
@@ -30,8 +30,6 @@ SerialOperatorTree::SerialOperatorTree(OperatorTree *tree)
     this->maxNodesPerChunk = 64;
     int sizePerChunk = this->maxNodesPerChunk*this->sizeNodeCoeff;
    
-    if(mpiOrbRank==0 and NOtrees%100==1)println(10, "nodes per chunk = " << this->maxNodesPerChunk<<" sizePerChunk "<<sizePerChunk<<" N Op trees: "<<NOtrees);
-
     this->lastNode = (OperatorNode*) this->sNodes;//position of last allocated node
 
     //make virtual table pointers

--- a/src/SerialTree.cpp
+++ b/src/SerialTree.cpp
@@ -14,7 +14,11 @@ SerialTree<D>::SerialTree(MWTree<D> *tree, SharedMemory *mem)
           coeffStack(0),
           maxNodes(0),
           tree_p(tree),
+#ifdef HAVE_MPI
           shMem(mem) {
+#else
+          shMem(0) {
+#endif
 }
 
 /** Make children scaling coefficients from parent

--- a/src/SerialTree.cpp
+++ b/src/SerialTree.cpp
@@ -6,6 +6,16 @@
 using namespace Eigen;
 using namespace std;
 
+template<int D>
+SerialTree<D>::SerialTree(MWTree<D> *tree, SharedMemory *mem)
+        : nNodes(0),
+          maxNodesPerChunk(0),
+          sizeNodeCoeff(0),
+          coeffStack(0),
+          maxNodes(0),
+          tree_p(tree),
+          shMem(mem) {
+}
 
 /** Make children scaling coefficients from parent
  * Other node info are not used/set

--- a/src/SerialTree.h
+++ b/src/SerialTree.h
@@ -20,7 +20,7 @@ template<int D> class MWNode;
 template<int D>
 class SerialTree {
 public:
-    SerialTree(MWTree<D> *tree) : isShared(false), shMem(0), tree_p(tree) { }
+    SerialTree(MWTree<D> *tree) : tree_p(tree) { }
     virtual ~SerialTree() { }
 
     MWTree<D>* getTree() { return this->tree_p; }
@@ -42,11 +42,8 @@ public:
     int sizeNodeCoeff;          //size of coeff for one node
     double **coeffStack;
     int maxNodes;               //max number of nodes that can be defined
-    bool isShared;              //The coefficients are stored in shared memory
-    SharedMemory *shMem;
     
 
 protected:
     MWTree<D> *tree_p;
 };
-

--- a/src/SerialTree.h
+++ b/src/SerialTree.h
@@ -20,10 +20,13 @@ template<int D> class MWNode;
 template<int D>
 class SerialTree {
 public:
-    SerialTree(MWTree<D> *tree) : tree_p(tree) { }
+    SerialTree(MWTree<D> *tree, SharedMemory *mem);
     virtual ~SerialTree() { }
 
     MWTree<D>* getTree() { return this->tree_p; }
+    SharedMemory* getMemory() { return this->shMem; }
+
+    bool isShared() const { if (this->shMem == 0) return false; return true; }
 
     virtual void allocRoots(MWTree<D> &tree) = 0;
     virtual void allocChildren(MWNode<D> &parent) = 0;
@@ -42,8 +45,8 @@ public:
     int sizeNodeCoeff;          //size of coeff for one node
     double **coeffStack;
     int maxNodes;               //max number of nodes that can be defined
-    
 
 protected:
     MWTree<D> *tree_p;
+    SharedMemory *shMem;
 };

--- a/src/constants.h
+++ b/src/constants.h
@@ -12,6 +12,7 @@ const int MaxDepth = 30; ///< Maximum depth of trees
 const int MaxScale = 31; ///< Maximum scale of trees
 const int MinScale = -31; ///< Minimum scale of trees
 const int MaxSepRank = 1000;
+const int SharedMemSize = 1000; ///< Default size (Mb) of MPI shared memory blocks
 
 namespace Axis {
 const int None = -1;

--- a/src/constants.h
+++ b/src/constants.h
@@ -12,10 +12,6 @@ const int MaxDepth = 30; ///< Maximum depth of trees
 const int MaxScale = 31; ///< Maximum scale of trees
 const int MinScale = -31; ///< Minimum scale of trees
 const int MaxSepRank = 1000;
-//Max number of orbitals stored temporarily. Larger->more memory
-//Also max size of orbitalvector that can be sent with send_OrbVec
-const int workOrbVecSize = 10;
-
 
 namespace Axis {
 const int None = -1;

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -1,545 +1,87 @@
-#include <iostream>
 #include "parallel.h"
-#include "Printer.h"
-#include "Timer.h"
 #include "FunctionTree.h"
 #include "ProjectedNode.h"
 #include "SerialFunctionTree.h"
-#include "SerialTree.h"
-#include "InterpolatingBasis.h"
-#include "MultiResolutionAnalysis.h"
+#include "Printer.h"
+#include "Timer.h"
 
+mpi::communicator mpi::world;
 
 using namespace std;
 
-int mpiOrbRank = 0;
-int mpiOrbSize = 1;
-int mpiShRank = 0;
-int mpiShSize = 1;
-
-#ifdef HAVE_MPI
-MPI_Comm mpiCommOrb;
-MPI_Comm mpiCommSh;
-#endif
-
-/** sh_size in MB
- */
-SharedMemory::SharedMemory(int sh_size){
-    this->allocShmem(sh_size);
-}
-
-SharedMemory::~SharedMemory(){
-#ifdef HAVE_MPI
-    MPI_Win_free(&this->sh_win);//deallocates the memory block
-#endif
-}
-
-void SharedMemory::allocShmem(int sh_size){
-#ifdef HAVE_MPI
-    //MPI_Aint types are used for adresses (can be larger than int).
-    MPI_Aint size = (mpiShRank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
-    int disp_unit = 16;//in order for the compiler to keep aligned. 
-    //size is in bytes
-    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, mpiCommSh, &this->sh_start_ptr, &this->sh_win);
-    MPI_Win_fence(0, this->sh_win);//wait until finished
-    MPI_Aint qsize = 0;
-    int qdisp = 0;
-    MPI_Win_shared_query(this->sh_win, 0, &qsize, &qdisp, &this->sh_start_ptr);
-    //    printf("me = %d, allocated: size=%zu, bytes at = %p %d\n", mpiShRank, qsize, this->sh_start_ptr, this->sh_start_ptr );
-    MPI_Win_fence(0, this->sh_win);
-    this->sh_max_ptr = this->sh_start_ptr + qsize/sizeof(double);
-    //printf("me = %d, start = %p, max  = %p diff %d\n", mpiShRank, this->sh_start_ptr, this->sh_max_ptr, this->sh_max_ptr-this->sh_start_ptr);
-    this->sh_end_ptr = this->sh_start_ptr;
-    //if(mpiOrbRank==0)d_ptr[18]=2.34;
-    //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
-#endif
-}
-
-
-/** Send or receive a serial tree using MPI
- */
-void MPI_Initializations(){
-
-#ifdef HAVE_MPI
-    MPI_Init(NULL, NULL);
-    define_MPI_groups();
-#endif
-}
-
 #ifdef HAVE_MPI
 template<int D>
-void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm){
-    MPI_Status status;
-    Timer timer;
-    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
-  
-    println(10," STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
-    int count = 1;
-    int STreeMeta[count];
+void mpi::communicator::send_tree(mpi::tree_request<D> &request, int dst) {
+    if (request.s_tree == 0) MSG_FATAL("Invalid request");
+
+    SerialFunctionTree<D> &sTree = *request.s_tree;
+    if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
     
-    if(STree->nGenNodes != 0)MSG_FATAL("sending of GenNodes not implemented");
-  
-    timer.start();
-    for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-	//set serialIx of the unused nodes to -1
-	int ishift = ichunk*STree->maxNodesPerChunk;
-	for (int i = 0; i < STree->maxNodesPerChunk; i++){
-	    if(STree->nodeStackStatus[ishift+i] !=1 )(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
-	}
-	MPI_Send(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm);
-	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if (not STree->isShared or not orbIsSh(dest)){
-	    MPI_Send(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm);}
+    MPI_Send(&request.n_chunks, sizeof(int), MPI_BYTE, dst, request.tag, this->comm);
+    println(10, " Sending " << request.n_chunks << " chunks");
+
+    Timer t1;
+    int count = 1;
+    for (int iChunk = 0; iChunk < request.n_chunks; iChunk++) {
+        count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
+        //set serialIx of the unused nodes to -1
+        int iShift = iChunk*sTree.maxNodesPerChunk;
+        for (int i = 0; i < sTree.maxNodesPerChunk; i++) {
+            if (sTree.nodeStackStatus[iShift+i] !=1)
+                sTree.nodeChunks[iChunk][i].setSerialIx(-1);
+        }
+        MPI_Send(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, request.tag+1+iChunk, this->comm);
+        count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
+        MPI_Send(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, request.tag+iChunk*1000, this->comm);
     }
-  
-    timer.stop();
-    println(10," time send     " << timer); 
+    t1.stop();
+    println(10, " Time send                   " << setw(30) << t1);
 }
 #endif
 
 #ifdef HAVE_MPI
 template<int D>
-void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request){
-    MPI_Status status;
-    Timer timer;
-    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
-  
-    println(10,mpiOrbRank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
+void mpi::communicator::recv_tree(mpi::tree_request<D> &request, int src) {
+    if (request.s_tree == 0) MSG_FATAL("Invalid request");
+
+    SerialFunctionTree<D> &sTree = *request.s_tree;
+
+    MPI_Recv(&request.n_chunks, sizeof(int), MPI_BYTE, src, request.tag, this->comm, &request.mpi_stat);
+    println(10, " Recieving " << request.n_chunks << " chunks");
+
+    Timer t1;
     int count = 1;
-    int STreeMeta[count];
-
-    timer.start();
-    for (int ichunk = 0 ; ichunk < Nchunks ; ichunk++){
-	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-	//set serialIx of the unused nodes to -1
-	int ishift = ichunk*STree->maxNodesPerChunk;
-	for (int i = 0; i < STree->maxNodesPerChunk; i++){
-	    if (STree->nodeStackStatus[ishift+i] != 1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
-	}
-	MPI_Isend(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm, &request);
-	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if (not STree->isShared or not orbIsSh(dest)){
-	    MPI_Isend(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm, &request);}
+    for (int iChunk = 0; iChunk < request.n_chunks; iChunk++) {
+        if (iChunk < sTree.nodeChunks.size()) {
+            sTree.sNodes = sTree.nodeChunks[iChunk];
+        } else {
+            double *sNodesCoeff;
+            sNodesCoeff = new double[sTree.sizeNodeCoeff*sTree.maxNodesPerChunk];
+            sTree.nodeCoeffChunks.push_back(sNodesCoeff);
+            sTree.sNodes = (ProjectedNode<D>*) new char[sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>)];
+            sTree.nodeChunks.push_back(sTree.sNodes);
+        }
+        count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
+        MPI_Recv(sTree.nodeChunks[iChunk], count, MPI_BYTE, src, request.tag+1+iChunk, this->comm, &request.mpi_stat);
+        count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
+        MPI_Recv(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, src, request.tag+iChunk*1000, this->comm, &request.mpi_stat);
     }
-    timer.stop();
-    println(10, " time send     " << timer); 
+    t1.stop();
+    println(10, " Time recieve                " << setw(30) << t1);
+
+    Timer t2;
+    sTree.rewritePointers(request.n_chunks);
+    t2.stop();
+    println(10, " Time rewrite pointers       " << setw(30) << t2);
 }
 #endif
 
 #ifdef HAVE_MPI
-template<int D>
-void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI_Comm comm){
-    MPI_Status status;
-    Timer timer;
-    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
-  
-    println(10, mpiOrbRank<<" STree  at "<<STree<<" receiving  "<<Nchunks<<" chunks from "<<source);
-    int count = 1;
-    int STreeMeta[count];
-
-    timer.start();
-    for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-	if (ichunk<STree->nodeChunks.size()) {
-	    STree->sNodes = STree->nodeChunks[ichunk];
-	}else{
-	    double *sNodesCoeff;
-	    if( STree->isShared and orbIsSh(source)) {
-		if(ichunk == 0) STree->shMem->sh_end_ptr = STree->shMem->sh_start_ptr;
-		sNodesCoeff = STree->shMem->sh_end_ptr;	
-		STree->shMem->sh_end_ptr += (STree->sizeNodeCoeff*STree->maxNodesPerChunk);		
-	    }else{
-		sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
-	    }
-	    STree->nodeCoeffChunks.push_back(sNodesCoeff);
-	    STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
-	    STree->nodeChunks.push_back(STree->sNodes);
-	}      
-	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-	MPI_Recv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &status);
-	println(10, mpiOrbRank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
-	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if( not STree->isShared or not orbIsSh(source)) {
-	    MPI_Recv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &status);}
-	println(10, " received  "<<count<<" coefficients from "<<source);
-    }
-    timer.stop();
-    println(10, " time receive  " << timer);
-    timer.start();
-    STree->rewritePointers(Nchunks);
-    timer.stop();
-    println(10, " time rewrite pointers  " << timer);
-
-}
-#endif
-
-#ifdef HAVE_MPI
-template<int D>
-void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI_Comm comm){
-    MPI_Status status;
-    Timer timer;
-    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
-  
-
-    println(10, mpiOrbRank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" receiving from "<<source);
-    int count = 1;
-    int STreeMeta[count];
-
-    MPI_Request request=MPI_REQUEST_NULL;
-
-    timer.start();
-    for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-	if (ichunk<STree->nodeChunks.size()) {
-	    STree->sNodes = STree->nodeChunks[ichunk];
-	}else{
-	    double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
-	    STree->nodeCoeffChunks.push_back(sNodesCoeff);
-	    STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
-	    STree->nodeChunks.push_back(STree->sNodes);
-	}      
-	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-	MPI_Irecv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &request);
-	println(10, mpiOrbRank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
-	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if (not STree->isShared or mpiOrbRank/mpiShSize != source/mpiShSize){
-	    MPI_Irecv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &request);}
-	println(10, mpiOrbRank<<" received  "<<count<<" coefficients from "<<source);
-    }
-
-
-    timer.stop();
-    println(10, " time receive  " << timer);
-    timer.start();
-    STree->rewritePointers(Nchunks);
-    timer.stop();
-    println(10, " time rewrite pointers  " << timer);
-
-}
-#endif
-
-
-/** Assign work among MPI processes
- * For a NxN loop. Does assume symmetry
- * At each iteration data is processed, data is sent and data is received.
- * input: 
- * N, the size of one loop 
- * iter, the iteration 
- * output: 
- * which (i,j) pair to compute next
- * to whom send own data, from who receive data
- * NB: does not work for N even when N is not a multiple of mpiOrbSize
- */
-void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter){
-    int iter = 0;
-    int NBlock=N/mpiOrbSize;//number of subblocks
-    int M = N%mpiOrbSize; //number of lines and column left after subblocks are taken out
-    int Maxiter=-1;
-    int iter_base;
-    int iBlock = 0;
-    int jBlock = 0;
-
-    if(N%2==0 and N%mpiOrbSize!=0 ) MSG_FATAL("Assign_NxN_sym not implemented for this case");
-    for (iter = 0; iter < *MaxIter; iter++) {
-	doi[iter] = -1;
-	doj[iter] = -1;
-	sendto[iter] = -1;
-	sendorb[iter] = -1;
-	rcvorb[iter] = -1;
-    }
-
-    for (int dBlock = 0; dBlock < (N+mpiOrbSize-1)/mpiOrbSize; dBlock++) {
-	//treat diagonal block first
-	int imax=mpiOrbSize;//size of the diagonal block
-	if(dBlock == NBlock) imax=M;
-	int jmax=mpiOrbSize;
-	if(dBlock == NBlock) jmax=M;
-	for (int i = 0; i < imax; i++) {
-	    for (int j = 0; j < jmax; j++) {
-
-		//used in a diagonal block: 1+mpiOrbSize/2 
-		//used in a block below diagonal: (1+mpiOrbSize)*0.5
-		//   if even mpiOrbRank: 1+mpiOrbSize/2 if even block, and mpiOrbSize/2 if odd block, 0.5*(1+mpiOrbSize) on average, 
-		//used in a block over diagonal: (1+mpiOrbSize)*0.5-1
-		//number of entire blocks in a column: N/mpiOrbSize 
-		//possibly used in lowest reduced block in column: M/2
-		//used in all blocks in one column d (starting at 0): (1+(N/mpiOrbSize)*(1+mpiOrbSize))/2-d+M/2
-		//used in all blocks up to column d, without d: d*(1+(N/mpiOrbSize)*(1+mpiOrbSize))/2-(d*(d-1))/2+d*M/2
-
-
-		//(mpiOrbSize+j-i)%mpiOrbSize : for one block
-		//((N+mpiOrbSize-1)/mpiOrbSize) : number of blocks in one column
-		//-dBlock: The diagonal is not counted again in each block
-		iter_base = (mpiOrbSize+j-i)%mpiOrbSize * ((N+mpiOrbSize-1)/mpiOrbSize)-dBlock;
-		if( i == j ) iter_base = 0;
-		//the last block may be smaller
-		if( dBlock == NBlock )iter_base = (imax+j-i)%M * ((N+mpiOrbSize-1)/mpiOrbSize);
-		//Shift for all the columns already taken into account
-		iter = iter_base + dBlock*((1+((N+mpiOrbSize-1)/mpiOrbSize)*(1+mpiOrbSize))/2) - (dBlock*(dBlock-1))/2 + dBlock*M/2;
-
-		if( (imax+j-i)%imax <= imax/2 ){
-		    int i_glob = i + dBlock*mpiOrbSize;
-		    int j_glob = j + dBlock*mpiOrbSize;
-
-		    if(i == mpiOrbRank and ( imax%2!=0 or (imax+j-i)%imax < imax/2 or i < j )) {
-			if(iter > Maxiter) Maxiter = iter;
-			doi[iter]=i_glob;
-			doj[iter]=j_glob;
-			if(i!=j)rcvorb[iter]=j_glob;
-			if(imax%2 == 0 and (imax+j-i)%imax == imax/2 and i < j) {
-			    sendto[iter] = j;
-			    sendorb[iter] = i_glob;	    
-			}
-		    }else if(j == mpiOrbRank and ( imax%2 != 0 or (imax+j-i)%imax < imax/2 or i < j )){
-			sendto[iter] = i;
-			sendorb[iter] = j_glob;
-			if(imax%2 == 0 and (imax+j-i)%imax == imax/2 and i < j){
-			    rcvorb[iter] = i;
-			}
-		    }
-
-		    //all columns that can be generated from received data.	
-		    if ((i == mpiOrbRank and (i <= j or (mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2) ))){
-			for (int icol = i; icol < N; icol+=mpiOrbSize) {
-			    iBlock = icol/mpiOrbSize;
-			    if ((i != j or iBlock > dBlock) and  (mpiOrbSize%2 != 0 or ((imax+j-i)%imax < imax/2) or ((iBlock+dBlock)%2 != 0 and i > j) or ((iBlock+dBlock)%2 == 0 and i < j)  )){
-				if (iBlock != dBlock) {
-				    int sh=1;//diagonal block is the first
-				    if(iBlock>dBlock)sh=0;//diagonal block accounted for
-				    if(i==j)sh=-dBlock;//only below diagonal are counted
-				    if(mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2) sh = -(iBlock+1)/2;//only half are present
-				    if(mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2 and (dBlock%2 == 0 and iBlock == 0)) sh = 1;//same iter as diagonalblock
-				    if(mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2 and (dBlock%2 != 0 and iBlock == 1)) sh = 1;//iBlock=0 same iter as diagonal block, start next iter
-				    int i_glob = i + iBlock*mpiOrbSize;
-				    int j_glob = j + dBlock*mpiOrbSize;
-				    if ((imax+j-i)%imax <= imax/2 ) {
-					doi[iter+iBlock+sh] = i_glob;
-					doj[iter+iBlock+sh] = j_glob;}
-				    //rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
-				    //sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
-				    //sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
-				    if(iter+iBlock+sh > Maxiter) Maxiter = iter+iBlock+sh;
-				}
-			    }
-			}
-		    }else if(i == mpiOrbRank) {
-			//part of blocks below blockdiagonal
-			//for (jBlock = 0; jBlock < NBlock; jBlock++) {
-			for (int jrow = j; jrow < N; jrow+=mpiOrbSize) {
-			    jBlock = jrow/mpiOrbSize;
-			    if(jBlock != dBlock  and (mpiOrbSize%2 or (imax+j-i)%imax < (imax)/2 or (jBlock%2 == 0))){
-				int sh = 1;
-				if(jBlock > dBlock) sh = 0;//not very elegant
-				int i_glob = i + dBlock*mpiOrbSize;
-				int j_glob = j + jBlock*mpiOrbSize;
-				if((imax+j-i)%imax<(imax+1)/2){
-				    doi[iter+jBlock+sh] = i_glob;
-				    doj[iter+jBlock+sh] = j_glob;}
-				//rcvorb[iter+jBlock+sh]=-1;//indicates "use same as before"
-				//sendorb[iter+jBlock+sh]=-1;//indicates "do not send anything"
-				//sendto[iter+jBlock+sh]=-1;//indicates "do not send anything"
-				if(iter+jBlock+sh>Maxiter)Maxiter=iter+jBlock+sh;
-			    }
-			}
-		    }
-		}
-	    }
-	}
-    }
-
-    *MaxIter = Maxiter;
-}
-
-
-/** Assign work among MPI processes
- * For a NxN loop. Does not assume symmetry
- * At each iteration data is processed, data is sent and data is received.
- * input: 
- * N, the size of one loop 
- * iter, the iteration 
- * output: 
- * which (i,j) pair to compute next
- * to whom send own data, from who receive data
- */
-void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter){
-    int iter = 0;
-    int NBlock=N/mpiOrbSize;//number of subblocks
-    int M = N%mpiOrbSize; //number of lines and column left after subblocks are taken out
-    int Maxiter = -1;
-    int iter_base;
-    int iBlock = 0;
-    int jBlock = 0;
-
-    for (iter = 0; iter < *MaxIter; iter++) {
-	doi[iter] = -1;
-	doj[iter] = -1;
-	sendto[iter] = -1;
-	sendorb[iter] = -1;
-	rcvorb[iter] = -1;
-    }
-
-    for (int dBlock = 0; dBlock < (N+mpiOrbSize-1)/mpiOrbSize; dBlock++) {
-
-	//1)  //diagonal block
-	int imax=mpiOrbSize;
-	if(dBlock==NBlock)imax=M;
-	int jmax=mpiOrbSize;
-	if(dBlock==NBlock)jmax=M;
-	for (int i = 0; i < imax; i++) {
-	    for (int j = 0; j < jmax; j++) {
-		iter_base = (i+j)%mpiOrbSize * ((N+mpiOrbSize-1)/mpiOrbSize);
-		if(dBlock==NBlock)iter_base = (i+j)%M * ((N+mpiOrbSize-1)/mpiOrbSize);
-		iter = iter_base + dBlock*mpiOrbSize*((N+mpiOrbSize-1)/mpiOrbSize);
-		int i_glob = i + dBlock*mpiOrbSize;
-		int j_glob = j + dBlock*mpiOrbSize;
-		if(i==mpiOrbRank){
-		    //this processor receive orbital j_glob from MPIrank=j, and send its own orbital i_glob to MPIrank=j.
-		    if(iter>Maxiter)Maxiter=iter;
-		    doi[iter]=i_glob;
-		    doj[iter]=j_glob;
-		    if(i==j){
-			sendto[iter]=-1;
-			sendorb[iter]=-1;
-			rcvorb[iter]=-1;
-		    }else{
-			sendto[iter]=j;
-			sendorb[iter]=i_glob;
-			rcvorb[iter]=j_glob;}// contains info both which orbital and indirectly who from
-		}
-		//2)	//treat all rows and columns that can be generated from received data	
-		if(i<=j and i==mpiOrbRank){
-		    //do the corresponding column 
-		    //for (iBlock = 0; iBlock < NBlock; iBlock++) {
-		    for (int icol = i; icol < N; icol+=mpiOrbSize) {
-			iBlock=icol/mpiOrbSize;
-			if(iBlock!=dBlock){
-			    int sh=1;
-			    if(iBlock>dBlock)sh=0;//not very elegant
-			    int i_glob = i + iBlock*mpiOrbSize;
-			    int j_glob = j + dBlock*mpiOrbSize;
-			    doi[iter+iBlock+sh] = i_glob;
-			    doj[iter+iBlock+sh] = j_glob;
-			    rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
-			    sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
-			    sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
-			    if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
-			}
-		    }
-		}else if(i==mpiOrbRank){
-		    //do the corresponding row
-		    //for (jBlock = 0; jBlock < NBlock; jBlock++) {
-		    for (int jrow = j; jrow < N; jrow+=mpiOrbSize) {
-			jBlock=jrow/mpiOrbSize;
-			if(jBlock!=dBlock){
-			    int sh=1;
-			    if(jBlock>dBlock)sh=0;//not very elegant
-			    int i_glob = i + dBlock*mpiOrbSize;
-			    int j_glob = j + jBlock*mpiOrbSize;
-	    
-			    doi[iter+jBlock+sh] = i_glob;
-			    doj[iter+jBlock+sh] = j_glob;
-			    rcvorb[iter+jBlock+sh]=-1;//indicates "use same as before"
-			    sendorb[iter+jBlock+sh]=-1;//indicates "do not send anything"
-			    sendto[iter+jBlock+sh]=-1;//indicates "do not send anything"
-			    if(iter+jBlock+sh>Maxiter)Maxiter=iter+jBlock+sh;
-			}
-		    }
-		}
-	    }
-	}
-    }
-    int NiterMax = ((N+mpiOrbSize-1)/mpiOrbSize)*((N+mpiOrbSize-1)/mpiOrbSize)*mpiOrbSize;
-    if(Maxiter>NiterMax)cout<<"CHECK Assign_NxN "<<endl;
-    *MaxIter = Maxiter;
-}
-
-/** Define all the different MPI groups
- */
-void define_MPI_groups(){
-
-#ifdef HAVE_MPI
-    int MPI_worldsize;
-    MPI_Comm_size(MPI_COMM_WORLD, &MPI_worldsize);
-    println(10,"MPI world size: "<< MPI_worldsize ); 
-    int MPI_worldrank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &MPI_worldrank);
-
-    //divide the world into groups
-    //each group has its own group communicator definition
- 
-    //split world into groups that can share memory
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &mpiCommSh);
-
-    MPI_Comm_rank(mpiCommSh, &mpiShRank);//rank in the Sh group
-    MPI_Comm_size(mpiCommSh, &mpiShSize);
-    println(10,"MPI SH size: "<< mpiShSize ); 
-
-    //define a rank of the group. 
-    MPI_Comm mpiCommSh_group;
-    MPI_Comm_split(MPI_COMM_WORLD, mpiShRank, MPI_worldrank, &mpiCommSh_group);//mpiShRank is color (same color->in same group),  MPI_worldrank is key (orders rank within the groups)
-    int MPI_SH_group_rank;
-    //we define a new orbital rank, so that the orbitals within a shared memory group, have consecutive ranks.
-    MPI_Comm_rank(mpiCommSh_group, &MPI_SH_group_rank);//
-    mpiOrbRank = mpiShRank + MPI_SH_group_rank*MPI_worldsize;//NB: not consecutive numbers
-
-    MPI_Comm_split(MPI_COMM_WORLD, 0, mpiOrbRank, &mpiCommOrb);//0 is color (same color->in same group), mpiOrbRank is key (orders rank in the group)
-    MPI_Comm_rank(mpiCommOrb, &mpiOrbRank);
-    MPI_Comm_size(mpiCommOrb, &mpiOrbSize);
-    println(10,"orbital group size: "<< mpiOrbSize); 
-    //        cout<<"world rank="<<MPI_worldrank<<"  Orbital rank="<<mpiOrbRank<<"  Shared mem rank="<<mpiShRank<<"  Shared memory group rank="<<MPI_SH_group_rank<<endl;
-
-#endif
-  
-}
-/** Tells whether an orbital is in the same shared memory group as the calling process
-*   Assumes that orbital ranks within a shared memory group are consecutive
-*/
-bool orbIsSh(int orbRank){
-    if (orbRank < mpiOrbRank-mpiShRank or  orbRank >= mpiOrbRank-mpiShRank + mpiShSize) {
-	return false;
-    } else { return true; }
-}
-
-#ifdef HAVE_MPI
-/** Define MPI groups that share the same compute-node i.e. the same memory and array with shared memory between
- * sh_size is size in MBytes
- * returns a pointer to the shared memory*/
-void Share_memory(int sh_size, double * &d_ptr, MPI_Win &win){
-
-    //MPI_Aint types are used for adresses (can be larger than int).
-    MPI_Aint size = (mpiShRank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
-    //MPI_Win win = MPI_WIN_NULL;
-    int disp_unit = 16;//in order for the compiler to keep aligned. 
-    //size is in bytes
-    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, mpiCommSh, &d_ptr, &win);
-
-    MPI_Win_fence(0, win);//wait until finished
-
-    MPI_Aint qsize = 0;
-    int qdisp = 0;
-    int * qbase = NULL;
-    MPI_Win_shared_query(win, 0, &qsize, &qdisp, &d_ptr);
-    printf("me = %d, allocated: size=%zu, bytes at = %p %d\n", mpiShRank, qsize, d_ptr, d_ptr);
-    MPI_Win_fence(0, win);
-    //if(mpiOrbRank==0)d_ptr[18]=2.34;
-    //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
-
-    //MPI_Win_free(&win);//to include in destructor
-
-} 
-#endif
-
-#ifdef HAVE_MPI
-template void Rcv_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void Rcv_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void Rcv_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void Send_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int dest, int tag, MPI_Comm comm);
-template void Send_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int dest, int tag, MPI_Comm comm);
-template void Send_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int dest, int tag, MPI_Comm comm);
-template void IRcv_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void IRcv_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void IRcv_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void ISend_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
-template void ISend_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
-template void ISend_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
+template void mpi::communicator::send_tree(mpi::tree_request<1> &request, int dst);
+template void mpi::communicator::send_tree(mpi::tree_request<2> &request, int dst);
+template void mpi::communicator::send_tree(mpi::tree_request<3> &request, int dst);
+template void mpi::communicator::recv_tree(mpi::tree_request<1> &request, int src);
+template void mpi::communicator::recv_tree(mpi::tree_request<2> &request, int src);
+template void mpi::communicator::recv_tree(mpi::tree_request<3> &request, int src);
 #endif
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -9,8 +9,8 @@ using namespace std;
 
 /** sh_size in MB
  */
-#ifdef HAVE_MPI
 SharedMemory::SharedMemory(MPI_Comm &comm, int sh_size) {
+#ifdef HAVE_MPI
     int rank;
     MPI_Comm_rank(comm, &rank);
     // MPI_Aint types are used for adresses (can be larger than int)
@@ -25,19 +25,19 @@ SharedMemory::SharedMemory(MPI_Comm &comm, int sh_size) {
     MPI_Win_fence(0, this->sh_win);
     this->sh_max_ptr = this->sh_start_ptr + qsize/sizeof(double);
     this->sh_end_ptr = this->sh_start_ptr;
-}
 #endif
+}
 
-#ifdef HAVE_MPI
 SharedMemory::~SharedMemory() {
+#ifdef HAVE_MPI
     //deallocates the memory block
     MPI_Win_free(&this->sh_win);
-}
 #endif
+}
 
-#ifdef HAVE_MPI
 template<int D>
-void mpi::send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm) {
+void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm) {
+#ifdef HAVE_MPI
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
 
@@ -62,12 +62,12 @@ void mpi::send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm) {
     }
     t1.stop();
     println(10, " Time send                   " << setw(30) << t1);
-}
 #endif
+}
 
-#ifdef HAVE_MPI
 template<int D>
-void mpi::recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
+void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
+#ifdef HAVE_MPI
     MPI_Status status;
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
 
@@ -99,12 +99,12 @@ void mpi::recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
     sTree.rewritePointers(nChunks);
     t2.stop();
     println(10, " Time rewrite pointers       " << setw(30) << t2);
-}
 #endif
+}
 
-#ifdef HAVE_MPI
 template<int D>
-void mpi::isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req) {
+void isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req) {
+#ifdef HAVE_MPI
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
 
@@ -129,12 +129,12 @@ void mpi::isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MP
     }
     t1.stop();
     println(10, " Time send                   " << setw(30) << t1);
-}
 #endif
+}
 
-#ifdef HAVE_MPI
 template<int D>
-void mpi::share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
+void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
+#ifdef HAVE_MPI
     Timer t1;
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
@@ -194,22 +194,18 @@ void mpi::share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
 
     t1.stop();
     println(10, " Time share                  " << setw(30) << t1);
-
+#endif
 }
-#endif
 
-#ifdef HAVE_MPI
-template void mpi::send_tree(FunctionTree<1> &tree, int dst, int tag, MPI_Comm &comm);
-template void mpi::send_tree(FunctionTree<2> &tree, int dst, int tag, MPI_Comm &comm);
-template void mpi::send_tree(FunctionTree<3> &tree, int dst, int tag, MPI_Comm &comm);
-template void mpi::recv_tree(FunctionTree<1> &tree, int src, int tag, MPI_Comm &comm);
-template void mpi::recv_tree(FunctionTree<2> &tree, int src, int tag, MPI_Comm &comm);
-template void mpi::recv_tree(FunctionTree<3> &tree, int src, int tag, MPI_Comm &comm);
-template void mpi::isend_tree(FunctionTree<1> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
-template void mpi::isend_tree(FunctionTree<2> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
-template void mpi::isend_tree(FunctionTree<3> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
-template void mpi::share_tree(FunctionTree<1> &tree, int src, int tag, MPI_Comm &comm);
-template void mpi::share_tree(FunctionTree<2> &tree, int src, int tag, MPI_Comm &comm);
-template void mpi::share_tree(FunctionTree<3> &tree, int src, int tag, MPI_Comm &comm);
-#endif
-
+template void send_tree(FunctionTree<1> &tree, int dst, int tag, MPI_Comm &comm);
+template void send_tree(FunctionTree<2> &tree, int dst, int tag, MPI_Comm &comm);
+template void send_tree(FunctionTree<3> &tree, int dst, int tag, MPI_Comm &comm);
+template void recv_tree(FunctionTree<1> &tree, int src, int tag, MPI_Comm &comm);
+template void recv_tree(FunctionTree<2> &tree, int src, int tag, MPI_Comm &comm);
+template void recv_tree(FunctionTree<3> &tree, int src, int tag, MPI_Comm &comm);
+template void isend_tree(FunctionTree<1> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
+template void isend_tree(FunctionTree<2> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
+template void isend_tree(FunctionTree<3> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
+template void share_tree(FunctionTree<1> &tree, int src, int tag, MPI_Comm &comm);
+template void share_tree(FunctionTree<2> &tree, int src, int tag, MPI_Comm &comm);
+template void share_tree(FunctionTree<3> &tree, int src, int tag, MPI_Comm &comm);

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -42,7 +42,7 @@ void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm) {
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
 
     int nChunks = sTree.nodeChunks.size();
-    MPI_Send(&nChunks, sizeof(int), MPI_BYTE, dst, tag-1, comm);
+    MPI_Send(&nChunks, sizeof(int), MPI_BYTE, dst, tag, comm);
     println(10, " Sending " << nChunks << " chunks");
 
     Timer t1;
@@ -56,9 +56,9 @@ void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm) {
                 sTree.nodeChunks[iChunk][i].setSerialIx(-1);
             }
         }
-        MPI_Send(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, tag+iChunk, comm);
+        MPI_Send(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, tag+iChunk+1, comm);
         count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
-        MPI_Send(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, tag+iChunk+1000, comm);
+        MPI_Send(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, tag+iChunk+1001, comm);
     }
     t1.stop();
     println(10, " Time send                   " << setw(30) << t1);
@@ -72,8 +72,8 @@ void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
 
     int nChunks;
-    MPI_Recv(&nChunks, sizeof(int), MPI_BYTE, src, tag-1, comm, &status);
-    println(10, " Recieving " << nChunks << " chunks");
+    MPI_Recv(&nChunks, sizeof(int), MPI_BYTE, src, tag, comm, &status);
+    println(10, " Receiving " << nChunks << " chunks");
 
     Timer t1;
     int count = 1;
@@ -88,9 +88,9 @@ void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
             sTree.nodeChunks.push_back(sTree.sNodes);
         }
         count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
-        MPI_Recv(sTree.nodeChunks[iChunk], count, MPI_BYTE, src, tag+iChunk, comm, &status);
+        MPI_Recv(sTree.nodeChunks[iChunk], count, MPI_BYTE, src, tag+iChunk+1, comm, &status);
         count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
-        MPI_Recv(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, src, tag+iChunk+1000, comm, &status);
+        MPI_Recv(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, src, tag+iChunk+1001, comm, &status);
     }
     t1.stop();
     println(10, " Time recieve                " << setw(30) << t1);
@@ -109,7 +109,7 @@ void isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MPI_Req
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
 
     int nChunks = sTree.nodeChunks.size();
-    MPI_Isend(&nChunks, sizeof(int), MPI_BYTE, dst, tag-1, comm, &req);
+    MPI_Isend(&nChunks, sizeof(int), MPI_BYTE, dst, tag, comm, &req);
     println(10, " Sending " << nChunks << " chunks");
 
     Timer t1;
@@ -123,9 +123,9 @@ void isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MPI_Req
                 sTree.nodeChunks[iChunk][i].setSerialIx(-1);
             }
         }
-        MPI_Isend(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, tag+iChunk, comm, &req);
+        MPI_Isend(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, tag+iChunk+1, comm, &req);
         count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
-        MPI_Isend(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, tag+iChunk+1000, comm, &req);
+        MPI_Isend(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, tag+iChunk+1001, comm, &req);
     }
     t1.stop();
     println(10, " Time send                   " << setw(30) << t1);
@@ -170,7 +170,7 @@ void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
 
             int nChunks;
             MPI_Recv(&nChunks, sizeof(int), MPI_BYTE, src, dst_tag-1, comm, &status);
-            println(10, " Recieved " << nChunks << " chunks");
+            println(10, " Received " << nChunks << " chunks");
 
             int count = 1;
             for (int iChunk = 0; iChunk < nChunks; iChunk++) {
@@ -185,7 +185,7 @@ void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) {
                     sTree.nodeChunks.push_back(sTree.sNodes);
                 }
                 count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
-                println(10, " Recieving chunk " << iChunk);
+                println(10, " Receiving chunk " << iChunk);
                 MPI_Recv(sTree.nodeChunks[iChunk], count, MPI_BYTE, src, dst_tag+iChunk, comm, &status);
             }
             sTree.rewritePointers(nChunks);

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -8,6 +8,10 @@
 
 #ifdef HAVE_MPI
 #include <mpi.h>
+#else
+typedef int MPI_Comm;
+typedef int MPI_Win;
+typedef int MPI_Request;
 #endif
 
 #ifdef HAVE_OPENMP
@@ -22,15 +26,11 @@
 #define omp_test_lock(x)
 #endif
 
-template<int D> class FunctionTree;
-
-#ifdef HAVE_MPI
-
 /** Share memory within a compute node
  */
 class SharedMemory {
 public:
-    SharedMemory(MPI_Comm &comm, int sh_size = 500);
+    SharedMemory(MPI_Comm &comm, int sh_size = SharedMemSize);
     ~SharedMemory();
 
     double *sh_start_ptr;  //start of shared block
@@ -39,33 +39,11 @@ public:
     MPI_Win sh_win;        //MPI window object
 };
 
-namespace mpi {
+template<int D> class FunctionTree;
 
 template<int D> void isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req);
 template<int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm);
 template<int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm);
 template<int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm);
 
-};
-
-#else
-
-typedef int MPI_Comm;
-
-class SharedMemory {
-public:
-    SharedMemory(MPI_Comm &comm, int sh_size = 0) { }
-    ~SharedMemory() { }
-};
-
-namespace mpi {
-
-template<int D> void isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm, MPI_Request &req) { }
-template<int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm &comm) { }
-template<int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) { }
-template<int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm &comm) { }
-
-};
-
-#endif
 


### PR DESCRIPTION
The code can now be compiled with MPI support. The inherent parallelization of MRCPP is still only using shared memory OpenMP, so there is no MPI work/data distribution _inside_ MRCPP. This patch provides an API for doing work/data distribution in the host program by sending complete function objects between MPI processes. The API is very simple: An MPI communicator must be initialized (and finalized) by the host program and assigned to the MRCPP global communicator ``mpi::world``:
```cpp
MPI_Init(&argc, &argv);
mpi::world = MPI_COMM_WORLD; // Assign to MRCPP global communicator
int world_size = mpi::world.size(); // Get total number of ranks
int world_rank = mpi::world.rank(); // Get my rank id
MPI_Finalize();
```
Work distribution is achieved brute force by assigning different functions to particular ranks:
```cpp
FunctionTree<3> tree(MRA); //All ranks define the tree
if (mpi::world.rank() == 0) project(tree, f); //Only rank 0 projects the function
```
A ``FunctionTree`` can be bundled up in a ``mpi::tree_request`` along with a unique tag and sent between ranks (blocking communication):
```cpp
mpi::tree_request<3> request(tree, 111); //Create request to send tree with unique tag  
if (mpi::world.rank() == 0) mpi::world.send_tree(request, 1); //Rank 0 sends to 1
if (mpi::world.rank() == 1) mpi::world.recv_tree(request, 0); //Rank 1 receives from 0 
```
This completes the API.