### PR TITLE
Add more grid building features

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        base: auto 
+    patch:
+      default:
+        target: auto
+        threshold: 10%
+        base: auto 

--- a/examples/tree_cleaner.cpp
+++ b/examples/tree_cleaner.cpp
@@ -41,7 +41,8 @@ int main(int argc, char **argv) {
     int n_nodes = 1;
     while (n_nodes > 0) {
         mrcpp::project(-1.0, f_tree, f); // Projecting on fixed grid
-        n_nodes = mrcpp::clear_grid(prec, f_tree); // Refine grid and clear MW coefs
+        n_nodes = mrcpp::refine_grid(f_tree, prec); // Refine grid
+        mrcpp::clear_grid(f_tree); // Clear MW coefs
         printout(0, " iter " << std::setw(3) << iter++ << std::setw(45));
         printout(0, " n_nodes " << std::setw(5) << n_nodes << std::endl);
     }

--- a/src/treebuilders/TreeBuilder.h
+++ b/src/treebuilders/TreeBuilder.h
@@ -15,9 +15,10 @@ public:
                TreeAdaptor<D> &adaptor,
                int maxIter) const;
 
-    int clear(MWTree<D> &tree,
-              TreeCalculator<D> &calculator,
-              TreeAdaptor<D> &adaptor) const;
+    int split(MWTree<D> &tree, TreeAdaptor<D> &adaptor, bool passCoefs) const;
+    void calc(MWTree<D> &tree, TreeCalculator<D> &calculator) const;
+    void clear(MWTree<D> &tree, TreeCalculator<D> &calculator) const;
+
 protected:
     double calcScalingNorm(const MWNodeVector &vec) const;
     double calcWaveletNorm(const MWNodeVector &vec) const;

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -166,7 +166,7 @@ void divergence(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTreeV
         apply(*out_d, oper, func_d, d);
         tmp_vec.push_back(std::make_tuple(coef_d, out_d));
     }
-    copy_grid(out, tmp_vec);
+    build_grid(out, tmp_vec);
     add(-1.0, out, tmp_vec, 0); // Addition on union grid
     clear(tmp_vec, true);
 }

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -1,4 +1,5 @@
 #include "grid.h"
+#include "add.h"
 #include "TreeBuilder.h"
 #include "AnalyticAdaptor.h"
 #include "CopyAdaptor.h"
@@ -40,7 +41,7 @@ void build_grid(FunctionTree<D> &out,
     Printer::printSeparator(10, ' ');
 }
 
-/** @brief Copy grid of another MW function representation
+/** @brief Build grid based on another MW function representation
  *
  * @param[in,out] out Output tree to be built
  * @param[in] inp Input tree
@@ -60,9 +61,9 @@ void build_grid(FunctionTree<D> &out,
  *
  */
 template<int D>
-void copy_grid(FunctionTree<D> &out,
-               FunctionTree<D> &inp,
-               int maxIter) {
+void build_grid(FunctionTree<D> &out,
+                FunctionTree<D> &inp,
+                int maxIter) {
     int maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, 0);
@@ -71,7 +72,7 @@ void copy_grid(FunctionTree<D> &out,
     Printer::printSeparator(10, ' ');
 }
 
-/** @brief Copy grid of several MW function representation
+/** @brief Build grid based on several MW function representation
  *
  * @param[in,out] out Output tree to be built
  * @param[in] inp Input tree vector
@@ -91,9 +92,9 @@ void copy_grid(FunctionTree<D> &out,
  *
  */
 template<int D>
-void copy_grid(FunctionTree<D> &out,
-               FunctionTreeVector<D> &inp,
-               int maxIter) {
+void build_grid(FunctionTree<D> &out,
+                FunctionTreeVector<D> &inp,
+                int maxIter) {
     int maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, 0);
@@ -102,39 +103,116 @@ void copy_grid(FunctionTree<D> &out,
     Printer::printSeparator(10, ' ');
 }
 
-/** @brief Clear the grid of a MW function representation
+/** @brief Copy function from one tree onto the grid of another tree
  *
- * @param[in] prec Precision for initial split check
- * @param[in,out] out Output function to be cleared
+ * @param[in,out] out Output tree to be built
+ * @param[in] inp Input tree
  *
- * This will first perform a split check on the existing end nodes in the tree
- * based on the provided precision parameter, then it will clear all MW coefs in
- * the existing nodes, thus leaving an empty grid that can be reused by computing
- * new MW coefs.
- *
- * A negative precision means NO refinement.
+ * This algorithm will start at whatever grid is present in the output tree when
+ * the function is called:
+ *  1) Loop through current leaf nodes of the output tree
+ *  2) Copy MW coefs from the corresponding input node
  *
  */
 template<int D>
-int clear_grid(double prec, FunctionTree<D> &out) {
-    int maxScale = out.getMRA().getMaxScale();
+void copy_func(FunctionTree<D> &out, FunctionTree<D> &inp) {
+    FunctionTreeVector<D> tmp_vec;
+    tmp_vec.push_back(std::make_tuple(1.0, &inp));
+    add(-1.0, out, tmp_vec);
+}
+
+/** @brief Copy the grid of another MW function representation
+ *
+ * @param[in,out] out Output tree to be built
+ * @param[in] inp Input tree
+ *
+ * The grid of the output function will be identical to the grid of the input
+ * function, but without MW coefficients.
+ *
+ */
+template<int D>
+void copy_grid(FunctionTree<D> &out, FunctionTree<D> &inp) {
+    out.clear();
+    build_grid(out, inp);
+}
+
+/** @brief Clear the grid of a MW function representation
+ *
+ * @param[in,out] out Output function to be cleared
+ *
+ * This will clear all MW coefs in the existing nodes, thus leaving an empty
+ * grid that can be reused by computing new MW coefs.
+ *
+ */
+template<int D>
+void clear_grid(FunctionTree<D> &out) {
     TreeBuilder<D> builder;
     DefaultCalculator<D> calculator;
+    builder.clear(out, calculator);
+}
+
+/** @brief Refine the grid of a MW function representation
+ *
+ * @param[in,out] out Output tree to be refined
+ * @param[in] prec Precision for initial split check
+ *
+ * This will first perform a split check on the existing end nodes in the tree
+ * based on the provided precision parameter, then it will compute scaling coefs
+ * of the new nodes, thus leaving the function representation unchanged, but on a
+ * larger grid.
+ *
+ */
+template<int D>
+int refine_grid(FunctionTree<D> &out, double prec) {
+    int maxScale = out.getMRA().getMaxScale();
+    TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale);
-    return builder.clear(out, calculator, adaptor);
+    int nSplit = builder.split(out, adaptor, true);
+    return nSplit;
+}
+
+/** @brief Refine the grid of a MW function representation
+ *
+ * @param[in,out] out Output tree to be refined
+ * @param[in] inp Input tree
+ *
+ * This will first perform a split check on the existing end nodes in the output
+ * tree based on the structure of the input tree (same as build_grid), then it will
+ * compute scaling coefs of the new nodes, thus leaving the function representation
+ * unchanged, but on a larger grid.
+ *
+ */
+template<int D> int refine_grid(FunctionTree<D> &out, FunctionTree<D> &inp) {
+    int maxScale = out.getMRA().getMaxScale();
+    TreeBuilder<D> builder;
+    CopyAdaptor<D> adaptor(inp, maxScale, 0);
+    int nSplit = builder.split(out, adaptor, true);
+    return nSplit;
 }
 
 template void build_grid(FunctionTree<1> &out, const RepresentableFunction<1> &inp, int maxIter);
 template void build_grid(FunctionTree<2> &out, const RepresentableFunction<2> &inp, int maxIter);
 template void build_grid(FunctionTree<3> &out, const RepresentableFunction<3> &inp, int maxIter);
-template void copy_grid(FunctionTree<1> &out, FunctionTree<1> &inp, int maxIter);
-template void copy_grid(FunctionTree<2> &out, FunctionTree<2> &inp, int maxIter);
-template void copy_grid(FunctionTree<3> &out, FunctionTree<3> &inp, int maxIter);
-template void copy_grid(FunctionTree<1> &out, FunctionTreeVector<1> &inp, int maxIter);
-template void copy_grid(FunctionTree<2> &out, FunctionTreeVector<2> &inp, int maxIter);
-template void copy_grid(FunctionTree<3> &out, FunctionTreeVector<3> &inp, int maxIter);
-template int clear_grid(double prec, FunctionTree<1> &out);
-template int clear_grid(double prec, FunctionTree<2> &out);
-template int clear_grid(double prec, FunctionTree<3> &out);
+template void build_grid(FunctionTree<1> &out, FunctionTree<1> &inp, int maxIter);
+template void build_grid(FunctionTree<2> &out, FunctionTree<2> &inp, int maxIter);
+template void build_grid(FunctionTree<3> &out, FunctionTree<3> &inp, int maxIter);
+template void build_grid(FunctionTree<1> &out, FunctionTreeVector<1> &inp, int maxIter);
+template void build_grid(FunctionTree<2> &out, FunctionTreeVector<2> &inp, int maxIter);
+template void build_grid(FunctionTree<3> &out, FunctionTreeVector<3> &inp, int maxIter);
+template void copy_func(FunctionTree<1> &out, FunctionTree<1> &inp);
+template void copy_func(FunctionTree<2> &out, FunctionTree<2> &inp);
+template void copy_func(FunctionTree<3> &out, FunctionTree<3> &inp);
+template void copy_grid(FunctionTree<1> &out, FunctionTree<1> &inp);
+template void copy_grid(FunctionTree<2> &out, FunctionTree<2> &inp);
+template void copy_grid(FunctionTree<3> &out, FunctionTree<3> &inp);
+template void clear_grid(FunctionTree<1> &out);
+template void clear_grid(FunctionTree<2> &out);
+template void clear_grid(FunctionTree<3> &out);
+template int refine_grid(FunctionTree<1> &out, double prec);
+template int refine_grid(FunctionTree<2> &out, double prec);
+template int refine_grid(FunctionTree<3> &out, double prec);
+template int refine_grid(FunctionTree<1> &out, FunctionTree<1> &inp);
+template int refine_grid(FunctionTree<2> &out, FunctionTree<2> &inp);
+template int refine_grid(FunctionTree<3> &out, FunctionTree<3> &inp);
 
 } //namespace mrcpp

--- a/src/treebuilders/grid.h
+++ b/src/treebuilders/grid.h
@@ -6,7 +6,11 @@
 
 namespace mrcpp {
 template<int D> void build_grid(FunctionTree<D> &out, const RepresentableFunction<D> &inp, int maxIter = -1);
-template<int D> void copy_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter = -1);
-template<int D> void copy_grid(FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1);
-template<int D> int clear_grid(double prec, FunctionTree<D> &out);
+template<int D> void build_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter = -1);
+template<int D> void build_grid(FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1);
+template<int D> void copy_func(FunctionTree<D> &out, FunctionTree<D> &inp);
+template<int D> void copy_grid(FunctionTree<D> &out, FunctionTree<D> &inp);
+template<int D> void clear_grid(FunctionTree<D> &out);
+template<int D> int refine_grid(FunctionTree<D> &out, double prec);
+template<int D> int refine_grid(FunctionTree<D> &out, FunctionTree<D> &inp);
 }

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -136,11 +136,11 @@ void dot(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp_a, Functi
         if (out.getMRA() != tree_a.getMRA()) MSG_FATAL("Trees not compatible");
         if (out.getMRA() != tree_b.getMRA()) MSG_FATAL("Trees not compatible");
         FunctionTree<D> *out_d = new FunctionTree<D>(out.getMRA());
-        copy_grid(*out_d, out);
+        build_grid(*out_d, out);
         multiply(prec, *out_d, 1.0, tree_a, tree_b, maxIter);
         tmp_vec.push_back(std::make_tuple(coef_a*coef_b, out_d));
     }
-    copy_grid(out, tmp_vec);
+    build_grid(out, tmp_vec);
     add(-1.0, out, tmp_vec, 0);
     clear(tmp_vec, true);
 }

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -114,13 +114,13 @@ public:
 
     friend std::ostream& operator<<(std::ostream &o, const MWNode<D> &nd) { return nd.print(o); }
 
+    friend class TreeBuilder<D>;
     friend class MultiplicationCalculator<D>;
     friend class SerialFunctionTree<D>;
     friend class SerialOperatorTree;
     friend class MWTree<D>;
     friend class FunctionTree<D>;
     friend class OperatorTree;
-    friend class Density;
 
 protected:
     MWTree<D> *tree;

--- a/tests/treebuilders/build_grid.cpp
+++ b/tests/treebuilders/build_grid.cpp
@@ -63,7 +63,7 @@ template<int D> void testBuildGrid() {
 
             AND_WHEN("the empty tree is passed to the GridGenerator") {
                 FunctionTree<D> g_tree(*mra);
-                copy_grid(g_tree, f_tree);
+                build_grid(g_tree, f_tree);
 
                 THEN("we get an identical empty grid") {
                     REQUIRE( g_tree.getSquareNorm() == Approx(-1.0) );

--- a/tests/treebuilders/clear_grid.cpp
+++ b/tests/treebuilders/clear_grid.cpp
@@ -59,7 +59,7 @@ template<int D> void testClearGrid() {
         }
     }
     WHEN("the grid is cleared") {
-        clear_grid(-1.0, tree);
+        clear_grid(tree);
         THEN("it represents an undefined function on the same grid") {
             REQUIRE( tree.getDepth() == refDepth );
             REQUIRE( tree.getNNodes() == refNodes );
@@ -76,23 +76,14 @@ template<int D> void testClearGrid() {
             }
         }
     }
-    WHEN("the grid is cleared adaptively") {
+    WHEN("the grid is refined adaptively") {
         const double new_prec = 1.0e-5;
-        clear_grid(new_prec, tree);
-        THEN("it represents an undefined function on a larger grid") {
+        refine_grid(tree, new_prec);
+        THEN("it represents the same function on a larger grid") {
             REQUIRE( tree.getDepth() >= refDepth );
             REQUIRE( tree.getNNodes() > refNodes );
-            REQUIRE( tree.integrate() == Approx(0.0) );
-            REQUIRE( tree.getSquareNorm() == Approx(-1.0) );
-            AND_WHEN("the function is re-projected on the new grid") {
-                project(-1.0, tree, *func);
-                THEN("it becomes a larger representation of the same function") {
-                    REQUIRE( tree.getDepth() >= refDepth );
-                    REQUIRE( tree.getNNodes() > refNodes );
-                    REQUIRE( tree.integrate() == Approx(refInt).epsilon(1.0e-8) );
-                    REQUIRE( tree.getSquareNorm() == Approx(refNorm).epsilon(1.0e-8) );
-                }
-            }
+            REQUIRE( tree.integrate() == Approx(refInt).epsilon(1.0e-8) );
+            REQUIRE( tree.getSquareNorm() == Approx(refNorm).epsilon(1.0e-8) );
         }
     }
     finalize(&mra);

--- a/tests/treebuilders/multiplication.cpp
+++ b/tests/treebuilders/multiplication.cpp
@@ -118,8 +118,8 @@ TEST_CASE("Dot product FunctionTreeVectors", "[multiplication], [tree_vector_dot
     vec_b.push_back(std::make_tuple(3.0, &fx_tree));
 
     FunctionTree<3> dot_ab(*mra);
-    copy_grid(dot_ab, vec_a);
-    copy_grid(dot_ab, vec_b);
+    build_grid(dot_ab, vec_a);
+    build_grid(dot_ab, vec_b);
     dot(0.1*prec, dot_ab, vec_a, vec_b);
 
     for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Changed some of the API features regarding grid generation.

Old features
---------------
- `copy_grid(FunctionTree out, FunctionTree in)`:
_Extend_ `out` tree with nodes from `in`
- `copy_grid(FunctionTree out, FunctionTreeVector in)`:
_Extend_ `out` tree with nodes from `in`
- `clear_grid(double prec, FunctionTree out)`:
Refine `out` tree based on `prec` _and_ clear coefs
 
New features
----------------
- `build_grid(FunctionTree out, FunctionTree in)`:
Same as old `copy_grid` 
- `build_grid(FunctionTree out, FunctionTreeVector in)`:
Same as old `copy_grid`
- `refine_grid(FunctionTree out, double prec)`:
Refine `out` tree based on `prec`, gives identical function on _larger_ grid (same as the _first_ part of the old `clear_grid`)
- `refine_grid(FunctionTree out, FunctionTree inp)`:
Refine `out` tree based tree structure of `inp`, gives identical function on _larger_ grid
- `clear_grid(FunctionTree out)`:
Clear all MW coefs in `out` (same as the _second_ part of the old `clear_grid`)
- `copy_grid(FunctionTree out, FunctionTree in)`:
Makes `out` grid _identical_ to `in` grid
- `copy_func(FunctionTree out, FunctionTree in)`:
Copies the _function_ that is represented on `in` onto whatever grid is currently available in `out`

Status
--------
- [x] Ready to go