### PR TITLE
Bugfix: receiving cropped trees

### DIFF
--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -41,6 +41,7 @@ public:
     FunctionNode<D> &getRootFuncNode(int i) { return static_cast<FunctionNode<D> &>(this->rootBox.getNode(i)); }
 
     SerialFunctionTree<D>* getSerialFunctionTree() { return static_cast<SerialFunctionTree<D> *>(this->serialTree_p); }
+    void printSerialIndices();
 
     const FunctionNode<D> &getEndFuncNode(int i) const { return static_cast<const FunctionNode<D> &>(this->getEndMWNode(i)); }
     const FunctionNode<D> &getRootFuncNode(int i) const { return static_cast<const FunctionNode<D> &>(this->rootBox.getNode(i)); }

--- a/src/trees/GenNode.cpp
+++ b/src/trees/GenNode.cpp
@@ -53,8 +53,12 @@ double GenNode<D>::calcComponentNorm(int i) const {
 
 template<int D>
 void GenNode<D>::dealloc() {
+    int sIdx = this->serialIx;
+    this->serialIx = -1;
+    this->parentSerialIx = -1;
+    this->childSerialIx = -1;
     this->tree->decrementGenNodeCount();
-    this->tree->getSerialTree()->deallocGenNodes(this->getSerialIx());
+    this->tree->getSerialTree()->deallocGenNodes(sIdx);
 }
 
 template<int D>

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -667,12 +667,13 @@ void MWNode<D>::deleteChildren() {
     if (this->isLeafNode()) return;
     for (int cIdx = 0; cIdx < getTDim(); cIdx++) {
         if (this->children[cIdx] != 0) {
-	    MWNode<D> &child = getMWChild(cIdx);
-	    child.deleteChildren();
+            MWNode<D> &child = getMWChild(cIdx);
+            child.deleteChildren();
             child.dealloc();
-	}
-	this->children[cIdx] = 0;
+        }
+        this->children[cIdx] = 0;
     }
+    this->childSerialIx = -1;
     this->setIsLeafNode();
 }
 

--- a/src/trees/OperatorNode.cpp
+++ b/src/trees/OperatorNode.cpp
@@ -7,8 +7,12 @@ using namespace Eigen;
 namespace mrcpp {
 
 void OperatorNode::dealloc() {
+    int sIdx = this->serialIx;
+    this->serialIx = -1;
+    this->parentSerialIx = -1;
+    this->childSerialIx = -1;
     this->tree->decrementNodeCount(this->getScale());
-    this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
+    this->tree->getSerialTree()->deallocNodes(sIdx);
 }
 
 /** Calculate one specific component norm of the OperatorNode.

--- a/src/trees/ProjectedNode.cpp
+++ b/src/trees/ProjectedNode.cpp
@@ -28,8 +28,12 @@ void ProjectedNode<D>::deleteChildren() {
 
 template<int D>
 void ProjectedNode<D>::dealloc() {
+    int sIdx = this->serialIx;
+    this->serialIx = -1;
+    this->parentSerialIx = -1;
+    this->childSerialIx = -1;
     this->tree->decrementNodeCount(this->getScale());
-    this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
+    this->tree->getSerialTree()->deallocNodes(sIdx);
 }
 
 /** Update the coefficients of the node by a mw transform of the scaling

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -53,13 +53,6 @@ void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, int nChun
     int count = 1;
     for (int iChunk = 0; iChunk < nChunks; iChunk++) {
         count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
-        //set serialIx of the unused nodes to -1
-        int iShift = iChunk*sTree.maxNodesPerChunk;
-        for (int i = 0; i < sTree.maxNodesPerChunk; i++) {
-            if (sTree.nodeStackStatus[iShift+i] != 1) {
-                sTree.nodeChunks[iChunk][i].setSerialIx(-1);
-            }
-        }
         MPI_Send(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, tag+iChunk+1, comm);
         count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
         MPI_Send(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, tag+iChunk+1001, comm);
@@ -119,13 +112,6 @@ void isend_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, MPI_Requ
     int count = 1;
     for (int iChunk = 0; iChunk < nChunks; iChunk++) {
         count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
-        //set serialIx of the unused nodes to -1
-        int iShift = iChunk*sTree.maxNodesPerChunk;
-        for (int i = 0; i < sTree.maxNodesPerChunk; i++) {
-            if (sTree.nodeStackStatus[iShift+i] != 1) {
-                sTree.nodeChunks[iChunk][i].setSerialIx(-1);
-            }
-        }
         MPI_Isend(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, tag+iChunk+1, comm, req);
         count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;
         MPI_Isend(sTree.nodeCoeffChunks[iChunk], count, MPI_DOUBLE, dst, tag+iChunk+1001, comm, req);
@@ -156,13 +142,6 @@ void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm) {
             int count = 1;
             for (int iChunk = 0; iChunk < nChunks; iChunk++) {
                 count = sTree.maxNodesPerChunk*sizeof(ProjectedNode<D>);
-                //set serialIx of the unused nodes to -1
-                int iShift = iChunk*sTree.maxNodesPerChunk;
-                for (int i = 0; i < sTree.maxNodesPerChunk; i++) {
-                    if (sTree.nodeStackStatus[iShift+i] != 1) {
-                        sTree.nodeChunks[iChunk][i].setSerialIx(-1);
-                    }
-                }
                 println(10, " Sending chunk " << iChunk);
                 MPI_Send(sTree.nodeChunks[iChunk], count, MPI_BYTE, dst, dst_tag+iChunk+1, comm);
                 count = sTree.sizeNodeCoeff * sTree.maxNodesPerChunk;


### PR DESCRIPTION
Bugfix
-------
- The function `getNChunksUsed()` returned the actual number of used chunks, when it ought to return the position of the *last* used chunk. If entire chunks in the middle turned out empty after a `tree.crop()` they still needs to be counted if a node is present in the *last* chunk.

Changes
-----------
- Previously the `serialIx` was set to -1 just before `mpi::send_tree()` and `saveTree()`, now all serial indices (serial, parentSerial and childSerial) are cleared when chunks are first allocated *and* when nodes are deallocated.