### PR TITLE
Add some minor functionality to FunctionTreeVector

### DIFF
--- a/src/trees/FunctionTreeVector.cpp
+++ b/src/trees/FunctionTreeVector.cpp
@@ -86,7 +86,7 @@ const FunctionTree<D> *FunctionTreeVector<D>::operator[](int i) const {
 }
 
 template<int D>
-int FunctionTreeVector<D>::sumNodes() {
+int FunctionTreeVector<D>::sumNodes() const {
     int nNodes = 0;
     for (int i = 0; i < size(); i++) {
         if (funcs[i] != 0) {

--- a/src/trees/FunctionTreeVector.cpp
+++ b/src/trees/FunctionTreeVector.cpp
@@ -35,6 +35,14 @@ void FunctionTreeVector<D>::push_back(FunctionTree<D> *f) {
 }
 
 template<int D>
+void FunctionTreeVector<D>::push_back(FunctionTreeVector<D> &vec) {
+    for (int i = 0; i < vec.size(); i++) {
+        this->coefs.push_back(vec.coefs[i]);
+        this->funcs.push_back(vec.funcs[i]);
+    }
+}
+
+template<int D>
 void FunctionTreeVector<D>::clear(bool dealloc) {
     if (dealloc) {
         for (int i = 0; i < this->funcs.size(); i++) {
@@ -75,6 +83,17 @@ template<int D>
 const FunctionTree<D> *FunctionTreeVector<D>::operator[](int i) const {
     if (i < 0 or i >= this->funcs.size()) MSG_ERROR("Out of bounds");
     return this->funcs[i];
+}
+
+template<int D>
+int FunctionTreeVector<D>::sumNodes() {
+    int nNodes = 0;
+    for (int i = 0; i < size(); i++) {
+        if (funcs[i] != 0) {
+            nNodes += funcs[i]->getNNodes();
+        }
+    }
+    return nNodes;
 }
 
 template class FunctionTreeVector<1>;

--- a/src/trees/FunctionTreeVector.h
+++ b/src/trees/FunctionTreeVector.h
@@ -17,7 +17,7 @@ public:
 
     int size() const { return this->funcs.size(); }
     void clear(bool dealloc = false);
-    int sumNodes();
+    int sumNodes() const;
 
     void push_back(double c, FunctionTree<D> *f);
     void push_back(FunctionTree<D> *f);

--- a/src/trees/FunctionTreeVector.h
+++ b/src/trees/FunctionTreeVector.h
@@ -29,7 +29,7 @@ public:
 
     FunctionTree<D> *operator[](int i);
     const FunctionTree<D> *operator[](int i) const;
-    
+
 protected:
     std::vector<double> coefs;
     std::vector<FunctionTree<D> *> funcs;

--- a/src/trees/FunctionTreeVector.h
+++ b/src/trees/FunctionTreeVector.h
@@ -17,9 +17,11 @@ public:
 
     int size() const { return this->funcs.size(); }
     void clear(bool dealloc = false);
+    int sumNodes();
 
     void push_back(double c, FunctionTree<D> *f);
     void push_back(FunctionTree<D> *f);
+    void push_back(FunctionTreeVector<D> &vec);
 
     double getCoef(int i) const;
     FunctionTree<D> &getFunc(int i);
@@ -28,6 +30,7 @@ public:
     FunctionTree<D> *operator[](int i);
     const FunctionTree<D> *operator[](int i) const;
 
+    
 protected:
     std::vector<double> coefs;
     std::vector<FunctionTree<D> *> funcs;

--- a/src/trees/FunctionTreeVector.h
+++ b/src/trees/FunctionTreeVector.h
@@ -29,7 +29,6 @@ public:
 
     FunctionTree<D> *operator[](int i);
     const FunctionTree<D> *operator[](int i) const;
-
     
 protected:
     std::vector<double> coefs;


### PR DESCRIPTION
I upgraded `FunctionTreeVector`with some minor functionality:
1) `push_back` a whole `FunctionTreeVector`
2) count the total number of nodes.

The functionality is IMO generic enough, and in particular it allows me to simplify `XCFunctional` and to remove some duplicate stuff there.