### PR TITLE
Use list initialization rather than std::make_tuple

### DIFF
--- a/examples/addition.cpp
+++ b/examples/addition.cpp
@@ -52,9 +52,9 @@ int main(int argc, char **argv) {
 
     // g = f_1 - 2*f_2 + 3*f_3
     mrcpp::FunctionTreeVector<3> f_vec;
-    f_vec.push_back(std::make_tuple( 1.0, &f_tree_1));
-    f_vec.push_back(std::make_tuple(-2.0, &f_tree_2));
-    f_vec.push_back(std::make_tuple( 3.0, &f_tree_3));
+    f_vec.push_back({ 1.0, &f_tree_1});
+    f_vec.push_back({-2.0, &f_tree_2});
+    f_vec.push_back({ 3.0, &f_tree_3});
     mrcpp::add(prec, g_tree, f_vec);
 
     double integral = g_tree.integrate();

--- a/examples/mpi_matrix.cpp
+++ b/examples/mpi_matrix.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
             mrcpp::project(prec, *tree, f);
             tree->normalize();
         }
-        f_vec.push_back(std::make_tuple(1.0, tree));
+        f_vec.push_back({1.0, tree});
     }
 
     std::vector<MPI_Request> requests;

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -56,7 +56,7 @@ void ConvolutionOperator<D>::initializeOperator(GreensKernel &greens_kernel) {
         println(10, "Time transform      " << trans_t);
         println(10, std::endl);
 
-        this->kern_exp.push_back(std::make_tuple(1.0, k_tree));
+        this->kern_exp.push_back({1.0, k_tree});
         this->oper_exp.push_back(o_tree);
     }
 }

--- a/src/treebuilders/CopyAdaptor.cpp
+++ b/src/treebuilders/CopyAdaptor.cpp
@@ -1,14 +1,12 @@
 #include "CopyAdaptor.h"
 
-#include <tuple>
-
 namespace mrcpp {
 
 template<int D>
 CopyAdaptor<D>::CopyAdaptor(FunctionTree<D> &t, int ms, int *bw)
         : TreeAdaptor<D>(ms) {
     setBandWidth(bw);
-    tree_vec.push_back(std::make_tuple(1.0, &t));
+    tree_vec.push_back({1.0, &t});
 }
 
 template<int D>

--- a/src/treebuilders/add.cpp
+++ b/src/treebuilders/add.cpp
@@ -18,8 +18,8 @@ void add(double prec, FunctionTree<D> &out,
          double b, FunctionTree<D> &tree_b,
          int maxIter) {
     FunctionTreeVector<D> tree_vec;
-    tree_vec.push_back(std::make_tuple(a, &tree_a));
-    tree_vec.push_back(std::make_tuple(b, &tree_b));
+    tree_vec.push_back({a, &tree_a});
+    tree_vec.push_back({b, &tree_b});
     add(prec, out, tree_vec, maxIter);
 }
 

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -16,8 +16,8 @@ void multiply(double prec,
               FunctionTree<D> &tree_b,
               int maxIter) {
     FunctionTreeVector<D> tree_vec;
-    tree_vec.push_back(std::make_tuple(c, &tree_a));
-    tree_vec.push_back(std::make_tuple(1.0, &tree_b));
+    tree_vec.push_back({c, &tree_a});
+    tree_vec.push_back({1.0, &tree_b});
     mrcpp::multiply(prec, out, tree_vec, maxIter);
 }
 

--- a/tests/operators/helmholtz_operator.cpp
+++ b/tests/operators/helmholtz_operator.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Helmholtz' kernel", "[init_helmholtz], [helmholtz_operator], [mw_oper
                 FunctionTree<1> *kern_tree = new FunctionTree<1>(kern_mra);
                 build_grid(*kern_tree, kern_gauss);
                 project(proj_prec, *kern_tree, kern_gauss);
-                K.push_back(std::make_tuple(1.0, kern_tree));
+                K.push_back({1.0, kern_tree});
             }
 
             SECTION("Build operator tree by cross correlation") {

--- a/tests/operators/poisson_operator.cpp
+++ b/tests/operators/poisson_operator.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Initialize Poisson operator", "[init_poisson], [poisson_operator], [m
                 FunctionTree<1> *kern_tree = new FunctionTree<1>(kern_mra);
                 build_grid(*kern_tree, kern_gauss);
                 project(proj_prec, *kern_tree, kern_gauss);
-                kern_vec.push_back(std::make_tuple(1.0, kern_tree));
+                kern_vec.push_back({1.0, kern_tree});
             }
 
             SECTION("Build operator tree by cross correlation") {

--- a/tests/treebuilders/addition.cpp
+++ b/tests/treebuilders/addition.cpp
@@ -75,8 +75,8 @@ template<int D> void testAddition() {
     FunctionTreeVector<D> sum_vec;
     WHEN("the functions are added") {
         FunctionTree<D> c_tree(*mra);
-        sum_vec.push_back(std::make_tuple(a_coef, &a_tree));
-        sum_vec.push_back(std::make_tuple(b_coef, &b_tree));
+        sum_vec.push_back({a_coef, &a_tree});
+        sum_vec.push_back({b_coef, &b_tree});
         add(-1.0, c_tree, sum_vec);
         sum_vec.clear();
 
@@ -97,8 +97,8 @@ template<int D> void testAddition() {
 
         AND_WHEN("the first function is subtracted") {
             FunctionTree<D> d_tree(*mra);
-            sum_vec.push_back(std::make_tuple(1.0, &c_tree));
-            sum_vec.push_back(std::make_tuple(-1.0, &a_tree));
+            sum_vec.push_back({ 1.0, &c_tree});
+            sum_vec.push_back({-1.0, &a_tree});
             add(-1.0, d_tree, sum_vec);
             sum_vec.clear();
 
@@ -110,8 +110,8 @@ template<int D> void testAddition() {
 
             AND_WHEN("the second function is subtracted") {
                 FunctionTree<D> e_tree(*mra);
-                sum_vec.push_back(std::make_tuple(1.0, &d_tree));
-                sum_vec.push_back(std::make_tuple(-b_coef, &b_tree));
+                sum_vec.push_back({1.0, &d_tree});
+                sum_vec.push_back({-b_coef, &b_tree});
                 add(-1.0, e_tree, sum_vec);
                 sum_vec.clear();
 

--- a/tests/treebuilders/multiplication.cpp
+++ b/tests/treebuilders/multiplication.cpp
@@ -64,8 +64,8 @@ template<int D> void testMultiplication() {
     FunctionTreeVector<D> prod_vec;
     WHEN("the functions are multiplied") {
         FunctionTree<D> c_tree(*mra);
-        prod_vec.push_back(std::make_tuple(1.0, &a_tree));
-        prod_vec.push_back(std::make_tuple(1.0, &b_tree));
+        prod_vec.push_back({1.0, &a_tree});
+        prod_vec.push_back({1.0, &b_tree});
         multiply(prec, c_tree, prod_vec);
         prod_vec.clear();
 


### PR DESCRIPTION
A bit less verbose follow-up to #33. C++11 lets you do:
- either `tree_vec.push_back(std::make_tuple(coef, func));`
- or `tree_vec.push_back({coef, func});` (list initialization)
I prefer the latter, but both are legal and have the same effect. I have changed the code in MRCPP to use the list initialization.