### PR TITLE
Implement saveTree and loadTree for FunctionTrees

### DIFF
--- a/src/FunctionTree.cpp
+++ b/src/FunctionTree.cpp
@@ -72,7 +72,7 @@ void FunctionTree<D>::saveTree(const string &file) {
     SerialFunctionTree<D> &sTree = *this->getSerialFunctionTree();
 
     // Write size of tree
-    int nChunks = sTree.nodeChunks.size();
+    int nChunks = sTree.getNChunksUsed();
     f.write((char*) &nChunks, sizeof(int));
 
     // Write tree data, chunk by chunk

--- a/src/FunctionTree.cpp
+++ b/src/FunctionTree.cpp
@@ -39,10 +39,20 @@ FunctionTree<D>::~FunctionTree() {
     delete this->serialTree_p;
 }
 
-/** Leaves the tree inn the same state as after construction*/
+/** Leaves the tree inn the same state as after construction, e.i.
+  * undefined function containing only root nodes without coefficients.
+  * The assigned memory (nodeChunks in SerialTree) is NOT released,
+  * but is immediately available to the new function. */
 template<int D>
 void FunctionTree<D>::clear() {
-    NOT_IMPLEMENTED_ABORT;
+    for (int i = 0; i < this->rootBox.size(); i++) {
+        MWNode<D> &root = this->getRootMWNode(i);
+        root.deleteChildren();
+        root.clearHasCoefs();
+        root.clearNorms();
+    }
+    this->resetEndNodeTable();
+    this->clearSquareNorm();
 }
 
 /** Write the tree structure to disk, for later use.

--- a/src/FunctionTree.h
+++ b/src/FunctionTree.h
@@ -23,8 +23,8 @@ public:
     void getEndValues(Eigen::VectorXd &data);
     void setEndValues(Eigen::VectorXd &data);
 
-    bool saveTree(const std::string &file);
-    bool loadTree(const std::string &file);
+    void saveTree(const std::string &file);
+    void loadTree(const std::string &file);
 
     // In place operations
     void square();

--- a/src/MWTree.cpp
+++ b/src/MWTree.cpp
@@ -489,12 +489,12 @@ void MWTree<D>::deleteGenerated() {
 }
 
 template<int D>
-bool MWTree<D>::saveTree(const string &file) {
+void MWTree<D>::saveTree(const string &file) {
     NOT_IMPLEMENTED_ABORT;
 }
 
 template<int D>
-bool MWTree<D>::loadTree(const string &file) {
+void MWTree<D>::loadTree(const string &file) {
     NOT_IMPLEMENTED_ABORT;
 }
 

--- a/src/MWTree.h
+++ b/src/MWTree.h
@@ -92,8 +92,8 @@ public:
 
     int getNThreads() const { return this->nThreads; }
 
-    virtual bool saveTree(const std::string &file);
-    virtual bool loadTree(const std::string &file);
+    virtual void saveTree(const std::string &file);
+    virtual void loadTree(const std::string &file);
 
     int countBranchNodes(int depth = -1);
     int countLeafNodes(int depth = -1);

--- a/src/SerialFunctionTree.cpp
+++ b/src/SerialFunctionTree.cpp
@@ -474,6 +474,21 @@ void SerialFunctionTree<D>::rewritePointers(int nChunks){
     this->getTree()->resetEndNodeTable();
 }
 
+template<int D>
+int SerialFunctionTree<D>::getNChunksUsed() const {
+    int nUsed = 0;
+    for (int iChunk = 0; iChunk < getNChunks(); iChunk++) {
+        int iShift = iChunk * this->maxNodesPerChunk;
+        bool chunkUsed = false;
+        for (int i = 0; i < this->maxNodesPerChunk; i++) {
+            if (this->nodeStackStatus[iShift+i] == 1) {
+                chunkUsed = true;
+            }
+        }
+        if (chunkUsed) nUsed++;
+    }
+    return nUsed;
+}
 
 template class SerialFunctionTree<1>;
 template class SerialFunctionTree<2>;

--- a/src/SerialFunctionTree.h
+++ b/src/SerialFunctionTree.h
@@ -29,6 +29,9 @@ public:
     virtual void deallocGenNodes(int serialIx);
     virtual void deallocGenNodeChunks();
 
+    int getNChunks() const { return this->nodeChunks.size(); }
+    int getNChunksUsed() const;
+
     std::vector<ProjectedNode<D>*> nodeChunks;
     std::vector<double*> nodeCoeffChunks;
 

--- a/src/parallel_mpi.cpp
+++ b/src/parallel_mpi.cpp
@@ -42,7 +42,7 @@ void mrcpp::send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm) {
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
 
-    int nChunks = sTree.nodeChunks.size();
+    int nChunks = sTree.getNChunksUsed();
     MPI_Send(&nChunks, sizeof(int), MPI_BYTE, dst, tag, comm);
     println(10, " Sending " << nChunks << " chunks");
 
@@ -109,7 +109,7 @@ void mrcpp::isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, M
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_FATAL("Sending of GenNodes not implemented");
 
-    int nChunks = sTree.nodeChunks.size();
+    int nChunks = sTree.getNChunksUsed();
     MPI_Isend(&nChunks, sizeof(int), MPI_BYTE, dst, tag, comm, req);
     println(10, " Sending " << nChunks << " chunks");
 

--- a/tests/mrcpp/CMakeLists.txt
+++ b/tests/mrcpp/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(mrcpp-tests OBJECT band_width.cpp
                                poisson_operator.cpp
                                polynomial.cpp
                                scaling_basis.cpp
+                               tree_io.cpp
                                )
 
 add_Catch_test(band_width "band_width")
@@ -40,3 +41,4 @@ add_Catch_test(node_index "node_index")
 add_Catch_test(poisson_operator "poisson_operator")
 add_Catch_test(polynomials "polynomials")
 add_Catch_test(scaling_basis "scaling_basis")
+add_Catch_test(tree_io "tree_io")

--- a/tests/mrcpp/clear_grid.cpp
+++ b/tests/mrcpp/clear_grid.cpp
@@ -39,6 +39,25 @@ template<int D> void testClearGrid() {
     const double refInt = tree.integrate();
     const double refNorm = tree.getSquareNorm();
 
+    WHEN("the tree is cleared") {
+        tree.clear();
+        THEN("it represents an undefined function on the root grid") {
+            REQUIRE( (tree.getDepth() == 1) );
+            REQUIRE( (tree.getNNodes() == tree.getRootBox().size()) );
+            REQUIRE( (tree.integrate() == Approx(0.0)) );
+            REQUIRE( (tree.getSquareNorm() == Approx(-1.0)) );
+            AND_WHEN("the function is re-projected") {
+                build_grid(tree, *func);
+                project(prec, tree, *func);
+                THEN("the representation is the same as before it was cleared") {
+                    REQUIRE( (tree.getDepth() == refDepth) );
+                    REQUIRE( (tree.getNNodes() == refNodes) );
+                    REQUIRE( (tree.integrate() == Approx(refInt)) );
+                    REQUIRE( (tree.getSquareNorm() == Approx(refNorm)) );
+                }
+            }
+        }
+    }
     WHEN("the grid is cleared") {
         clear_grid(-1.0, tree);
         THEN("it represents an undefined function on the same grid") {

--- a/tests/mrcpp/tree_io.cpp
+++ b/tests/mrcpp/tree_io.cpp
@@ -1,0 +1,53 @@
+#include "catch.hpp"
+
+#include "factory_functions.h"
+
+#include "project.h"
+#include "grid.h"
+
+using namespace mrcpp;
+
+namespace tree_io {
+
+template<int D> void testProjectFunction();
+
+SCENARIO("FunctionTree IO", "[tree_io], [trees]") {
+    const double prec = 1.0e-4;
+
+    GaussFunc<3> *func = 0;
+    initialize(&func);
+    MultiResolutionAnalysis<3> *mra = 0;
+    initialize(&mra);
+
+    FunctionTree<3> f_tree(*mra);
+    project(prec, f_tree, *func);
+
+    const double ref_charge = f_tree.integrate();
+    const double ref_norm = f_tree.getSquareNorm();
+    const double ref_nodes = f_tree.getNNodes();
+
+    WHEN("a function is saved") {
+        f_tree.saveTree("f");
+        THEN("the old tree remains unchanged") {
+            REQUIRE( (f_tree.integrate() == Approx(ref_charge).epsilon(1.0e-12)) );
+            REQUIRE( (f_tree.getSquareNorm() == Approx(ref_norm).epsilon(1.0e-12)) );
+            REQUIRE( (f_tree.getNNodes() == ref_nodes) );
+        }
+        AND_WHEN("the saved function is load into a new tree") {
+            FunctionTree<3> g_tree(*mra);
+            g_tree.loadTree("f");
+            THEN("the new tree is identical to the old") {
+                REQUIRE( (g_tree.integrate() == Approx(ref_charge).epsilon(1.0e-12)) );
+                REQUIRE( (g_tree.getSquareNorm() == Approx(ref_norm).epsilon(1.0e-12)) );
+                REQUIRE( (g_tree.getNNodes() == ref_nodes) );
+            }
+        }
+    }
+    // Delete saved file
+    remove("f.tree");
+
+    finalize(&mra);
+    finalize(&func);
+}
+
+} // namespace


### PR DESCRIPTION
FunctionTrees can now be saved as binary files
and loaded at a later stage or in subsequent runs.
Implicitly assumes that the MRA of the tree which
is loaded into is identical to the saved tree.
The serialization is similar to MPI send/recv.