### PR TITLE
Add new (optimized) arithmetic operations

### DIFF
--- a/doc/mrcpp_api/mwfunctions.rst
+++ b/doc/mrcpp_api/mwfunctions.rst
@@ -124,6 +124,9 @@ add
 multiply
   Multiply existing functions, adaptive grid.
 
+square
+  Multiply an existing function with itself, adaptive grid.
+
 power
   Raise an existing function to a given power, adaptive grid.
 
@@ -164,8 +167,17 @@ rescale
 normalize
   Rescale the function by its norm, fixed grid.
 
+add
+  Add an existing function, fixed grid.
+
+multiply
+  Multiply an existing function, fixed grid.
+
 square
   Multiply an existing function with itself, fixed grid.
+
+power
+  Raise an existing function to a given power, fixed grid.
 
 crop
   Truncate the wavelet expansion accoring to a new precision threshold.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND _examples
     projection
     derivative
     addition
+    multiplication
     poisson
     scf
     mpi_shared_tree

--- a/src/treebuilders/ABGVCalculator.cpp
+++ b/src/treebuilders/ABGVCalculator.cpp
@@ -5,8 +5,8 @@
 #include "trees/MWNode.h"
 #include "utils/Printer.h"
 
-using namespace std;
-using namespace Eigen;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
 
 namespace mrcpp {
 
@@ -24,7 +24,7 @@ void ABGVCalculator::calcValueVectors(const ScalingBasis &basis) {
     int kp1 = basis.getQuadratureOrder();
     double sqrtCoef[kp1];
     for (int i = 0; i < kp1; i++) {
-        sqrtCoef[i] = sqrt(2.0 * i + 1.0);
+        sqrtCoef[i] = std::sqrt(2.0 * i + 1.0);
     }
 
     switch (basis.getScalingType()) {
@@ -52,7 +52,7 @@ void ABGVCalculator::calcKMatrix(const ScalingBasis &basis) {
     int kp1 = basis.getQuadratureOrder();
     double sqrtCoef[kp1];
     for (int i = 0; i < kp1; i++) {
-        sqrtCoef[i] = sqrt(2.0 * i + 1.0);
+        sqrtCoef[i] = std::sqrt(2.0 * i + 1.0);
     }
     getQuadratureCache(qCache);
     const VectorXd &roots = qCache.getRoots(kp1);
@@ -88,7 +88,7 @@ void ABGVCalculator::calcNode(MWNode<2> &node) {
     int kp1 = node.getKp1();
     int kp1_d = node.getKp1_d();
     int l = node.getTranslation()[1] - node.getTranslation()[0];
-    double two_np1 = pow(2.0, node.getScale() + 1);
+    double two_np1 = std::pow(2.0, node.getScale() + 1);
     double *coefs = node.getCoefs();
 
     double a = this->A;

--- a/src/treebuilders/ABGVCalculator.h
+++ b/src/treebuilders/ABGVCalculator.h
@@ -4,10 +4,9 @@
 
 namespace mrcpp {
 
-class ABGVCalculator : public TreeCalculator<2> {
+class ABGVCalculator final : public TreeCalculator<2> {
 public:
     ABGVCalculator(const ScalingBasis &basis, double a, double b);
-    virtual ~ABGVCalculator() { }
 
 protected:
     const double A;	 ///< Left boundary conditions, ref. Alpert et al.

--- a/src/treebuilders/AdditionCalculator.h
+++ b/src/treebuilders/AdditionCalculator.h
@@ -6,10 +6,9 @@
 namespace mrcpp {
 
 template<int D>
-class AdditionCalculator : public TreeCalculator<D> {
+class AdditionCalculator final : public TreeCalculator<D> {
 public:
     AdditionCalculator(const FunctionTreeVector<D> &inp) : sum_vec(inp) { }
-    virtual ~AdditionCalculator() { }
 
 protected:
     FunctionTreeVector<D> sum_vec;

--- a/src/treebuilders/CMakeLists.txt
+++ b/src/treebuilders/CMakeLists.txt
@@ -27,7 +27,10 @@ list(APPEND treebuilders_h
     ${CMAKE_CURRENT_SOURCE_DIR}/MultiplicationCalculator.h
     ${CMAKE_CURRENT_SOURCE_DIR}/OperatorAdaptor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/PHCalculator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/PowerCalculator.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ProjectionCalculator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/SplitAdaptor.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/SquareCalculator.h
     ${CMAKE_CURRENT_SOURCE_DIR}/TreeAdaptor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/TreeBuilder.h
     ${CMAKE_CURRENT_SOURCE_DIR}/TreeCalculator.h

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -14,8 +14,8 @@ extern "C" {
 }
 #endif
 
-using namespace std;
-using namespace Eigen;
+using Eigen::MatrixXd;
+using Eigen::MatrixXi;
 
 namespace mrcpp {
 
@@ -70,25 +70,23 @@ template<int D>
 void ConvolutionCalculator<D>::printTimers() const {
     int oldprec = Printer::setPrecision(1);
     int nThreads = omp_get_max_threads();
-    printout(20, endl);
-    printout(20, endl << "thread ");
+    printout(20, "\n\nthread ");
     for (int i = 0; i < nThreads; i++) {
-        printout(20, setw(9) << i);
+        printout(20, std::setw(9) << i);
     }
-    printout(20, endl << "band     ");
+    printout(20, "\nband     ");
     for (int i = 0; i < nThreads; i++) {
         printout(20, this->band_t[i]->getWallTime() << "  ");
     }
-    printout(20, endl << "calc     ");
+    printout(20, "\ncalc     ");
     for (int i = 0; i < nThreads; i++) {
         printout(20, this->calc_t[i]->getWallTime() << "  ");
     }
-    printout(20, endl << "norm     ");
+    printout(20, "\nnorm     ");
     for (int i = 0; i < nThreads; i++) {
         printout(20, this->norm_t[i]->getWallTime() << "  ");
     }
-    printout(20, endl);
-    printout(20, endl);
+    printout(20, "\n\n");
     Printer::setPrecision(oldprec);
 }
 
@@ -224,7 +222,7 @@ void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
     double gThrs = gTree.getSquareNorm();
     if (gThrs > 0.0) {
         double nTerms = (double) this->oper->size();
-        gThrs = this->prec*sqrt(gThrs/nTerms);
+        gThrs = this->prec*std::sqrt(gThrs/nTerms);
     }
     os.gThreshold = gThrs;
 
@@ -331,8 +329,8 @@ void ConvolutionCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
                     os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
         } else {
             // Identity operator in direction i
-            Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
-            Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
+            Eigen::Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
+            Eigen::Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
             if (oData[i] == 0) {
                 if (i == D - 1) { // Last dir: Add up into g
                     g += f.transpose();
@@ -344,8 +342,8 @@ void ConvolutionCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
     }
 #else
     for (int i = 0; i < D; i++) {
-        Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
-        Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
+        Eigen::Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
+        Eigen::Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
         if (oData[i] != 0) {
             Eigen::Map<MatrixXd> op(oData[i], os.kp1, os.kp1);
             if (i == D - 1) { // Last dir: Add up into g

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -8,7 +8,7 @@
 namespace mrcpp {
 
 template<int D>
-class ConvolutionCalculator : public TreeCalculator<D> {
+class ConvolutionCalculator final : public TreeCalculator<D> {
 public:
     ConvolutionCalculator(double p,
                           ConvolutionOperator<D> &o,

--- a/src/treebuilders/CopyAdaptor.cpp
+++ b/src/treebuilders/CopyAdaptor.cpp
@@ -41,7 +41,7 @@ bool CopyAdaptor<D>::splitNode(const MWNode<D> &node) const {
                 for (int i = 0; i < this->tree_vec.size(); i++) {
                     const FunctionTree<D> &func_i = get_func(tree_vec, i);
                     const MWNode<D> *node_i = func_i.findNode(bwIdx);
-                    if (node_i != 0) return true;
+                    if (node_i != nullptr) return true;
                 }
             }
         }

--- a/src/treebuilders/CopyAdaptor.h
+++ b/src/treebuilders/CopyAdaptor.h
@@ -6,11 +6,10 @@
 namespace mrcpp {
 
 template<int D>
-class CopyAdaptor : public TreeAdaptor<D> {
+class CopyAdaptor final : public TreeAdaptor<D> {
 public:
     CopyAdaptor(FunctionTree<D> &t, int ms, int *bw);
     CopyAdaptor(FunctionTreeVector<D> &t, int ms, int *bw);
-    virtual ~CopyAdaptor() { }
 
 protected:
     int bandWidth[D];

--- a/src/treebuilders/CrossCorrelationCalculator.cpp
+++ b/src/treebuilders/CrossCorrelationCalculator.cpp
@@ -4,8 +4,8 @@
 #include "utils/Printer.h"
 #include "eigen_disable_warnings.h"
 
-using namespace std;
-using namespace Eigen;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
 
 namespace mrcpp {
 
@@ -68,7 +68,7 @@ void CrossCorrelationCalculator::applyCcc(MWNode<2> &node,
         vec_o.segment(i*kp1_d, kp1_d) = (lMat*seg_a + rMat*seg_b);
     }
     double *coefs = node.getCoefs();
-    double two_n = pow(2.0, -scale/2.0);
+    double two_n = std::pow(2.0, -scale/2.0);
     for (int i = 0; i < t_dim*kp1_d; i++) {
         coefs[i] = two_n*vec_o(i);
     }

--- a/src/treebuilders/CrossCorrelationCalculator.h
+++ b/src/treebuilders/CrossCorrelationCalculator.h
@@ -5,10 +5,9 @@
 
 namespace mrcpp {
 
-class CrossCorrelationCalculator : public TreeCalculator<2> {
+class CrossCorrelationCalculator final : public TreeCalculator<2> {
 public:
     CrossCorrelationCalculator(FunctionTree<1> &k) : kernel(&k) { }
-    virtual ~CrossCorrelationCalculator() { }
 
 protected:
     FunctionTree<1> *kernel;

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -14,8 +14,7 @@ extern "C" {
 }
 #endif
 
-using namespace std;
-using namespace Eigen;
+using Eigen::MatrixXd;
 
 namespace mrcpp {
 
@@ -57,25 +56,23 @@ template<int D>
 void DerivativeCalculator<D>::printTimers() const {
     int oldprec = Printer::setPrecision(1);
     int nThreads = omp_get_max_threads();
-    printout(20, endl);
-    printout(20, endl << "thread ");
+    printout(20, "\n\nthread ");
     for (int i = 0; i < nThreads; i++) {
-        printout(20, setw(9) << i);
+        printout(20, std::setw(9) << i);
     }
-    printout(20, endl << "band     ");
+    printout(20, "\nband     ");
     for (int i = 0; i < nThreads; i++) {
         printout(20, this->band_t[i].getWallTime() << "  ");
     }
-    printout(20, endl << "calc     ");
+    printout(20, "\ncalc     ");
     for (int i = 0; i < nThreads; i++) {
         printout(20, this->calc_t[i].getWallTime() << "  ");
     }
-    printout(20, endl << "norm     ");
+    printout(20, "\nnorm     ");
     for (int i = 0; i < nThreads; i++) {
         printout(20, this->norm_t[i].getWallTime() << "  ");
     }
-    printout(20, endl);
-    printout(20, endl);
+    printout(20, "\n\n");
     Printer::setPrecision(oldprec);
 }
 
@@ -211,8 +208,8 @@ void DerivativeCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
                     os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
         } else {
             // Identity operator in direction i
-            Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
-            Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
+            Eigen::Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
+            Eigen::Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
             if (oData[i] == 0) {
                 if (i == D - 1) { // Last dir: Add up into g
                     g += f.transpose();
@@ -224,8 +221,8 @@ void DerivativeCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
     }
 #else
     for (int i = 0; i < D; i++) {
-        Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
-        Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
+        Eigen::Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
+        Eigen::Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
         if (oData[i] != 0) {
             Eigen::Map<MatrixXd> op(oData[i], os.kp1, os.kp1);
             if (i == D - 1) { // Last dir: Add up into g

--- a/src/treebuilders/DerivativeCalculator.h
+++ b/src/treebuilders/DerivativeCalculator.h
@@ -6,7 +6,7 @@
 namespace mrcpp {
 
 template<int D>
-class DerivativeCalculator : public TreeCalculator<D> {
+class DerivativeCalculator final : public TreeCalculator<D> {
 public:
     DerivativeCalculator(int dir, DerivativeOperator<D> &o, FunctionTree<D> &f);
     virtual ~DerivativeCalculator();

--- a/src/treebuilders/MultiplicationCalculator.h
+++ b/src/treebuilders/MultiplicationCalculator.h
@@ -6,10 +6,9 @@
 namespace mrcpp {
 
 template<int D>
-class MultiplicationCalculator : public TreeCalculator<D> {
+class MultiplicationCalculator final : public TreeCalculator<D> {
 public:
     MultiplicationCalculator(const FunctionTreeVector<D> &inp) : prod_vec(inp) { }
-    virtual ~MultiplicationCalculator() { }
 
 protected:
     FunctionTreeVector<D> prod_vec;

--- a/src/treebuilders/OperatorAdaptor.h
+++ b/src/treebuilders/OperatorAdaptor.h
@@ -4,11 +4,10 @@
 
 namespace mrcpp {
 
-class OperatorAdaptor : public WaveletAdaptor<2> {
+class OperatorAdaptor final : public WaveletAdaptor<2> {
 public:
     OperatorAdaptor(double pr, int ms, bool ap = false)
             : WaveletAdaptor<2>(pr, ms, ap) { }
-    virtual ~OperatorAdaptor() { }
 
 protected:
     virtual bool splitNode(const MWNode<2> &node) const {

--- a/src/treebuilders/PHCalculator.cpp
+++ b/src/treebuilders/PHCalculator.cpp
@@ -5,8 +5,7 @@
 #include "PHCalculator.h"
 #include "utils/Printer.h"
 
-using namespace std;
-using namespace Eigen;
+using Eigen::MatrixXd;
 
 namespace mrcpp {
 
@@ -19,20 +18,20 @@ PHCalculator::PHCalculator(const ScalingBasis &basis, int n)
 }
 
 void PHCalculator::readSMatrix(const ScalingBasis &basis, char n) {
-    string file;
-    string path = MW_FILTER_DIR;
+    std::string file;
+    std::string path = MW_FILTER_DIR;
     if (basis.getScalingType() == Legendre) file = path + "/L_ph_deriv_" + n + ".txt";
     if (basis.getScalingType() == Interpol) file = path + "/I_ph_deriv_" + n + ".txt";
     if (basis.getScalingOrder() <  0) MSG_FATAL("Scaling order not supported");
     if (basis.getScalingOrder() > 29) MSG_FATAL("Scaling order not supported");
 
-    fstream ifs;
+    std::fstream ifs;
     ifs.open(file.c_str());
     if (not ifs) MSG_ERROR("Failed to open file: " << file);
     for (int kp1 = 2; kp1 < 30; kp1++) {
-        string line;
+        std::string line;
         getline(ifs, line);
-        istringstream iss(line);
+        std::istringstream iss(line);
 
         int order;
         iss >> order;
@@ -41,7 +40,7 @@ void PHCalculator::readSMatrix(const ScalingBasis &basis, char n) {
         MatrixXd data = MatrixXd::Zero(3*kp1, kp1);
         for (int i = 0; i < 3*kp1; i++) {
             getline(ifs, line);
-            istringstream iss(line);
+            std::istringstream iss(line);
             for (int j = 0; j < kp1; j++) {
                 iss >> data(i,j);
             }
@@ -61,7 +60,7 @@ void PHCalculator::calcNode(MWNode<2> &node) {
     int kp1 = node.getKp1();
     int kp1_d = node.getKp1_d();
     int l = node.getTranslation()[1] - node.getTranslation()[0];
-    double two_np1 = pow(2.0, this->diff_order*np1);
+    double two_np1 = std::pow(2.0, this->diff_order*np1);
     double *coefs = node.getCoefs();
 
     switch (l) {

--- a/src/treebuilders/PHCalculator.h
+++ b/src/treebuilders/PHCalculator.h
@@ -7,10 +7,9 @@
 
 namespace mrcpp {
 
-class PHCalculator : public TreeCalculator<2> {
+class PHCalculator final : public TreeCalculator<2> {
 public:
     PHCalculator(const ScalingBasis &basis, int n);
-    virtual ~PHCalculator() { }
 
 protected:
     const int diff_order;

--- a/src/treebuilders/PowerCalculator.h
+++ b/src/treebuilders/PowerCalculator.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "TreeCalculator.h"
+
+namespace mrcpp {
+
+template<int D>
+class PowerCalculator final : public TreeCalculator<D> {
+public:
+    PowerCalculator(FunctionTree<D> &inp, double pow)
+        : power(pow), func(&inp) { }
+
+protected:
+    double power;
+    FunctionTree<D> *func;
+
+    virtual void calcNode(MWNode<D> &node_o) {
+        const NodeIndex<D> &idx = node_o.getNodeIndex();
+        int n_coefs = node_o.getNCoefs();
+        double *coefs_o = node_o.getCoefs();
+        // This generates missing nodes
+        MWNode<D> node_i = func->getNode(idx); // Copy node
+        node_i.mwTransform(Reconstruction);
+        node_i.cvTransform(Forward);
+        const double *coefs_i = node_i.getCoefs();
+        for (int j = 0; j < n_coefs; j++) {
+            coefs_o[j] = std::pow(coefs_i[j], this->power);
+        }
+        node_o.cvTransform(Backward);
+        node_o.mwTransform(Compression);
+        node_o.setHasCoefs();
+        node_o.calcNorms();
+    }
+};
+
+}

--- a/src/treebuilders/ProjectionCalculator.cpp
+++ b/src/treebuilders/ProjectionCalculator.cpp
@@ -1,8 +1,7 @@
 #include "ProjectionCalculator.h"
 #include "trees/MWNode.h"
 
-using namespace std;
-using namespace Eigen;
+using Eigen::MatrixXd;
 
 namespace mrcpp {
 

--- a/src/treebuilders/ProjectionCalculator.h
+++ b/src/treebuilders/ProjectionCalculator.h
@@ -5,10 +5,9 @@
 namespace mrcpp {
 
 template<int D>
-class ProjectionCalculator : public TreeCalculator<D> {
+class ProjectionCalculator final : public TreeCalculator<D> {
 public:
     ProjectionCalculator(const RepresentableFunction<D> &inp_func) : func(&inp_func) { }
-    virtual ~ProjectionCalculator() { }
 
 protected:
     const RepresentableFunction<D> *func;

--- a/src/treebuilders/SplitAdaptor.h
+++ b/src/treebuilders/SplitAdaptor.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "TreeAdaptor.h"
+
+namespace mrcpp {
+
+template<int D>
+class SplitAdaptor final : public TreeAdaptor<D> {
+public:
+    SplitAdaptor(int ms, bool sp) : TreeAdaptor<D>(ms), split(sp) { }
+
+protected:
+    bool split;
+
+    bool splitNode(const MWNode<D> &node) const { return this->split; }
+};
+
+}

--- a/src/treebuilders/SquareCalculator.h
+++ b/src/treebuilders/SquareCalculator.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "TreeCalculator.h"
+
+namespace mrcpp {
+
+template<int D>
+class SquareCalculator final : public TreeCalculator<D> {
+public:
+    SquareCalculator(FunctionTree<D> &inp) : func(&inp) { }
+
+protected:
+    FunctionTree<D> *func;
+
+    virtual void calcNode(MWNode<D> &node_o) {
+        const NodeIndex<D> &idx = node_o.getNodeIndex();
+        int n_coefs = node_o.getNCoefs();
+        double *coefs_o = node_o.getCoefs();
+        // This generates missing nodes
+        MWNode<D> node_i = func->getNode(idx); // Copy node
+        node_i.mwTransform(Reconstruction);
+        node_i.cvTransform(Forward);
+        const double *coefs_i = node_i.getCoefs();
+        for (int j = 0; j < n_coefs; j++) {
+            coefs_o[j] = coefs_i[j]*coefs_i[j];
+        }
+        node_o.cvTransform(Backward);
+        node_o.mwTransform(Compression);
+        node_o.setHasCoefs();
+        node_o.calcNorms();
+    }
+};
+
+}

--- a/src/treebuilders/TreeAdaptor.h
+++ b/src/treebuilders/TreeAdaptor.h
@@ -31,7 +31,7 @@ public:
 protected:
     int maxScale;
 
-    virtual bool splitNode(const MWNode<D> &node) const { return false; }
+    virtual bool splitNode(const MWNode<D> &node) const = 0;
 };
 
 }

--- a/src/treebuilders/TreeAdaptor.h
+++ b/src/treebuilders/TreeAdaptor.h
@@ -9,7 +9,7 @@ template<int D>
 class TreeAdaptor {
 public:
     TreeAdaptor(int ms) : maxScale(ms) { }
-    virtual ~TreeAdaptor() { }
+    virtual ~TreeAdaptor() = default;
 
     void setMaxScale(int ms) { this->maxScale = ms; }
 

--- a/src/treebuilders/TreeCalculator.h
+++ b/src/treebuilders/TreeCalculator.h
@@ -8,7 +8,7 @@ template<int D>
 class TreeCalculator {
 public:
     TreeCalculator() { }
-    virtual ~TreeCalculator() { }
+    virtual ~TreeCalculator() = default;
 
     virtual MWNodeVector* getInitialWorkVector(MWTree<D> &tree) const {
         return tree.copyEndNodeTable();

--- a/src/treebuilders/WaveletAdaptor.h
+++ b/src/treebuilders/WaveletAdaptor.h
@@ -1,25 +1,18 @@
 #pragma once
 
 #include "TreeAdaptor.h"
-#include "constants.h"
 
 namespace mrcpp {
 
 template<int D>
 class WaveletAdaptor : public TreeAdaptor<D> {
 public:
-    WaveletAdaptor(double pr,
-		   int ms,
-		   bool ap = false,
-		   double sf = 1.0)
-            : TreeAdaptor<D>(ms),
-              absPrec(ap),
-              prec(pr),
-	      splitFac(sf) { }
-    virtual ~WaveletAdaptor() { }
-
-    void setPrecision(double pr) { this->prec = pr; }
-    void setAbsPrec(bool ap) { this->absPrec = ap; }
+    WaveletAdaptor(double pr, int ms, bool ap = false, double sf = 1.0)
+        : TreeAdaptor<D>(ms),
+          absPrec(ap),
+          prec(pr),
+          splitFac(sf) { }
+    virtual ~WaveletAdaptor() = default;
 
 protected:
     bool absPrec;

--- a/src/treebuilders/add.cpp
+++ b/src/treebuilders/add.cpp
@@ -18,7 +18,7 @@ namespace mrcpp {
  * @param[in,out] out Output function to be built
  * @param[in] a Numerical coefficient of function a
  * @param[in] inp_a Input function a
- * @param[in] a Numerical coefficient of function b
+ * @param[in] b Numerical coefficient of function b
  * @param[in] inp_b Input function b
  * @param[in] maxIter Maximum number of refinement iterations in output tree
  *

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -3,6 +3,7 @@
 #include "add.h"
 #include "TreeBuilder.h"
 #include "CopyAdaptor.h"
+#include "SplitAdaptor.h"
 #include "WaveletAdaptor.h"
 #include "DefaultCalculator.h"
 #include "DerivativeCalculator.h"
@@ -101,7 +102,7 @@ void apply(FunctionTree<D> &out,
     pre_t.stop();
 
     // Apply operator on fixed expanded grid
-    TreeAdaptor<D> apply_adaptor(maxScale);
+    SplitAdaptor<D> apply_adaptor(maxScale, false); // Splits no nodes
     DerivativeCalculator<D> apply_calculator(dir, oper, inp);
     builder.build(out, apply_calculator, apply_adaptor, 0);
 

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -3,6 +3,7 @@
 #include "TreeBuilder.h"
 #include "AnalyticAdaptor.h"
 #include "CopyAdaptor.h"
+#include "SplitAdaptor.h"
 #include "WaveletAdaptor.h"
 #include "DefaultCalculator.h"
 #include "utils/Printer.h"
@@ -154,6 +155,28 @@ void clear_grid(FunctionTree<D> &out) {
 /** @brief Refine the grid of a MW function representation
  *
  * @param[in,out] out Output tree to be refined
+ * @param[in] scales Number of refinement levels
+ *
+ * This will split ALL nodes in the tree the given number of times, then it will
+ * compute scaling coefs of the new nodes, thus leaving the function representation
+ * unchanged, but on a larger grid.
+ *
+ */
+template<int D>
+int refine_grid(FunctionTree<D> &out, int scales) {
+    int nSplit = 0;
+    int maxScale = out.getMRA().getMaxScale();
+    TreeBuilder<D> builder;
+    SplitAdaptor<D> adaptor(maxScale, true); // Splits all nodes
+    for (int n = 0; n < scales; n++) {
+        nSplit += builder.split(out, adaptor, true); // Transfers coefs to children
+    }
+    return nSplit;
+}
+
+/** @brief Refine the grid of a MW function representation
+ *
+ * @param[in,out] out Output tree to be refined
  * @param[in] prec Precision for initial split check
  *
  * This will first perform a split check on the existing end nodes in the tree
@@ -208,6 +231,9 @@ template void copy_grid(FunctionTree<3> &out, FunctionTree<3> &inp);
 template void clear_grid(FunctionTree<1> &out);
 template void clear_grid(FunctionTree<2> &out);
 template void clear_grid(FunctionTree<3> &out);
+template int refine_grid(FunctionTree<1> &out, int scales);
+template int refine_grid(FunctionTree<2> &out, int scales);
+template int refine_grid(FunctionTree<3> &out, int scales);
 template int refine_grid(FunctionTree<1> &out, double prec);
 template int refine_grid(FunctionTree<2> &out, double prec);
 template int refine_grid(FunctionTree<3> &out, double prec);

--- a/src/treebuilders/grid.h
+++ b/src/treebuilders/grid.h
@@ -11,6 +11,7 @@ template<int D> void build_grid(FunctionTree<D> &out, FunctionTreeVector<D> &inp
 template<int D> void copy_func(FunctionTree<D> &out, FunctionTree<D> &inp);
 template<int D> void copy_grid(FunctionTree<D> &out, FunctionTree<D> &inp);
 template<int D> void clear_grid(FunctionTree<D> &out);
+template<int D> int refine_grid(FunctionTree<D> &out, int scales);
 template<int D> int refine_grid(FunctionTree<D> &out, double prec);
 template<int D> int refine_grid(FunctionTree<D> &out, FunctionTree<D> &inp);
 }

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -99,6 +99,26 @@ void multiply(double prec,
     Printer::printSeparator(10, ' ');
 }
 
+/** @brief Out-of-place square of MW function representations
+ *
+ * @param[in] prec Build precision of output function
+ * @param[in,out] out Output function to be built
+ * @param[in] inp Input function to square
+ * @param[in] maxIter Maximum number of refinement iterations in output tree
+ *
+ * The output function will be computed as the square of the input function,
+ * using the general algorithm:
+ *  1) Compute MW coefs on current grid
+ *  2) Refine grid where necessary based on prec
+ *  3) Repeat until convergence or maxIter is reached
+ *
+ * This algorithm will start at whatever grid is present in the output tree when
+ * the function is called (this grid should however be EMPTY, e.i. no coefs).
+ *
+ * A negative precision means NO refinement, as do maxIter = 0.
+ * A negative maxIter means no bound.
+ *
+ */
 template<int D>
 void square(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter) {
     int maxScale = out.getMRA().getMaxScale();
@@ -122,6 +142,27 @@ void square(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter
     Printer::printSeparator(10, ' ');
 }
 
+/** @brief Out-of-place power of MW function representations
+ *
+ * @param[in] prec Build precision of output function
+ * @param[in,out] out Output function to be built
+ * @param[in] inp Input function to square
+ * @param[in] pow Numerical power
+ * @param[in] maxIter Maximum number of refinement iterations in output tree
+ *
+ * The output function will be computed as the input function raised to the
+ * given power, using the general algorithm:
+ *  1) Compute MW coefs on current grid
+ *  2) Refine grid where necessary based on prec
+ *  3) Repeat until convergence or maxIter is reached
+ *
+ * This algorithm will start at whatever grid is present in the output tree when
+ * the function is called (this grid should however be EMPTY, e.i. no coefs).
+ *
+ * A negative precision means NO refinement, as do maxIter = 0.
+ * A negative maxIter means no bound.
+ *
+ */
 template<int D>
 void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double pow, int maxIter) {
     int maxScale = out.getMRA().getMaxScale();

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -3,6 +3,7 @@
 #include "grid.h"
 #include "TreeBuilder.h"
 #include "WaveletAdaptor.h"
+#include "PowerCalculator.h"
 #include "MultiplicationCalculator.h"
 #include "trees/HilbertIterator.h"
 #include "trees/FunctionTree.h"
@@ -98,8 +99,26 @@ void multiply(double prec,
 }
 
 template<int D>
-void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double pow) {
-    NOT_IMPLEMENTED_ABORT;
+void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double pow, int maxIter) {
+    int maxScale = out.getMRA().getMaxScale();
+    TreeBuilder<D> builder;
+    WaveletAdaptor<D> adaptor(prec, maxScale);
+    PowerCalculator<D> calculator(inp, pow);
+
+    builder.build(out, calculator, adaptor, maxIter);
+
+    Timer trans_t;
+    out.mwTransform(BottomUp);
+    out.calcSquareNorm();
+    trans_t.stop();
+
+    Timer clean_t;
+    inp.deleteGenerated();
+    clean_t.stop();
+
+    Printer::printTime(10, "Time transform", trans_t);
+    Printer::printTime(10, "Time cleaning", clean_t);
+    Printer::printSeparator(10, ' ');
 }
 
 template<int D>
@@ -203,9 +222,9 @@ template void multiply(double prec, FunctionTree<3> &out, double c, FunctionTree
 template void multiply(double prec, FunctionTree<1> &out, FunctionTreeVector<1> &inp, int maxIter);
 template void multiply(double prec, FunctionTree<2> &out, FunctionTreeVector<2> &inp, int maxIter);
 template void multiply(double prec, FunctionTree<3> &out, FunctionTreeVector<3> &inp, int maxIter);
-template void power(double prec, FunctionTree<1> &out, FunctionTree<1> &tree, double pow);
-template void power(double prec, FunctionTree<2> &out, FunctionTree<2> &tree, double pow);
-template void power(double prec, FunctionTree<3> &out, FunctionTree<3> &tree, double pow);
+template void power(double prec, FunctionTree<1> &out, FunctionTree<1> &tree, double pow, int maxIter);
+template void power(double prec, FunctionTree<2> &out, FunctionTree<2> &tree, double pow, int maxIter);
+template void power(double prec, FunctionTree<3> &out, FunctionTree<3> &tree, double pow, int maxIter);
 template void map(double prec, FunctionTree<1> &out, FunctionTree<1> &inp, RepresentableFunction<1> &func);
 template void map(double prec, FunctionTree<2> &out, FunctionTree<2> &inp, RepresentableFunction<2> &func);
 template void map(double prec, FunctionTree<3> &out, FunctionTree<3> &inp, RepresentableFunction<3> &func);

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -4,6 +4,7 @@
 #include "TreeBuilder.h"
 #include "WaveletAdaptor.h"
 #include "PowerCalculator.h"
+#include "SquareCalculator.h"
 #include "MultiplicationCalculator.h"
 #include "trees/HilbertIterator.h"
 #include "trees/FunctionTree.h"
@@ -91,6 +92,29 @@ void multiply(double prec,
         FunctionTree<D> &tree = get_func(inp, i);
         tree.deleteGenerated();
     }
+    clean_t.stop();
+
+    Printer::printTime(10, "Time transform", trans_t);
+    Printer::printTime(10, "Time cleaning", clean_t);
+    Printer::printSeparator(10, ' ');
+}
+
+template<int D>
+void square(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter) {
+    int maxScale = out.getMRA().getMaxScale();
+    TreeBuilder<D> builder;
+    WaveletAdaptor<D> adaptor(prec, maxScale);
+    SquareCalculator<D> calculator(inp);
+
+    builder.build(out, calculator, adaptor, maxIter);
+
+    Timer trans_t;
+    out.mwTransform(BottomUp);
+    out.calcSquareNorm();
+    trans_t.stop();
+
+    Timer clean_t;
+    inp.deleteGenerated();
     clean_t.stop();
 
     Printer::printTime(10, "Time transform", trans_t);
@@ -225,6 +249,9 @@ template void multiply(double prec, FunctionTree<3> &out, FunctionTreeVector<3> 
 template void power(double prec, FunctionTree<1> &out, FunctionTree<1> &tree, double pow, int maxIter);
 template void power(double prec, FunctionTree<2> &out, FunctionTree<2> &tree, double pow, int maxIter);
 template void power(double prec, FunctionTree<3> &out, FunctionTree<3> &tree, double pow, int maxIter);
+template void square(double prec, FunctionTree<1> &out, FunctionTree<1> &tree, int maxIter);
+template void square(double prec, FunctionTree<2> &out, FunctionTree<2> &tree, int maxIter);
+template void square(double prec, FunctionTree<3> &out, FunctionTree<3> &tree, int maxIter);
 template void map(double prec, FunctionTree<1> &out, FunctionTree<1> &inp, RepresentableFunction<1> &func);
 template void map(double prec, FunctionTree<2> &out, FunctionTree<2> &inp, RepresentableFunction<2> &func);
 template void map(double prec, FunctionTree<3> &out, FunctionTree<3> &inp, RepresentableFunction<3> &func);

--- a/src/treebuilders/multiply.h
+++ b/src/treebuilders/multiply.h
@@ -8,7 +8,7 @@ template<int D> class FunctionTree;
 
 template<int D> void multiply(double prec, FunctionTree<D> &out, double c, FunctionTree<D> &inp_a, FunctionTree<D> &inp_b, int maxIter = -1);
 template<int D> void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1);
-template<int D> void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double pow);
+template<int D> void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double pow, int maxIter = -1);
 template<int D> void map(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, RepresentableFunction<D> &func);
 template<int D> void dot(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp_a, FunctionTreeVector<D> &inp_b, int maxIter = -1);
 template<int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket);

--- a/src/treebuilders/multiply.h
+++ b/src/treebuilders/multiply.h
@@ -9,6 +9,7 @@ template<int D> class FunctionTree;
 template<int D> void multiply(double prec, FunctionTree<D> &out, double c, FunctionTree<D> &inp_a, FunctionTree<D> &inp_b, int maxIter = -1);
 template<int D> void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1);
 template<int D> void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double pow, int maxIter = -1);
+template<int D> void square(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter = -1);
 template<int D> void map(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, RepresentableFunction<D> &func);
 template<int D> void dot(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp_a, FunctionTreeVector<D> &inp_b, int maxIter = -1);
 template<int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket);

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -165,8 +165,11 @@ template<int D>
 void FunctionTree<D>::square() {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
 
+#pragma omp parallel
+{
     int nNodes = this->getNEndNodes();
     int nCoefs = this->getTDim()*this->getKp1_d();
+#pragma omp for schedule(guided)
     for (int n = 0; n < nNodes; n++) {
         MWNode<D> &node = *this->endNodeTable[n];
         node.mwTransform(Reconstruction);
@@ -179,6 +182,7 @@ void FunctionTree<D>::square() {
         node.mwTransform(Compression);
         node.calcNorms();
     }
+}
     this->mwTransform(BottomUp);
     this->calcSquareNorm();
 }
@@ -186,8 +190,11 @@ void FunctionTree<D>::square() {
 template<int D>
 void FunctionTree<D>::rescale(double c) {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
+#pragma omp parallel firstprivate(c)
+{
     int nNodes = this->getNEndNodes();
     int nCoefs = this->getTDim()*this->getKp1_d();
+#pragma omp for schedule(guided)
     for (int i = 0; i < nNodes; i++) {
         MWNode<D> &node = *this->endNodeTable[i];
         if (not node.hasCoefs()) MSG_FATAL("No coefs");
@@ -197,6 +204,7 @@ void FunctionTree<D>::rescale(double c) {
         }
         node.calcNorms();
     }
+}
     this->mwTransform(BottomUp);
     this->calcSquareNorm();
 }

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -207,6 +207,33 @@ void FunctionTree<D>::normalize() {
     this->rescale(1.0/sqrt(sq_norm));
 }
 
+template<int D>
+void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
+    if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
+#pragma omp parallel firstprivate(c), shared(inp)
+{
+    int nNodes = this->getNEndNodes();
+#pragma omp for schedule(guided)
+    for (int n = 0; n < nNodes; n++) {
+        MWNode<D> &out_node = *this->endNodeTable[n];
+        MWNode<D> &inp_node = inp.getNode(out_node.getNodeIndex());
+        double *out_coefs = out_node.getCoefs();
+        const double *inp_coefs = inp_node.getCoefs();
+        for (int i = 0; i < inp_node.getNCoefs(); i++) {
+            out_coefs[i] += c * inp_coefs[i];
+        }
+        out_node.calcNorms();
+    }
+}
+    this->mwTransform(BottomUp);
+    this->calcSquareNorm();
+    inp.deleteGenerated();
+}
+
+template<int D>
+void FunctionTree<D>::multiply(double c, FunctionTree<D> &inp) {
+    NOT_IMPLEMENTED_ABORT;
+}
 
 template<int D>
 int FunctionTree<D>::getNChunks() {

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -161,6 +161,12 @@ double FunctionTree<D>::evalf(const double *r) {
     return result;
 }
 
+/** @brief In-place square of function
+ *
+ * The leaf node point values of the output function will be in-place
+ * squared, no grid refinement.
+ *
+ */
 template<int D>
 void FunctionTree<D>::square() {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
@@ -187,6 +193,14 @@ void FunctionTree<D>::square() {
     this->calcSquareNorm();
 }
 
+/** @brief In-place raise to given power
+ *
+ * @param[in] c Numerical power
+ *
+ * The leaf node point values of the output function will be in-place
+ * raised to the given power, no grid refinement.
+ *
+ */
 template<int D>
 void FunctionTree<D>::power(double p) {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
@@ -213,6 +227,14 @@ void FunctionTree<D>::power(double p) {
     this->calcSquareNorm();
 }
 
+/** @brief In-place multiplication by a scalar
+ *
+ * @param[in] c Scalar coefficient
+ *
+ * The leaf node point values of the output function will be in-place
+ * multiplied by the given coefficient, no grid refinement.
+ *
+ */
 template<int D>
 void FunctionTree<D>::rescale(double c) {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
@@ -243,6 +265,15 @@ void FunctionTree<D>::normalize() {
     this->rescale(1.0/std::sqrt(sq_norm));
 }
 
+/** @brief In-place addition of MW function representations
+ *
+ * @param[in] c Numerical coefficient of input function
+ * @param[in] inp Input function to add
+ *
+ * The input function will be added in-place on the current grid of the output
+ * function, i.e. no further grid refinement.
+ *
+ */
 template<int D>
 void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
@@ -266,6 +297,15 @@ void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
     inp.deleteGenerated();
 }
 
+/** @brief In-place multiplication of MW function representations
+ *
+ * @param[in] c Numerical coefficient of input function
+ * @param[in] inp Input function to multiply
+ *
+ * The input function will be multiplied in-place on the current grid of the
+ * output function, i.e. no further grid refinement.
+ *
+ */
 template<int D>
 void FunctionTree<D>::multiply(double c, FunctionTree<D> &inp) {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -164,7 +164,8 @@ double FunctionTree<D>::evalf(const double *r) {
 
 template<int D>
 void FunctionTree<D>::square() {
-    this->deleteGenerated();
+    if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
+
     int nNodes = this->getNEndNodes();
     int nCoefs = this->getTDim()*this->getKp1_d();
     for (int n = 0; n < nNodes; n++) {
@@ -185,6 +186,7 @@ void FunctionTree<D>::square() {
 
 template<int D>
 void FunctionTree<D>::rescale(double c) {
+    if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
     int nNodes = this->getNEndNodes();
     int nCoefs = this->getTDim()*this->getKp1_d();
     for (int i = 0; i < nNodes; i++) {
@@ -202,6 +204,7 @@ void FunctionTree<D>::rescale(double c) {
 
 template<int D>
 void FunctionTree<D>::normalize() {
+    if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
     double sq_norm = this->getSquareNorm();
     if (sq_norm < 0.0) MSG_ERROR("Normalizing uninitialized function");
     this->rescale(1.0/sqrt(sq_norm));
@@ -247,6 +250,7 @@ int FunctionTree<D>::getNChunksUsed() {
 
 template<int D>
 void FunctionTree<D>::getEndValues(VectorXd &data) {
+    if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
     int nNodes = this->getNEndNodes();
     int nCoefs = this->getTDim()*this->getKp1_d();
     data = VectorXd::Zero(nNodes*nCoefs);
@@ -265,6 +269,7 @@ void FunctionTree<D>::getEndValues(VectorXd &data) {
 
 template<int D>
 void FunctionTree<D>::setEndValues(VectorXd &data) {
+    if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
     int nNodes = this->getNEndNodes();
     int nCoefs = this->getTDim()*this->getKp1_d();
     for (int i = 0; i < nNodes; i++) {

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -13,7 +13,6 @@
 #include "utils/Printer.h"
 #include "utils/Timer.h"
 
-using namespace std;
 using namespace Eigen;
 
 namespace mrcpp {
@@ -59,14 +58,14 @@ void FunctionTree<D>::clear() {
 /** Write the tree structure to disk, for later use.
   * Argument file name will get a ".tree" file extension. */
 template<int D>
-void FunctionTree<D>::saveTree(const string &file) {
+void FunctionTree<D>::saveTree(const std::string &file) {
     // This is basically a copy of MPI send_tree
     Timer t1;
-    stringstream fname;
+    std::stringstream fname;
     fname << file << ".tree";
 
-    fstream f;
-    f.open(fname.str(), ios::out | ios::binary);
+    std::fstream f;
+    f.open(fname.str(), std::ios::out | std::ios::binary);
     if (not f.is_open()) MSG_ERROR("Unable to open file");
 
     this->deleteGenerated();
@@ -100,14 +99,14 @@ void FunctionTree<D>::saveTree(const string &file) {
 /** Read a previously stored tree structure from disk.
   * Argument file name will get a ".tree" file extension. */
 template<int D>
-void FunctionTree<D>::loadTree(const string &file) {
+void FunctionTree<D>::loadTree(const std::string &file) {
     // This is basically a copy of MPI recv_tree
     Timer t1;
-    stringstream fname;
+    std::stringstream fname;
     fname << file << ".tree";
 
-    fstream f;
-    f.open(fname.str(), ios::in | ios::binary);
+    std::fstream f;
+    f.open(fname.str(), std::ios::in | std::ios::binary);
     if (not f.is_open()) MSG_ERROR("Unable to open file");
 
     // Read size of tree
@@ -207,7 +206,7 @@ void FunctionTree<D>::normalize() {
     if (this->getNGenNodes() != 0) MSG_FATAL("GenNodes not cleared");
     double sq_norm = this->getSquareNorm();
     if (sq_norm < 0.0) MSG_ERROR("Normalizing uninitialized function");
-    this->rescale(1.0/sqrt(sq_norm));
+    this->rescale(1.0/std::sqrt(sq_norm));
 }
 
 template<int D>

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -28,6 +28,7 @@ public:
 
     // In place operations
     void square();
+    void power(double p);
     void rescale(double c);
     void normalize();
     void add(double c, FunctionTree<D> &inp);

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -30,6 +30,8 @@ public:
     void square();
     void rescale(double c);
     void normalize();
+    void add(double c, FunctionTree<D> &inp);
+    void multiply(double c, FunctionTree<D> &inp);
 
     int getNChunks();
     int getNChunksUsed();

--- a/tests/treebuilders/CMakeLists.txt
+++ b/tests/treebuilders/CMakeLists.txt
@@ -9,5 +9,6 @@ target_sources(mrcpp-tests PRIVATE
 add_Catch_test(NAME clear_grid              LABELS clear_grid)
 add_Catch_test(NAME build_grid              LABELS build_grid)
 add_Catch_test(NAME addition                LABELS addition)
-add_Catch_test(NAME multiplication          LABELS multiplicationx)
+add_Catch_test(NAME multiplication          LABELS multiplication)
+add_Catch_test(NAME square                  LABELS square)
 add_Catch_test(NAME projection              LABELS projection)

--- a/tests/treebuilders/addition.cpp
+++ b/tests/treebuilders/addition.cpp
@@ -121,6 +121,15 @@ template<int D> void testAddition() {
                     REQUIRE( e_int == Approx(ref_int).margin(prec*prec) );
                 }
             }
+            AND_WHEN("the second function is subtracted in-place") {
+                d_tree.add(-b_coef, b_tree);
+
+                THEN("the integral is zero") {
+                    double d_int = d_tree.integrate();
+                    double ref_int = 0.0;
+                    REQUIRE( d_int == Approx(ref_int).margin(prec*prec) );
+                }
+            }
         }
     }
     finalize(&mra);


### PR DESCRIPTION
Features added
-------------------
In-place operations on *fixed* grid:
- `tree.square()`
- `tree.power(double pow)`
- `tree.add(double c, FunctionTree inp)`
- `tree.multiply(double c, FunctionTree inp)`

Out-of-place operations on *adaptive* grid:
- `mrcpp::square(double prec, FunctionTree out, FunctionTree inp)`
- `mrcpp::power(double prec, FunctionTree out, FunctionTree inp, double pow)`
- `mrcpp::refine_grid(FunctionTree out, int n_levels)` (uniform refine by n levels)

Misc
-----
- Minor cleanups in `TreeCalculator` and `TreeAdaptor` classes
- OpenMP parallelized in-place operations

Status
--------
- [x] Ready to go