### PR TITLE
Minor cleanups

### DIFF
--- a/examples/addition.cpp
+++ b/examples/addition.cpp
@@ -42,10 +42,10 @@ int main(int argc, char **argv) {
     auto f_func_3 = mrcpp::GaussFunc<D>(beta, alpha, pos_3, power);
 
     // Initialize MW functions
-    auto f_tree_1 = mrcpp::FunctionTree<D>(MRA);
-    auto f_tree_2 = mrcpp::FunctionTree<D>(MRA);
-    auto f_tree_3 = mrcpp::FunctionTree<D>(MRA);
-    auto g_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::FunctionTree<D> f_tree_1(MRA);
+    mrcpp::FunctionTree<D> f_tree_2(MRA);
+    mrcpp::FunctionTree<D> f_tree_3(MRA);
+    mrcpp::FunctionTree<D> g_tree(MRA);
 
     // Projecting functions
     mrcpp::project(prec, f_tree_1, f_func_1);

--- a/examples/derivative.cpp
+++ b/examples/derivative.cpp
@@ -44,11 +44,11 @@ int main(int argc, char **argv) {
     };
 
     // Initializing MW functions and operators
-    auto D_00 = mrcpp::ABGVOperator<D>(MRA, 0.0, 0.0);
-    auto f_tree = mrcpp::FunctionTree<D>(MRA);
-    auto df_tree = mrcpp::FunctionTree<D>(MRA);
-    auto dg_tree = mrcpp::FunctionTree<D>(MRA);
-    auto err_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::ABGVOperator<D> D_00(MRA, 0.0, 0.0);
+    mrcpp::FunctionTree<D> f_tree(MRA);
+    mrcpp::FunctionTree<D> df_tree(MRA);
+    mrcpp::FunctionTree<D> dg_tree(MRA);
+    mrcpp::FunctionTree<D> err_tree(MRA);
 
     // Projecting functions
     mrcpp::project<D>(prec, f_tree, f);

--- a/examples/mpi_send_tree.cpp
+++ b/examples/mpi_send_tree.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     };
 
     // All ranks define the function
-    auto f_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::FunctionTree<D> f_tree(MRA);
 
     // Only rank 0 projects the function
     if (wrank == 0) mrcpp::project<D>(prec, f_tree, f);

--- a/examples/mpi_shared_tree.cpp
+++ b/examples/mpi_shared_tree.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
 
     // Initialize a shared memory tree, max 100MB
     auto shared_mem = new mrcpp::SharedMemory(scomm, 100);
-    auto f_tree = mrcpp::FunctionTree<D>(MRA, shared_mem);
+    mrcpp::FunctionTree<D> f_tree(MRA, shared_mem);
 
     // Only first rank projects
     auto frank = 0;

--- a/examples/multiplication.cpp
+++ b/examples/multiplication.cpp
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
     auto g_func = mrcpp::GaussFunc<D>(beta, alpha, g_pos, power);
 
     // Initialize MW functions
-    auto f_tree = mrcpp::FunctionTree<D>(MRA);
-    auto g_tree = mrcpp::FunctionTree<D>(MRA);
-    auto h_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::FunctionTree<D> f_tree(MRA);
+    mrcpp::FunctionTree<D> g_tree(MRA);
+    mrcpp::FunctionTree<D> h_tree(MRA);
 
     // Projecting f and g
     mrcpp::project<D>(prec, f_tree, f_func);

--- a/examples/poisson.cpp
+++ b/examples/poisson.cpp
@@ -40,9 +40,9 @@ int main(int argc, char **argv) {
     auto ana_energy = f_func.calcCoulombEnergy(f_func);
 
     // Initializing MW functions and operator
-    auto P = mrcpp::PoissonOperator(MRA, prec);
-    auto f_tree = mrcpp::FunctionTree<D>(MRA);
-    auto g_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::PoissonOperator P(MRA, prec);
+    mrcpp::FunctionTree<D> f_tree(MRA);
+    mrcpp::FunctionTree<D> g_tree(MRA);
 
     // Projecting function
     mrcpp::build_grid(f_tree, f_func);

--- a/examples/projection.cpp
+++ b/examples/projection.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     };
 
     // Projecting function
-    auto f_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::FunctionTree<D> f_tree(MRA);
     mrcpp::project<D>(prec, f_tree, f, -1);
 
     auto integral = f_tree.integrate();

--- a/examples/scf.cpp
+++ b/examples/scf.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
 
     // Nuclear potential
     auto Z = 1.0;
-    auto V = FunctionTree<D>(MRA);
+    FunctionTree<D> V(MRA);
     setupNuclearPotential(Z, V);
 
     // Wave function
@@ -103,10 +103,10 @@ int main(int argc, char **argv) {
         // Initialize Helmholtz operator
         if (epsilon_n > 0.0) epsilon_n *= -1.0;
         auto mu_n = std::sqrt(-2.0*epsilon_n);
-        auto H = HelmholtzOperator(MRA, mu_n, prec);
+        HelmholtzOperator H(MRA, mu_n, prec);
 
         // Compute Helmholtz argument V*phi
-        auto Vphi = FunctionTree<D>(MRA);
+        FunctionTree<D> Vphi(MRA);
         copy_grid(Vphi, *phi_n); // Copy grid from orbital
         multiply(prec, Vphi, 1.0, V, *phi_n, 1); // Relax grid max one level
 
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
         phi_np1->rescale(-1.0/(2.0*mrcpp::pi));
 
         // Compute orbital residual
-        auto d_phi_n = FunctionTree<D>(MRA);
+        FunctionTree<D> d_phi_n(MRA);
         copy_grid(d_phi_n, *phi_np1); // Copy grid from phi_np1
         add(-1.0, d_phi_n, 1.0, *phi_np1, -1.0, *phi_n); // No grid relaxation
         error = std::sqrt(d_phi_n.getSquareNorm());
@@ -159,7 +159,6 @@ int main(int argc, char **argv) {
     Printer::printHeader(0, "Final energy");
     Printer::printDouble(0, "Eigenvalue", epsilon_n);
     Printer::printSeparator(0, '=', 2);
-
 
     return 0;
 }

--- a/examples/tree_cleaner.cpp
+++ b/examples/tree_cleaner.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     };
 
     // Initializing MW function
-    auto f_tree = mrcpp::FunctionTree<D>(MRA);
+    mrcpp::FunctionTree<D> f_tree(MRA);
 
     auto iter = 0;
     auto n_nodes = 1;

--- a/src/core/CrossCorrelation.h
+++ b/src/core/CrossCorrelation.h
@@ -7,12 +7,10 @@
 
 namespace mrcpp {
 
-class CrossCorrelation {
+class CrossCorrelation final {
 public:
     CrossCorrelation(int k, int t, const std::string &lib = "");
-    CrossCorrelation(int t, const Eigen::MatrixXd &ldata,
-                            const Eigen::MatrixXd &rdata);
-    virtual ~CrossCorrelation() { }
+    CrossCorrelation(int t, const Eigen::MatrixXd &ldata, const Eigen::MatrixXd &rdata);
 
     int getType() const { return this->type; }
     int getOrder() const { return this->order; }

--- a/src/core/CrossCorrelationCache.h
+++ b/src/core/CrossCorrelationCache.h
@@ -12,14 +12,14 @@ namespace mrcpp {
     CrossCorrelationCache<T> &X = CrossCorrelationCache<T>::getInstance()
 
 template <int T>
-class CrossCorrelationCache: public ObjectCache<CrossCorrelation> {
+class CrossCorrelationCache final : public ObjectCache<CrossCorrelation> {
 public:
     static CrossCorrelationCache<T> &getInstance() {
         static CrossCorrelationCache<T> theCrossCorrelationCache;
         return theCrossCorrelationCache;
     }
-    virtual void load(int order);
-    virtual CrossCorrelation &get(int order);
+    void load(int order);
+    CrossCorrelation &get(int order);
 
     const Eigen::MatrixXd &getLMatrix(int order);
     const Eigen::MatrixXd &getRMatrix(int order);
@@ -33,7 +33,6 @@ protected:
     std::string libPath; ///< Base path to filter library
 private:
     CrossCorrelationCache();
-    virtual ~CrossCorrelationCache() { }
     CrossCorrelationCache(CrossCorrelationCache<T> const &ccc) { }
     CrossCorrelationCache<T> &operator=(CrossCorrelationCache<T> const &ccc) { return *this; }
 };

--- a/src/core/FilterCache.h
+++ b/src/core/FilterCache.h
@@ -30,7 +30,7 @@ namespace mrcpp {
 /** This class is an abstract base class for the various filter caches.
  * It's needed in order to be able to use the actual filter caches
  * without reference to the actual filter types */
-class BaseFilterCache: public ObjectCache<MWFilter> {
+class BaseFilterCache : public ObjectCache<MWFilter> {
 public:
     virtual void load(int order) = 0;
     virtual MWFilter &get(int order) = 0;
@@ -40,25 +40,24 @@ public:
 };
 
 template <int T>
-class FilterCache: public BaseFilterCache {
+class FilterCache final : public BaseFilterCache {
 public:
     static FilterCache &getInstance() {
         static FilterCache theFilterCache;
         return theFilterCache;
     }
 
-    virtual void load(int order);
-    virtual MWFilter &get(int order);
-    virtual const Eigen::MatrixXd &getFilterMatrix(int order);
+    void load(int order);
+    MWFilter &get(int order);
+    const Eigen::MatrixXd &getFilterMatrix(int order);
 
-    virtual const std::string &getLibPath() { return this->libPath; }
-    virtual void setLibPath(const std::string &path) { this->libPath = path; }
+    const std::string &getLibPath() { return this->libPath; }
+    void setLibPath(const std::string &path) { this->libPath = path; }
 protected:
     int type;
     std::string libPath; ///< Base path to filter library
 private:
     FilterCache();
-    virtual ~FilterCache() { }
     FilterCache(FilterCache<T> const &fc) { }
     FilterCache &operator=(FilterCache<T> const &fc) { return *this; }
 };

--- a/src/core/GaussQuadrature.h
+++ b/src/core/GaussQuadrature.h
@@ -12,10 +12,9 @@ static const double EPS = 3.0e-12;
 static const int NewtonMaxIter = 10;
 static const int MaxQuadratureDim = 7;
 
-class GaussQuadrature {
+class GaussQuadrature final {
 public:
     GaussQuadrature(int k, double a = -1.0, double b = 1.0, int inter = 1);
-    virtual ~GaussQuadrature() { }
 
     double integrate(RepresentableFunction<1> &func) const;
     double integrate(RepresentableFunction<2> &func) const;

--- a/src/core/InterpolatingBasis.h
+++ b/src/core/InterpolatingBasis.h
@@ -4,14 +4,13 @@
 
 namespace mrcpp {
 
-class InterpolatingBasis : public ScalingBasis {
+class InterpolatingBasis final : public ScalingBasis {
 public:
     InterpolatingBasis(int k) : ScalingBasis(k, Interpol) {
         initScalingBasis();
         calcQuadratureValues();
         calcCVMaps();
     }
-    virtual ~InterpolatingBasis() { }
 
     void initScalingBasis();
     void calcQuadratureValues();

--- a/src/core/LegendreBasis.h
+++ b/src/core/LegendreBasis.h
@@ -7,14 +7,13 @@
 
 namespace mrcpp {
 
-class LegendreBasis : public ScalingBasis {
+class LegendreBasis final : public ScalingBasis {
 public:
     LegendreBasis(int k) : ScalingBasis(k, Legendre) {
         initScalingBasis();
         calcQuadratureValues();
         calcCVMaps();
     }
-    virtual ~LegendreBasis() { }
 
     void initScalingBasis();
     void calcQuadratureValues();

--- a/src/core/MWFilter.h
+++ b/src/core/MWFilter.h
@@ -10,16 +10,15 @@ namespace mrcpp {
 typedef Eigen::Block<Eigen::MatrixXd, Eigen::Dynamic, Eigen::Dynamic>
 FilterBlock;
 
-class MWFilter {
+class MWFilter final {
 public:
     MWFilter(int k, int t, const std::string &lib = "");
     MWFilter(int t, const Eigen::MatrixXd &data);
-    virtual ~MWFilter() { }
 
-    virtual void apply(Eigen::MatrixXd &data) const;
-    virtual void apply(Eigen::VectorXd &data) const;
-    virtual void applyInverse(Eigen::MatrixXd &data) const;
-    virtual void applyInverse(Eigen::VectorXd &data) const;
+    void apply(Eigen::MatrixXd &data) const;
+    void apply(Eigen::VectorXd &data) const;
+    void applyInverse(Eigen::MatrixXd &data) const;
+    void applyInverse(Eigen::VectorXd &data) const;
 
     int getOrder() const { return this->order; }
     int getType() const { return this->type; }

--- a/src/core/QuadratureCache.h
+++ b/src/core/QuadratureCache.h
@@ -10,7 +10,7 @@ namespace mrcpp {
 
 #define getQuadratureCache(X) QuadratureCache &X=QuadratureCache::getInstance()
 
-class QuadratureCache: public ObjectCache<GaussQuadrature> {
+class QuadratureCache final : public ObjectCache<GaussQuadrature> {
 public:
     static QuadratureCache &getInstance() {
         static QuadratureCache theQuadratureCache;
@@ -35,7 +35,7 @@ private:
     int intervals;
 
     QuadratureCache();
-    virtual ~QuadratureCache();
+    ~QuadratureCache();
 
     QuadratureCache(QuadratureCache const &qc) : ObjectCache<GaussQuadrature>(qc) { }
     QuadratureCache &operator=(QuadratureCache const&) { return *this; }

--- a/src/core/ScalingBasis.h
+++ b/src/core/ScalingBasis.h
@@ -11,7 +11,7 @@ namespace mrcpp {
 class ScalingBasis {
 public:
     ScalingBasis(int k, int t);
-    virtual ~ScalingBasis() { }
+    virtual ~ScalingBasis() = default;
 
     void evalf(const double *r, Eigen::MatrixXd &vals) const;
 

--- a/src/core/ScalingCache.h
+++ b/src/core/ScalingCache.h
@@ -12,13 +12,13 @@ namespace mrcpp {
     ScalingCache<InterpolatingBasis>::getInstance()
 
 template<class P>
-class ScalingCache: public ObjectCache<P> {
+class ScalingCache final : public ObjectCache<P> {
 public:
     static ScalingCache &getInstance() {
         static ScalingCache theScalingCache;
         return theScalingCache;
     }
-    virtual void load(int order) {
+    void load(int order) {
         SET_CACHE_LOCK();
         if (not this->hasId(order)) {
             P *f = new P(order);
@@ -36,7 +36,6 @@ public:
     }
 private:
     ScalingCache() { }
-    virtual ~ScalingCache() { }
     ScalingCache(const ScalingCache<P> &sc);
     ScalingCache<P> &operator=(const ScalingCache<P> &sc) { return *this;	}
 };

--- a/src/functions/AnalyticFunction.h
+++ b/src/functions/AnalyticFunction.h
@@ -9,12 +9,13 @@ namespace mrcpp {
 template<int D>
 class AnalyticFunction : public RepresentableFunction<D> {
 public:
-    AnalyticFunction() { }
+    AnalyticFunction() = default;
+    virtual ~AnalyticFunction() = default;
+
     AnalyticFunction(std::function<double (const Coord<D> &r)> f,
                      const double *a = nullptr,
                      const double *b = nullptr)
         : RepresentableFunction<D>(a, b), func(f) { }
-    virtual ~AnalyticFunction() { }
 
     void set(std::function<double (const Coord<D> &r)> f) { this->func = f; }
 

--- a/src/functions/BoysFunction.h
+++ b/src/functions/BoysFunction.h
@@ -5,10 +5,9 @@
 
 namespace mrcpp {
 
-class BoysFunction : public RepresentableFunction<1> {
+class BoysFunction final : public RepresentableFunction<1> {
 public:
     BoysFunction(int n, double prec = 1.0e-10);
-    virtual ~BoysFunction() { }
 
     double evalf(const Coord<1> &r) const;
 

--- a/src/functions/GaussFunc.h
+++ b/src/functions/GaussFunc.h
@@ -24,7 +24,7 @@
 namespace mrcpp {
 
 template<int D>
-class GaussFunc: public Gaussian<D> {
+class GaussFunc final : public Gaussian<D> {
 public:
     GaussFunc(double alpha = 0.0, double coef = 1.0, const double pos[D] = nullptr, const int pow[D] = nullptr)
         : Gaussian<D>(alpha, coef, pos, pow) {}
@@ -32,7 +32,6 @@ public:
         : Gaussian<D>(alpha, coef, pos, pow) {}
     GaussFunc(const GaussFunc<D> &gf) : Gaussian<D>(gf) {}
     Gaussian<D> *copy() const;
-    ~GaussFunc() { }
 
     double calcCoulombEnergy(GaussFunc<D> &gf);
     double calcSquareNorm();
@@ -64,8 +63,7 @@ public:
         this->squareNorm = -1.0;
     }
 protected:
-    static double ObaraSaika_ab(int power_a, int power_b, double pos_a,
-            double pos_b, double expo_a, double expo_b);
+    static double ObaraSaika_ab(int power_a, int power_b, double pos_a, double pos_b, double expo_a, double expo_b);
 
     std::ostream& print(std::ostream &o) const;
 };

--- a/src/functions/GaussPoly.h
+++ b/src/functions/GaussPoly.h
@@ -20,10 +20,9 @@
 namespace mrcpp {
 
 template<int D>
-class GaussPoly : public Gaussian<D> {
+class GaussPoly final : public Gaussian<D> {
 public:
-    GaussPoly(double alpha = 0.0, double coef = 1.0, const double pos[D] = nullptr,
-        const int pow[D] = nullptr);
+    GaussPoly(double alpha = 0.0, double coef = 1.0, const double pos[D] = nullptr, const int pow[D] = nullptr);
     GaussPoly(const GaussPoly<D> &gp);
     GaussPoly(const GaussFunc<D> &gf);
     Gaussian<D> *copy() const;
@@ -55,8 +54,7 @@ public:
     void setPower(const int pow[D]);
     void setPoly(int d, Polynomial &poly);
 
-    void fillCoefPowVector(std::vector<double> &coefs, std::vector<int *> &power,
-        int pow[D], int dir) const;
+    void fillCoefPowVector(std::vector<double> &coefs, std::vector<int *> &power, int pow[D], int dir) const;
 
 private:
     Polynomial *poly[D];

--- a/src/functions/LegendrePoly.h
+++ b/src/functions/LegendrePoly.h
@@ -4,10 +4,9 @@
 
 namespace mrcpp {
 
-class LegendrePoly: public Polynomial {
+class LegendrePoly final : public Polynomial {
 public:
     LegendrePoly(int k, double n = 1.0, double l = 0.0);
-    virtual ~LegendrePoly() { }
 
     Eigen::Vector2d firstDerivative(double x) const;
     Eigen::Vector3d secondDerivative(double x) const;

--- a/src/functions/Polynomial.h
+++ b/src/functions/Polynomial.h
@@ -20,12 +20,12 @@ namespace mrcpp {
 
 class Polynomial: public RepresentableFunction<1> {
 public:
-    Polynomial(int k = 0, const double *a = 0, const double *b = 0);
-    Polynomial(const Eigen::VectorXd &c, const double *a=0, const double *b=0);
-    Polynomial(double c, int k = 0, const double *a=0, const double *b=0);
+    Polynomial(int k = 0, const double *a = nullptr, const double *b = nullptr);
+    Polynomial(const Eigen::VectorXd &c, const double *a = nullptr, const double *b = nullptr);
+    Polynomial(double c, int k = 0, const double *a = nullptr, const double *b = nullptr);
     Polynomial(const Polynomial &poly);
     Polynomial &operator=(const Polynomial &poly);
-    virtual ~Polynomial() { }
+    virtual ~Polynomial() = default;
 
     double evalf(double x) const;
     double evalf(const Coord<1> &r) const { return evalf(r[0]); }

--- a/src/operators/ABGVOperator.h
+++ b/src/operators/ABGVOperator.h
@@ -5,10 +5,9 @@
 namespace mrcpp {
 
 template<int D>
-class ABGVOperator : public DerivativeOperator<D> {
+class ABGVOperator final : public DerivativeOperator<D> {
 public:
     ABGVOperator(const MultiResolutionAnalysis<D> &mra, double a, double b);
-    virtual ~ABGVOperator() { }
 
 protected:
     void initializeOperator(double a, double b);

--- a/src/operators/ABGVOperator.h
+++ b/src/operators/ABGVOperator.h
@@ -8,6 +8,8 @@ template<int D>
 class ABGVOperator final : public DerivativeOperator<D> {
 public:
     ABGVOperator(const MultiResolutionAnalysis<D> &mra, double a, double b);
+    ABGVOperator(const ABGVOperator &oper) = delete;
+    ABGVOperator &operator=(const ABGVOperator &oper) = delete;
 
 protected:
     void initializeOperator(double a, double b);

--- a/src/operators/ConvolutionOperator.h
+++ b/src/operators/ConvolutionOperator.h
@@ -9,6 +9,8 @@ template<int D>
 class ConvolutionOperator : public MWOperator {
 public:
     ConvolutionOperator(const MultiResolutionAnalysis<D> &mra, double pr);
+    ConvolutionOperator(const ConvolutionOperator &oper) = delete;
+    ConvolutionOperator &operator=(const ConvolutionOperator &oper) = delete;
     virtual ~ConvolutionOperator();
 
 protected:

--- a/src/operators/DerivativeConvolution.h
+++ b/src/operators/DerivativeConvolution.h
@@ -15,6 +15,8 @@ public:
         this->initializeOperator(derivative_kernel);
         this->setApplyDir(d);
     }
+    DerivativeConvolution(const DerivativeConvolution &oper) = delete;
+    DerivativeConvolution &operator=(const DerivativeConvolution &oper) = delete;
 };
 
 }

--- a/src/operators/DerivativeConvolution.h
+++ b/src/operators/DerivativeConvolution.h
@@ -6,19 +6,15 @@
 namespace mrcpp {
 
 template<int D>
-class DerivativeConvolution : public ConvolutionOperator<D> {
+class DerivativeConvolution final : public ConvolutionOperator<D> {
 public:
-    DerivativeConvolution(int d,
-                          const MultiResolutionAnalysis<D> &mra,
-                          double apply = -1.0,
-                          double build = -1.0)
+    DerivativeConvolution(int d, const MultiResolutionAnalysis<D> &mra, double apply = -1.0, double build = -1.0)
             : ConvolutionOperator<D>(mra, apply, build) {
         double epsilon = this->build_prec/10.0;
         DerivativeKernel derivative_kernel(epsilon);
         this->initializeOperator(derivative_kernel);
         this->setApplyDir(d);
     }
-    virtual ~DerivativeConvolution() { }
 };
 
 }

--- a/src/operators/DerivativeKernel.h
+++ b/src/operators/DerivativeKernel.h
@@ -12,6 +12,8 @@ public:
             : GreensKernel(eps, -1.0, -1.0) {
         initializeKernel();
     }
+    DerivativeKernel(const DerivativeKernel &kern) = delete;
+    DerivativeKernel &operator=(const DerivativeKernel &kern) = delete;
 
 protected:
     void initializeKernel() {

--- a/src/operators/DerivativeKernel.h
+++ b/src/operators/DerivativeKernel.h
@@ -6,15 +6,15 @@
 
 namespace mrcpp {
 
-class DerivativeKernel : public GreensKernel {
+class DerivativeKernel final : public GreensKernel {
 public:
     DerivativeKernel(double eps)
             : GreensKernel(eps, -1.0, -1.0) {
         initializeKernel();
     }
-    virtual ~DerivativeKernel() { }
+
 protected:
-    virtual void initializeKernel() {
+    void initializeKernel() {
         double alpha = 1.0/this->epsilon;
         double coef = std::pow(alpha/mrcpp::pi, 1.0/2.0);
         GaussFunc<1> g(alpha, coef);
@@ -22,7 +22,7 @@ protected:
         this->append(dg);
     }
 
-    virtual std::ostream& print(std::ostream &o) const {
+    std::ostream& print(std::ostream &o) const {
         o << " DerivativeKernel: " << std::endl;
         o << " epsilon:  " << this->epsilon << std::endl;
         return o;

--- a/src/operators/DerivativeOperator.h
+++ b/src/operators/DerivativeOperator.h
@@ -9,6 +9,8 @@ class DerivativeOperator : public MWOperator {
 public:
     DerivativeOperator(const MultiResolutionAnalysis<D> &mra) 
             : MWOperator(mra.getOperatorMRA()) { }
+    DerivativeOperator(const DerivativeOperator &oper) = delete;
+    DerivativeOperator &operator=(const DerivativeOperator &oper) = delete;
     virtual ~DerivativeOperator() = default;
 };
 

--- a/src/operators/DerivativeOperator.h
+++ b/src/operators/DerivativeOperator.h
@@ -9,7 +9,7 @@ class DerivativeOperator : public MWOperator {
 public:
     DerivativeOperator(const MultiResolutionAnalysis<D> &mra) 
             : MWOperator(mra.getOperatorMRA()) { }
-    virtual ~DerivativeOperator() { }
+    virtual ~DerivativeOperator() = default;
 };
 
 }

--- a/src/operators/GreensKernel.h
+++ b/src/operators/GreensKernel.h
@@ -17,7 +17,8 @@ public:
           rMin(r_min),
           rMax(r_max) {
     }
-
+    GreensKernel(const GreensKernel &kern) = delete;
+    GreensKernel &operator=(const GreensKernel &kern) = delete;
     virtual ~GreensKernel() = default;
 
     double getEpsilon() const { return this->epsilon; }

--- a/src/operators/GreensKernel.h
+++ b/src/operators/GreensKernel.h
@@ -18,7 +18,7 @@ public:
           rMax(r_max) {
     }
 
-    virtual ~GreensKernel() { }
+    virtual ~GreensKernel() = default;
 
     double getEpsilon() const { return this->epsilon; }
     double getRMin() const { return this->rMin; }

--- a/src/operators/HelmholtzKernel.h
+++ b/src/operators/HelmholtzKernel.h
@@ -11,6 +11,8 @@ public:
               mu(m) {
         initializeKernel();
     }
+    HelmholtzKernel(const HelmholtzKernel &kern) = delete;
+    HelmholtzKernel &operator=(const HelmholtzKernel &kern) = delete;
 
 protected:
     const double mu; /**< exponent */

--- a/src/operators/HelmholtzKernel.h
+++ b/src/operators/HelmholtzKernel.h
@@ -4,18 +4,18 @@
 
 namespace mrcpp {
 
-class HelmholtzKernel: public GreensKernel {
+class HelmholtzKernel final : public GreensKernel {
 public:
     HelmholtzKernel(double m, double eps, double r_min, double r_max)
             : GreensKernel(eps, r_min, r_max),
               mu(m) {
         initializeKernel();
     }
-    virtual ~HelmholtzKernel() { }
+
 protected:
     const double mu; /**< exponent */
-    virtual void initializeKernel();
-    virtual std::ostream& print(std::ostream &o) const;
+    void initializeKernel();
+    std::ostream& print(std::ostream &o) const;
 };
 
 }

--- a/src/operators/HelmholtzOperator.h
+++ b/src/operators/HelmholtzOperator.h
@@ -7,6 +7,8 @@ namespace mrcpp {
 class HelmholtzOperator final : public ConvolutionOperator<3> {
 public:
     HelmholtzOperator(const MultiResolutionAnalysis<3> &mra, double m, double pr = -1.0);
+    HelmholtzOperator(const HelmholtzOperator &oper) = delete;
+    HelmholtzOperator &operator=(const HelmholtzOperator &oper) = delete;
 
     double getMu() const { return this->mu; }
 protected:

--- a/src/operators/HelmholtzOperator.h
+++ b/src/operators/HelmholtzOperator.h
@@ -4,10 +4,9 @@
 
 namespace mrcpp {
 
-class HelmholtzOperator : public ConvolutionOperator<3> {
+class HelmholtzOperator final : public ConvolutionOperator<3> {
 public:
     HelmholtzOperator(const MultiResolutionAnalysis<3> &mra, double m, double pr = -1.0);
-    virtual ~HelmholtzOperator() { }
 
     double getMu() const { return this->mu; }
 protected:

--- a/src/operators/IdentityConvolution.h
+++ b/src/operators/IdentityConvolution.h
@@ -14,6 +14,8 @@ public:
         IdentityKernel identity_kernel(epsilon);
         this->initializeOperator(identity_kernel);
     }
+    IdentityConvolution(const IdentityConvolution &oper) = delete;
+    IdentityConvolution &operator=(const IdentityConvolution &oper) = delete;
 };
 
 }

--- a/src/operators/IdentityConvolution.h
+++ b/src/operators/IdentityConvolution.h
@@ -6,7 +6,7 @@
 namespace mrcpp {
 
 template<int D>
-class IdentityConvolution : public ConvolutionOperator<D> {
+class IdentityConvolution final : public ConvolutionOperator<D> {
 public:
     IdentityConvolution(const MultiResolutionAnalysis<D> &mra, double pr = -1.0)
             : ConvolutionOperator<D>(mra, pr) {
@@ -14,7 +14,6 @@ public:
         IdentityKernel identity_kernel(epsilon);
         this->initializeOperator(identity_kernel);
     }
-    virtual ~IdentityConvolution() { }
 };
 
 }

--- a/src/operators/IdentityKernel.h
+++ b/src/operators/IdentityKernel.h
@@ -5,21 +5,21 @@
 
 namespace mrcpp {
 
-class IdentityKernel : public GreensKernel {
+class IdentityKernel final : public GreensKernel {
 public:
     IdentityKernel(double eps)
             : GreensKernel(eps, -1.0, -1.0) {
         initializeKernel();
     }
-    virtual ~IdentityKernel() { }
+
 protected:
-    virtual void initializeKernel() {
+    void initializeKernel() {
         double alpha = std::sqrt(1.0/this->epsilon);
         double coef = std::pow(alpha/mrcpp::pi, 1.0/2.0);
         GaussFunc<1> gFunc(alpha, coef);
         this->append(gFunc);
     }
-    virtual std::ostream& print(std::ostream &o) const {
+    std::ostream& print(std::ostream &o) const {
         o << "Kernel: " << std::endl;
         o << "epsilon:  " << this->epsilon << std::endl;
         o << "rMin:     " << this->rMin << std::endl;

--- a/src/operators/IdentityKernel.h
+++ b/src/operators/IdentityKernel.h
@@ -11,6 +11,8 @@ public:
             : GreensKernel(eps, -1.0, -1.0) {
         initializeKernel();
     }
+    IdentityKernel(const IdentityKernel &kern) = delete;
+    IdentityKernel &operator=(const IdentityKernel &kern) = delete;
 
 protected:
     void initializeKernel() {

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -9,7 +9,9 @@ namespace mrcpp {
 
 class MWOperator {
 public:
-    MWOperator(MultiResolutionAnalysis<2> mra) : oper_mra(mra) { }
+    MWOperator(const MultiResolutionAnalysis<2> &mra) : oper_mra(mra) { }
+    MWOperator(const MWOperator &oper) = delete;
+    MWOperator &operator=(const MWOperator &oper) = delete;
     virtual ~MWOperator() { this->clear(true); }
 
     int size() const { return this->oper_exp.size(); }

--- a/src/operators/OperatorState.h
+++ b/src/operators/OperatorState.h
@@ -17,7 +17,7 @@ namespace mrcpp {
 #define GET_OP_IDX(FT,GT,ID) (2 * ((GT >> ID) & 1) + ((FT >> ID) & 1))
 
 template<int D>
-class OperatorState {
+class OperatorState final {
 public:
     OperatorState(MWNode<D> &gn, double *scr1) : gNode(&gn) {
         this->kp1 = this->gNode->getKp1();

--- a/src/operators/OperatorStatistics.h
+++ b/src/operators/OperatorStatistics.h
@@ -9,10 +9,10 @@
 namespace mrcpp {
 
 template<int D>
-class OperatorStatistics {
+class OperatorStatistics final {
 public:
     OperatorStatistics();
-    virtual ~OperatorStatistics();
+    ~OperatorStatistics();
 
     void flushNodeCounters();
     void incrementFNodeCounters(const MWNode<D> &fNode, int ft, int gt);

--- a/src/operators/PHOperator.h
+++ b/src/operators/PHOperator.h
@@ -5,10 +5,9 @@
 namespace mrcpp {
 
 template<int D>
-class PHOperator : public DerivativeOperator<D> {
+class PHOperator final : public DerivativeOperator<D> {
 public:
     PHOperator(const MultiResolutionAnalysis<D> &mra, int order);
-    virtual ~PHOperator() { }
 
 protected:
     void initializeOperator(int order);

--- a/src/operators/PHOperator.h
+++ b/src/operators/PHOperator.h
@@ -8,6 +8,8 @@ template<int D>
 class PHOperator final : public DerivativeOperator<D> {
 public:
     PHOperator(const MultiResolutionAnalysis<D> &mra, int order);
+    PHOperator(const PHOperator &oper) = delete;
+    PHOperator &operator=(const PHOperator &oper) = delete;
 
 protected:
     void initializeOperator(int order);

--- a/src/operators/PoissonKernel.h
+++ b/src/operators/PoissonKernel.h
@@ -4,16 +4,16 @@
 
 namespace mrcpp {
 
-class PoissonKernel: public GreensKernel {
+class PoissonKernel final : public GreensKernel {
 public:
     PoissonKernel(double eps, double r_min, double r_max)
             : GreensKernel(eps, r_min, r_max) {
         initializeKernel();
     }
-    virtual ~PoissonKernel() { }
+
 protected:
-    virtual void initializeKernel();
-    virtual std::ostream& print(std::ostream &o) const;
+    void initializeKernel();
+    std::ostream& print(std::ostream &o) const;
 };
 
 }

--- a/src/operators/PoissonKernel.h
+++ b/src/operators/PoissonKernel.h
@@ -10,6 +10,8 @@ public:
             : GreensKernel(eps, r_min, r_max) {
         initializeKernel();
     }
+    PoissonKernel(const PoissonKernel &kern) = delete;
+    PoissonKernel &operator=(const PoissonKernel &kern) = delete;
 
 protected:
     void initializeKernel();

--- a/src/operators/PoissonOperator.h
+++ b/src/operators/PoissonOperator.h
@@ -4,10 +4,9 @@
 
 namespace mrcpp {
 
-class PoissonOperator : public ConvolutionOperator<3> {
+class PoissonOperator final : public ConvolutionOperator<3> {
 public:
     PoissonOperator(const MultiResolutionAnalysis<3> &mra, double pr = -1.0);
-    virtual ~PoissonOperator() { }
 };
 
 }

--- a/src/operators/PoissonOperator.h
+++ b/src/operators/PoissonOperator.h
@@ -7,6 +7,8 @@ namespace mrcpp {
 class PoissonOperator final : public ConvolutionOperator<3> {
 public:
     PoissonOperator(const MultiResolutionAnalysis<3> &mra, double pr = -1.0);
+    PoissonOperator(const PoissonOperator &oper) = delete;
+    PoissonOperator &operator=(const PoissonOperator &oper) = delete;
 };
 
 }

--- a/src/treebuilders/ABGVCalculator.h
+++ b/src/treebuilders/ABGVCalculator.h
@@ -15,7 +15,7 @@ protected:
     Eigen::VectorXd valueZero;
     Eigen::VectorXd valueOne;
 
-    virtual void calcNode(MWNode<2> &node);
+    void calcNode(MWNode<2> &node);
 
     void calcKMatrix(const ScalingBasis &basis);
     void calcValueVectors(const ScalingBasis &basis);

--- a/src/treebuilders/AdditionCalculator.h
+++ b/src/treebuilders/AdditionCalculator.h
@@ -13,7 +13,7 @@ public:
 protected:
     FunctionTreeVector<D> sum_vec;
 
-    virtual void calcNode(MWNode<D> &node_o) {
+    void calcNode(MWNode<D> &node_o) {
         node_o.zeroCoefs();
         const NodeIndex<D> &idx = node_o.getNodeIndex();
         double *coefs_o = node_o.getCoefs();

--- a/src/treebuilders/AnalyticAdaptor.h
+++ b/src/treebuilders/AnalyticAdaptor.h
@@ -6,17 +6,14 @@
 namespace mrcpp {
 
 template<int D>
-class AnalyticAdaptor : public TreeAdaptor<D> {
+class AnalyticAdaptor final : public TreeAdaptor<D> {
 public:
-    AnalyticAdaptor(const RepresentableFunction<D> &f, int ms)
-            : TreeAdaptor<D>(ms),
-              func(&f) { }
-    virtual ~AnalyticAdaptor() { }
+    AnalyticAdaptor(const RepresentableFunction<D> &f, int ms) : TreeAdaptor<D>(ms), func(&f) { }
 
 protected:
     const RepresentableFunction<D> *func;
 
-    virtual bool splitNode(const MWNode<D> &node) const {
+    bool splitNode(const MWNode<D> &node) const {
         int scale = node.getScale();
         int nQuadPts = node.getKp1();
         if (this->func->isVisibleAtScale(scale, nQuadPts)) {

--- a/src/treebuilders/BandWidthAdaptor.h
+++ b/src/treebuilders/BandWidthAdaptor.h
@@ -9,17 +9,14 @@
 
 namespace mrcpp {
 
-class BandWidthAdaptor : public TreeAdaptor<2> {
+class BandWidthAdaptor final : public TreeAdaptor<2> {
 public:
-    BandWidthAdaptor(int bw, int ms)
-            : TreeAdaptor<2>(ms),
-              bandWidth(bw) { }
-    virtual ~BandWidthAdaptor() { }
+    BandWidthAdaptor(int bw, int ms) : TreeAdaptor<2>(ms), bandWidth(bw) { }
 
 protected:
     const int bandWidth;
 
-    virtual bool splitNode(const MWNode<2> &node) const {
+    bool splitNode(const MWNode<2> &node) const {
         const NodeIndex<2> &idx = node.getNodeIndex();
         int lx = idx.getTranslation(0);
         int ly = idx.getTranslation(1);

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -10,13 +10,10 @@ namespace mrcpp {
 template<int D>
 class ConvolutionCalculator final : public TreeCalculator<D> {
 public:
-    ConvolutionCalculator(double p,
-                          ConvolutionOperator<D> &o,
-                          FunctionTree<D> &f,
-                          int depth = MaxDepth);
-    virtual ~ConvolutionCalculator();
+    ConvolutionCalculator(double p, ConvolutionOperator<D> &o, FunctionTree<D> &f, int depth = MaxDepth);
+    ~ConvolutionCalculator();
 
-    virtual MWNodeVector<D>* getInitialWorkVector(MWTree<D> &tree) const;
+    MWNodeVector<D>* getInitialWorkVector(MWTree<D> &tree) const;
 
 protected:
     int maxDepth;
@@ -44,8 +41,8 @@ protected:
     int getBandSizeFactor(int i, int depth,const OperatorState<D> &os) const;
     void calcBandSizeFactor(Eigen::MatrixXi &bs, int depth, const BandWidth &bw);
 
-    virtual void calcNode(MWNode<D> &node);
-    virtual void postProcess() {
+    void calcNode(MWNode<D> &node);
+    void postProcess() {
         printTimers();
         clearTimers();
         initTimers();

--- a/src/treebuilders/CrossCorrelationCalculator.h
+++ b/src/treebuilders/CrossCorrelationCalculator.h
@@ -12,7 +12,7 @@ public:
 protected:
     FunctionTree<1> *kernel;
 
-    virtual void calcNode(MWNode<2> &node);
+    void calcNode(MWNode<2> &node);
 
     template<int T>
     void applyCcc(MWNode<2> &node, CrossCorrelationCache<T> &ccc);

--- a/src/treebuilders/DefaultCalculator.h
+++ b/src/treebuilders/DefaultCalculator.h
@@ -5,20 +5,17 @@
 namespace mrcpp {
 
 template<int D>
-class DefaultCalculator :public TreeCalculator<D> {
+class DefaultCalculator final : public TreeCalculator<D> {
 public:
-    DefaultCalculator() { }
-    virtual ~DefaultCalculator() { }
-
     // Reimplementation without OpenMP, the default is faster this way
-    virtual void calcNodeVector(MWNodeVector<D> &nodeVec) {
+    void calcNodeVector(MWNodeVector<D> &nodeVec) {
         int nNodes = nodeVec.size();
         for (int n = 0; n < nNodes; n++) {
             calcNode(*nodeVec[n]);
         }
     }
 protected:
-    virtual void calcNode(MWNode<D> &node) {
+    void calcNode(MWNode<D> &node) {
         node.clearHasCoefs();
         node.clearNorms();
     }

--- a/src/treebuilders/DerivativeCalculator.h
+++ b/src/treebuilders/DerivativeCalculator.h
@@ -9,9 +9,9 @@ template<int D>
 class DerivativeCalculator final : public TreeCalculator<D> {
 public:
     DerivativeCalculator(int dir, DerivativeOperator<D> &o, FunctionTree<D> &f);
-    virtual ~DerivativeCalculator();
+    ~DerivativeCalculator();
 
-    virtual MWNodeVector<D>* getInitialWorkVector(MWTree<D> &tree) const;
+    MWNodeVector<D>* getInitialWorkVector(MWTree<D> &tree) const;
 
 protected:
     int applyDir;
@@ -29,8 +29,8 @@ protected:
     void clearTimers();
     void printTimers() const;
 
-    virtual void calcNode(MWNode<D> &node);
-    virtual void postProcess() {
+    void calcNode(MWNode<D> &node);
+    void postProcess() {
         printTimers();
         clearTimers();
         initTimers();

--- a/src/treebuilders/MultiplicationCalculator.h
+++ b/src/treebuilders/MultiplicationCalculator.h
@@ -13,7 +13,7 @@ public:
 protected:
     FunctionTreeVector<D> prod_vec;
 
-    virtual void calcNode(MWNode<D> &node_o) {
+    void calcNode(MWNode<D> &node_o) {
         const NodeIndex<D> &idx = node_o.getNodeIndex();
         double *coefs_o = node_o.getCoefs();
         for (int j = 0; j < node_o.getNCoefs(); j++) {

--- a/src/treebuilders/OperatorAdaptor.h
+++ b/src/treebuilders/OperatorAdaptor.h
@@ -6,11 +6,10 @@ namespace mrcpp {
 
 class OperatorAdaptor final : public WaveletAdaptor<2> {
 public:
-    OperatorAdaptor(double pr, int ms, bool ap = false)
-            : WaveletAdaptor<2>(pr, ms, ap) { }
+    OperatorAdaptor(double pr, int ms, bool ap = false) : WaveletAdaptor<2>(pr, ms, ap) { }
 
 protected:
-    virtual bool splitNode(const MWNode<2> &node) const {
+    bool splitNode(const MWNode<2> &node) const {
         int chkCompNorm = 0;
         for (int i = 1; i < 4; i++) {
             if (node.getComponentNorm(i) > 0.0) {

--- a/src/treebuilders/PHCalculator.h
+++ b/src/treebuilders/PHCalculator.h
@@ -17,7 +17,7 @@ protected:
     Eigen::MatrixXd S_0;
     Eigen::MatrixXd S_p1;
 
-    virtual void calcNode(MWNode<2> &node);
+    void calcNode(MWNode<2> &node);
     void readSMatrix(const ScalingBasis &basis, char n);
 };
 

--- a/src/treebuilders/PowerCalculator.h
+++ b/src/treebuilders/PowerCalculator.h
@@ -7,14 +7,13 @@ namespace mrcpp {
 template<int D>
 class PowerCalculator final : public TreeCalculator<D> {
 public:
-    PowerCalculator(FunctionTree<D> &inp, double pow)
-        : power(pow), func(&inp) { }
+    PowerCalculator(FunctionTree<D> &inp, double pow) : power(pow), func(&inp) { }
 
 protected:
     double power;
     FunctionTree<D> *func;
 
-    virtual void calcNode(MWNode<D> &node_o) {
+    void calcNode(MWNode<D> &node_o) {
         const NodeIndex<D> &idx = node_o.getNodeIndex();
         int n_coefs = node_o.getNCoefs();
         double *coefs_o = node_o.getCoefs();

--- a/src/treebuilders/ProjectionCalculator.h
+++ b/src/treebuilders/ProjectionCalculator.h
@@ -12,7 +12,7 @@ public:
 protected:
     const RepresentableFunction<D> *func;
 
-    virtual void calcNode(MWNode<D> &node);
+    void calcNode(MWNode<D> &node);
 };
 
 }

--- a/src/treebuilders/SquareCalculator.h
+++ b/src/treebuilders/SquareCalculator.h
@@ -12,7 +12,7 @@ public:
 protected:
     FunctionTree<D> *func;
 
-    virtual void calcNode(MWNode<D> &node_o) {
+    void calcNode(MWNode<D> &node_o) {
         const NodeIndex<D> &idx = node_o.getNodeIndex();
         int n_coefs = node_o.getNCoefs();
         double *coefs_o = node_o.getCoefs();

--- a/src/treebuilders/TreeBuilder.h
+++ b/src/treebuilders/TreeBuilder.h
@@ -5,19 +5,12 @@
 namespace mrcpp {
 
 template<int D>
-class TreeBuilder {
+class TreeBuilder final {
 public:
-    TreeBuilder() { }
-    virtual ~TreeBuilder() { }
-
-    void build(MWTree<D> &tree,
-               TreeCalculator<D> &calculator,
-               TreeAdaptor<D> &adaptor,
-               int maxIter) const;
-
-    int split(MWTree<D> &tree, TreeAdaptor<D> &adaptor, bool passCoefs) const;
-    void calc(MWTree<D> &tree, TreeCalculator<D> &calculator) const;
+    void build(MWTree<D> &tree, TreeCalculator<D> &calculator, TreeAdaptor<D> &adaptor, int maxIter) const;
     void clear(MWTree<D> &tree, TreeCalculator<D> &calculator) const;
+    void calc(MWTree<D> &tree, TreeCalculator<D> &calculator) const;
+    int split(MWTree<D> &tree, TreeAdaptor<D> &adaptor, bool passCoefs) const;
 
 protected:
     double calcScalingNorm(const MWNodeVector<D> &vec) const;

--- a/src/treebuilders/TreeCalculator.h
+++ b/src/treebuilders/TreeCalculator.h
@@ -7,7 +7,7 @@ namespace mrcpp {
 template<int D>
 class TreeCalculator {
 public:
-    TreeCalculator() { }
+    TreeCalculator() = default;
     virtual ~TreeCalculator() = default;
 
     virtual MWNodeVector<D>* getInitialWorkVector(MWTree<D> &tree) const {

--- a/src/trees/BandWidth.h
+++ b/src/trees/BandWidth.h
@@ -10,11 +10,10 @@
 
 namespace mrcpp {
 
-class BandWidth {
+class BandWidth final {
 public:
     BandWidth(int depth = 0) : widths(depth + 1, 5) { this->clear(); }
     BandWidth &operator=(const BandWidth &bw);
-    virtual ~BandWidth() { }
 
     void clear() { this->widths.setConstant(-1); }
 

--- a/src/trees/BoundingBox.h
+++ b/src/trees/BoundingBox.h
@@ -21,7 +21,7 @@ public:
     BoundingBox(const NodeIndex<D> &idx, const int *nb = nullptr);
     BoundingBox(const BoundingBox<D> &box);
     BoundingBox<D> &operator=(const BoundingBox<D> &box);
-    virtual ~BoundingBox() { }
+    virtual ~BoundingBox() = default;
 
     inline bool operator==(const BoundingBox<D> &box) const;
     inline bool operator!=(const BoundingBox<D> &box) const;

--- a/src/trees/FunctionNode.h
+++ b/src/trees/FunctionNode.h
@@ -26,6 +26,8 @@ public:
 
 protected:
     FunctionNode() : MWNode<D>() { }
+    FunctionNode(const FunctionNode<D> &node) = delete;
+    FunctionTree<D> &operator=(const FunctionNode<D> &node) = delete;
     virtual ~FunctionNode() { assert(this->tree == 0); }
 
     double evalf(const Coord<D> &r);

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -13,6 +13,8 @@ template<int D>
 class FunctionTree final : public MWTree<D> {
 public:
     FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory *sh_mem = nullptr);
+    FunctionTree(const FunctionTree<D> &tree) = delete;
+    FunctionTree<D> &operator=(const FunctionTree<D> &tree) = delete;
     ~FunctionTree();
 
     void clear();

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -10,15 +10,15 @@
 namespace mrcpp {
 
 template<int D>
-class FunctionTree: public MWTree<D> {
+class FunctionTree final : public MWTree<D> {
 public:
     FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory *sh_mem = nullptr);
-    virtual ~FunctionTree();
+    ~FunctionTree();
 
     void clear();
 
     double integrate() const;
-    virtual double evalf(const Coord<D> &r);
+    double evalf(const Coord<D> &r);
 
     void getEndValues(Eigen::VectorXd &data);
     void setEndValues(Eigen::VectorXd &data);

--- a/src/trees/GenNode.h
+++ b/src/trees/GenNode.h
@@ -26,6 +26,8 @@ public:
 
 protected:
     GenNode() : FunctionNode<D>() { }
+    GenNode(const GenNode<D> &node) = delete;
+    GenNode<D> &operator=(const GenNode<D> &node) = delete;
     ~GenNode() { assert(this->tree == 0); }
 
     double calcComponentNorm(int i) const;

--- a/src/trees/GenNode.h
+++ b/src/trees/GenNode.h
@@ -10,26 +10,26 @@
 namespace mrcpp {
 
 template<int D>
-class GenNode: public FunctionNode<D> {
+class GenNode final : public FunctionNode<D> {
 public:
     double getWaveletNorm() const { return 0.0; }
 
-    virtual void createChildren();
-    virtual void genChildren();
-    virtual void cvTransform(int kind);
-    virtual void mwTransform(int kind);
+    void createChildren();
+    void genChildren();
+    void cvTransform(int kind);
+    void mwTransform(int kind);
 
-    virtual void setValues(const Eigen::VectorXd &vec);
-    virtual void getValues(Eigen::VectorXd &vec);
+    void setValues(const Eigen::VectorXd &vec);
+    void getValues(Eigen::VectorXd &vec);
 
     friend class SerialFunctionTree<D>;
 
 protected:
     GenNode() : FunctionNode<D>() { }
-    virtual ~GenNode() { assert(this->tree == 0); }
+    ~GenNode() { assert(this->tree == 0); }
 
     double calcComponentNorm(int i) const;
-    virtual void dealloc();
+    void dealloc();
     void reCompress();
 };
 

--- a/src/trees/HilbertIterator.h
+++ b/src/trees/HilbertIterator.h
@@ -8,13 +8,12 @@
 namespace mrcpp {
 
 template<int D>
-class HilbertIterator: public TreeIterator<D> {
+class HilbertIterator final : public TreeIterator<D> {
 public:
     HilbertIterator(MWTree<D> *tree, int dir = TopDown)
             : TreeIterator<D>(dir) {
         this->init(tree);
     }
-    virtual ~HilbertIterator() { }
 
 protected:
     int getChildIndex(int i) const {

--- a/src/trees/HilbertPath.h
+++ b/src/trees/HilbertPath.h
@@ -3,7 +3,7 @@
 namespace mrcpp {
 
 template<int D>
-class HilbertPath {
+class HilbertPath final {
 public:
     HilbertPath() : path(0) { }
     HilbertPath(const HilbertPath<D> &p) : path(p.path) { }
@@ -11,7 +11,6 @@ public:
         int hIdx = p.getHIndex(cIdx);
         this->path = p.getChildPath(hIdx);
     }
-    virtual ~HilbertPath() { }
 
     short int getPath() const { return this->path; }
     short int getChildPath(int hIdx) const { return this->pTable[this->path][hIdx]; }

--- a/src/trees/LebesgueIterator.h
+++ b/src/trees/LebesgueIterator.h
@@ -7,13 +7,13 @@
 namespace mrcpp {
 
 template<int D>
-class LebesgueIterator: public TreeIterator<D> {
+class LebesgueIterator final : public TreeIterator<D> {
 public:
     LebesgueIterator(MWTree<D> *tree, int dir = TopDown):
         TreeIterator<D>(dir) {
         this->init(tree);
     }
-    virtual ~LebesgueIterator() {}
+
 protected:
     int getChildIndex(int i) const { return i; }
 };

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -20,6 +20,7 @@ template<int D>
 class MWNode {
 public:
     MWNode(const MWNode<D> &node);
+    MWNode<D> &operator=(const MWNode<D> &node) = delete;
     virtual ~MWNode();
 
     int getKp1() const { return getMWTree().getKp1(); }

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -30,6 +30,8 @@ template<int D>
 class MWTree {
 public:
     MWTree(const MultiResolutionAnalysis<D> &mra);
+    MWTree(const MWTree<D> &tree) = delete;
+    MWTree<D> &operator=(const MWTree<D> &tree) = delete;
     virtual ~MWTree();
 
     void setZero();

--- a/src/trees/MultiResolutionAnalysis.cpp
+++ b/src/trees/MultiResolutionAnalysis.cpp
@@ -17,8 +17,7 @@ MultiResolutionAnalysis<D>::MultiResolutionAnalysis(const MultiResolutionAnalysi
 }
 
 template<int D>
-MultiResolutionAnalysis<D>::MultiResolutionAnalysis(const BoundingBox<D> &bb,
-                        const ScalingBasis &sb, int depth)
+MultiResolutionAnalysis<D>::MultiResolutionAnalysis(const BoundingBox<D> &bb, const ScalingBasis &sb, int depth)
         : maxDepth(depth),
           basis(sb),
           world(bb) {

--- a/src/trees/MultiResolutionAnalysis.h
+++ b/src/trees/MultiResolutionAnalysis.h
@@ -9,13 +9,12 @@
 namespace mrcpp {
 
 template<int D>
-class MultiResolutionAnalysis {
+class MultiResolutionAnalysis final {
 public:
     MultiResolutionAnalysis(const MultiResolutionAnalysis<D> &mra);
     MultiResolutionAnalysis(const BoundingBox<D> &bb,
                             const ScalingBasis &sb,
                             int depth = MaxDepth);
-    virtual ~MultiResolutionAnalysis() { }
 
     int getOrder() const { return this->basis.getScalingOrder(); }
     int getMaxDepth() const { return this->maxDepth; }

--- a/src/trees/MultiResolutionAnalysis.h
+++ b/src/trees/MultiResolutionAnalysis.h
@@ -11,10 +11,9 @@ namespace mrcpp {
 template<int D>
 class MultiResolutionAnalysis final {
 public:
+    MultiResolutionAnalysis(const BoundingBox<D> &bb, const ScalingBasis &sb, int depth = MaxDepth);
     MultiResolutionAnalysis(const MultiResolutionAnalysis<D> &mra);
-    MultiResolutionAnalysis(const BoundingBox<D> &bb,
-                            const ScalingBasis &sb,
-                            int depth = MaxDepth);
+    MultiResolutionAnalysis &operator=(const MultiResolutionAnalysis &mra) = delete;
 
     int getOrder() const { return this->basis.getScalingOrder(); }
     int getMaxDepth() const { return this->maxDepth; }

--- a/src/trees/NodeBox.h
+++ b/src/trees/NodeBox.h
@@ -15,14 +15,14 @@
 namespace mrcpp {
 
 template<int D>
-class NodeBox : public BoundingBox<D> {
+class NodeBox final : public BoundingBox<D> {
 public:
     NodeBox();
     NodeBox(const NodeIndex<D> &idx, const int *nb = nullptr);
     NodeBox(const NodeBox<D> &box);
     NodeBox(const BoundingBox<D> &box);
     NodeBox<D> &operator=(const NodeBox<D> &box);
-    virtual ~NodeBox();
+    ~NodeBox();
 
     void setNode(int idx, MWNode<D> **node);
     void clearNode(int idx) { this->nodes[idx] = 0; }

--- a/src/trees/NodeIndex.h
+++ b/src/trees/NodeIndex.h
@@ -13,12 +13,11 @@
 namespace mrcpp {
 
 template<int D>
-class NodeIndex {
+class NodeIndex final {
 public:
     NodeIndex(int n = 0, const int *l = nullptr);
     NodeIndex(const NodeIndex<D> &idx);
     NodeIndex(const NodeIndex<D> &pIdx, int cIdx);
-    virtual ~NodeIndex() { }
 
     inline NodeIndex<D>& operator=(const NodeIndex<D> &idx);
     inline bool operator==(const NodeIndex<D> &idx) const;

--- a/src/trees/OperatorNode.h
+++ b/src/trees/OperatorNode.h
@@ -35,6 +35,8 @@ public:
 
 protected:
     OperatorNode() : MWNode<2>() { }
+    OperatorNode(const OperatorNode &node) = delete;
+    OperatorNode &operator=(const OperatorNode &node) = delete;
 
     void dealloc();
     double calcComponentNorm(int i) const;

--- a/src/trees/OperatorNode.h
+++ b/src/trees/OperatorNode.h
@@ -5,7 +5,7 @@
 
 namespace mrcpp {
 
-class OperatorNode : public MWNode<2> {
+class OperatorNode final : public MWNode<2> {
 public:
     OperatorTree &getOperTree() { return static_cast<OperatorTree &>(*this->tree); }
     OperatorNode &getOperParent() { return static_cast<OperatorNode &>(*this->parent); }
@@ -35,7 +35,6 @@ public:
 
 protected:
     OperatorNode() : MWNode<2>() { }
-    virtual ~OperatorNode() { }
 
     void dealloc();
     double calcComponentNorm(int i) const;

--- a/src/trees/OperatorTree.h
+++ b/src/trees/OperatorTree.h
@@ -7,6 +7,8 @@ namespace mrcpp {
 class OperatorTree final : public MWTree<2> {
 public:
     OperatorTree(const MultiResolutionAnalysis<2> &mra, double np);
+    OperatorTree(const OperatorTree &tree) = delete;
+    OperatorTree &operator=(const OperatorTree &tree) = delete;
     virtual ~OperatorTree();
 
     double getNormPrecision() const { return this->normPrec; }

--- a/src/trees/OperatorTree.h
+++ b/src/trees/OperatorTree.h
@@ -4,10 +4,9 @@
 
 namespace mrcpp {
 
-class OperatorTree: public MWTree<2> {
+class OperatorTree final : public MWTree<2> {
 public:
-    OperatorTree(const MultiResolutionAnalysis<2> &mra,
-                 double np);
+    OperatorTree(const MultiResolutionAnalysis<2> &mra, double np);
     virtual ~OperatorTree();
 
     double getNormPrecision() const { return this->normPrec; }
@@ -24,8 +23,8 @@ public:
     OperatorNode &getNode(int n, int l) { return *nodePtrAccess[n][l]; }
     const OperatorNode &getNode(int n, int l) const { return *nodePtrAccess[n][l]; }
 
-    virtual void mwTransformDown(bool overwrite);
-    virtual void mwTransformUp();
+    void mwTransformDown(bool overwrite);
+    void mwTransformUp();
 
 protected:
     const double normPrec;

--- a/src/trees/ProjectedNode.h
+++ b/src/trees/ProjectedNode.h
@@ -15,6 +15,8 @@ public:
 
 protected:
     ProjectedNode() : FunctionNode<D>() { }
+    ProjectedNode(const ProjectedNode<D> &node) = delete;
+    ProjectedNode<D> &operator=(const ProjectedNode<D> &node) = delete;
     ~ProjectedNode() { assert(this->tree == 0); }
 
     void dealloc();

--- a/src/trees/ProjectedNode.h
+++ b/src/trees/ProjectedNode.h
@@ -5,7 +5,7 @@
 namespace mrcpp {
 
 template<int D>
-class ProjectedNode: public FunctionNode<D> {
+class ProjectedNode final : public FunctionNode<D> {
 public:
     void createChildren();
     void genChildren();
@@ -15,7 +15,7 @@ public:
 
 protected:
     ProjectedNode() : FunctionNode<D>() { }
-    virtual ~ProjectedNode() { assert(this->tree == 0); }
+    ~ProjectedNode() { assert(this->tree == 0); }
 
     void dealloc();
     void reCompress();

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -19,6 +19,8 @@ template<int D>
 class SerialFunctionTree final : public SerialTree<D> {
 public:
     SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *sh_mem);
+    SerialFunctionTree(const SerialFunctionTree<D> &tree) = delete;
+    SerialFunctionTree<D> &operator=(const SerialFunctionTree<D> &tree) = delete;
     ~SerialFunctionTree();
 
     void allocRoots(MWTree<D> &tree);

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -16,18 +16,18 @@
 namespace mrcpp {
 
 template<int D>
-class SerialFunctionTree : public SerialTree<D> {
+class SerialFunctionTree final : public SerialTree<D> {
 public:
     SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *sh_mem);
-    virtual ~SerialFunctionTree();
+    ~SerialFunctionTree();
 
-    virtual void allocRoots(MWTree<D> &tree);
-    virtual void allocChildren(MWNode<D> &parent);
-    virtual void allocGenChildren(MWNode<D> &parent);
+    void allocRoots(MWTree<D> &tree);
+    void allocChildren(MWNode<D> &parent);
+    void allocGenChildren(MWNode<D> &parent);
 
-    virtual void deallocNodes(int serialIx);
-    virtual void deallocGenNodes(int serialIx);
-    virtual void deallocGenNodeChunks();
+    void deallocNodes(int serialIx);
+    void deallocGenNodes(int serialIx);
+    void deallocGenNodeChunks();
 
     int getNChunks() const { return this->nodeChunks.size(); }
     int getNChunksUsed() const;

--- a/src/trees/SerialOperatorTree.h
+++ b/src/trees/SerialOperatorTree.h
@@ -18,6 +18,8 @@ namespace mrcpp {
 class SerialOperatorTree final : public SerialTree<2> {
 public:
     SerialOperatorTree(OperatorTree *tree);
+    SerialOperatorTree(const SerialOperatorTree &tree) = delete;
+    SerialOperatorTree &operator=(const SerialOperatorTree &tree) = delete;
     ~SerialOperatorTree();
 
     void allocRoots(MWTree<2> &tree);

--- a/src/trees/SerialOperatorTree.h
+++ b/src/trees/SerialOperatorTree.h
@@ -15,18 +15,18 @@
 
 namespace mrcpp {
 
-class SerialOperatorTree : public SerialTree<2> {
+class SerialOperatorTree final : public SerialTree<2> {
 public:
     SerialOperatorTree(OperatorTree *tree);
-    virtual ~SerialOperatorTree();
+    ~SerialOperatorTree();
 
-    virtual void allocRoots(MWTree<2> &tree);
-    virtual void allocChildren(MWNode<2> &parent);
-    virtual void allocGenChildren(MWNode<2> &parent);
+    void allocRoots(MWTree<2> &tree);
+    void allocChildren(MWNode<2> &parent);
+    void allocGenChildren(MWNode<2> &parent);
 
-    virtual void deallocNodes(int serialIx);
-    virtual void deallocGenNodes(int serialIx);
-    virtual void deallocGenNodeChunks();
+    void deallocNodes(int serialIx);
+    void deallocGenNodes(int serialIx);
+    void deallocGenNodeChunks();
 
 protected:
     OperatorNode *sNodes;       //serial OperatorNodes

--- a/src/trees/SerialTree.h
+++ b/src/trees/SerialTree.h
@@ -20,7 +20,7 @@ template<int D>
 class SerialTree {
 public:
     SerialTree(MWTree<D> *tree, SharedMemory *mem);
-    virtual ~SerialTree() { }
+    virtual ~SerialTree() = default;
 
     MWTree<D>* getTree() { return this->tree_p; }
     SharedMemory* getMemory() { return this->shMem; }

--- a/src/trees/SerialTree.h
+++ b/src/trees/SerialTree.h
@@ -20,6 +20,8 @@ template<int D>
 class SerialTree {
 public:
     SerialTree(MWTree<D> *tree, SharedMemory *mem);
+    SerialTree(const SerialTree<D> &tree) = delete;
+    SerialTree<D> &operator=(const SerialTree<D> &tree) = delete;
     virtual ~SerialTree() = default;
 
     MWTree<D>* getTree() { return this->tree_p; }

--- a/src/trees/TreeIterator.h
+++ b/src/trees/TreeIterator.h
@@ -41,7 +41,7 @@ protected:
 };
 
 template<int D>
-class IteratorNode {
+class IteratorNode final {
 public:
     MWNode<D> *node;
     IteratorNode<D> *next;

--- a/src/utils/Plotter.h
+++ b/src/utils/Plotter.h
@@ -16,7 +16,7 @@ template<int D>
 class Plotter {
 public:
     Plotter(int npts = 1000, const double *a = 0, const double *b = 0);
-    virtual ~Plotter() { }
+    virtual ~Plotter() = default;
 
     void setRange(const double *a, const double *b);
     void setNPoints(int npts);

--- a/src/utils/Printer.h
+++ b/src/utils/Printer.h
@@ -15,7 +15,7 @@ namespace mrcpp {
 
 class Timer;
 
-class Printer {
+class Printer final {
 public:
     static void init(int level = 0, int rank = 0, int size = 1, const char *file = 0);
     static void printEnvironment(int level = 0);

--- a/src/utils/Timer.h
+++ b/src/utils/Timer.h
@@ -7,7 +7,7 @@ namespace mrcpp {
 
 typedef std::chrono::time_point<std::chrono::high_resolution_clock> timeT;
 
-class Timer {
+class Timer final {
 public:
     Timer(bool start_timer = true);
     Timer& operator=(const Timer &timer);


### PR DESCRIPTION
- add `final` specifier to classes
- remove `virtual` keywords from final classes
- remove empty destructors `~Foo() { }` of final classes, or replace with `= default;` for non-final classes
- `= delete` constructors that should not be used