### PR TITLE
Fix: PHOperator and evaluation of FunctionTrees

### DIFF
--- a/src/operators/DerivativeOperator.h
+++ b/src/operators/DerivativeOperator.h
@@ -7,11 +7,15 @@ namespace mrcpp {
 template<int D>
 class DerivativeOperator : public MWOperator {
 public:
-    DerivativeOperator(const MultiResolutionAnalysis<D> &mra) 
+    DerivativeOperator(const MultiResolutionAnalysis<D> &mra)
             : MWOperator(mra.getOperatorMRA()) { }
     DerivativeOperator(const DerivativeOperator &oper) = delete;
     DerivativeOperator &operator=(const DerivativeOperator &oper) = delete;
     ~DerivativeOperator() override = default;
+    int getOrder() const { return order; }
+
+protected:
+    int order{1};
 };
 
 }

--- a/src/operators/PHOperator.cpp
+++ b/src/operators/PHOperator.cpp
@@ -10,17 +10,19 @@ namespace mrcpp {
 template<int D>
 PHOperator<D>::PHOperator(const MultiResolutionAnalysis<D> &mra, int order)
         : DerivativeOperator<D>(mra) {
-    initializeOperator(order);
+    this->order = order;
+    initializeOperator();
+
 }
 
 template<int D>
-void PHOperator<D>::initializeOperator(int order) {
+void PHOperator<D>::initializeOperator() {
     int bw = 1; // Operator bandwidth
     int max_scale = this->oper_mra.getMaxScale();
     const ScalingBasis &basis = this->oper_mra.getScalingBasis();
 
     TreeBuilder<2> builder;
-    PHCalculator calculator(basis, order);
+    PHCalculator calculator(basis, this->order);
     BandWidthAdaptor adaptor(bw, max_scale);
 
     auto *o_tree = new OperatorTree(this->oper_mra, MachineZero);

--- a/src/operators/PHOperator.h
+++ b/src/operators/PHOperator.h
@@ -12,7 +12,7 @@ public:
     PHOperator &operator=(const PHOperator &oper) = delete;
 
 protected:
-    void initializeOperator(int order);
+    void initializeOperator();
 };
 
 }

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -111,7 +111,7 @@ void DerivativeCalculator<D>::calcNode(MWNode<D> &gNode) {
         }
     }
     // Multiply appropriate scaling factor
-    const double sf = gNode.getMWTree().getMRA().getWorldBox().getScalingFactor(this->applyDir);
+    const double sf = std::pow(gNode.getMWTree().getMRA().getWorldBox().getScalingFactor(this->applyDir), oper->getOrder());
     for (int i = 0; i < gNode.getNCoefs(); i++) gNode.getCoefs()[i] /= sf;
     this->calc_t[omp_get_thread_num()].stop();
 

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -175,11 +175,15 @@ double FunctionTree<D>::evalf(const Coord<D> &r) {
     auto arg = r;
     for (auto i = 0; i < D; i++) arg[i] = arg[i]/sf[i];
 
+    // Adjust for scaling factor included in basis
+    auto coef = 1.0;
+    for (const auto &fac : sf) coef /= std::sqrt(fac);
+
     MWNode<D> &mr_node = this->getNodeOrEndNode(arg);
     FunctionNode<D> &f_node = static_cast<FunctionNode<D> &>(mr_node);
     auto result = f_node.evalf(arg);
     this->deleteGenerated();
-    return result;
+    return coef*result;
 }
 /** @brief In-place square of function
  *

--- a/tests/operators/derivative_operator.cpp
+++ b/tests/operators/derivative_operator.cpp
@@ -19,10 +19,11 @@ template<int D> MultiResolutionAnalysis<D>* initializeMRA() {
     int min_scale = -4;
     std::array<int, D> corner;
     std::array<int, D> boxes;
+    std::array<double, D> scaling_factor;
     corner.fill(-1);
     boxes.fill(2);
-    NodeIndex<D> idx(min_scale, corner.data());
-    BoundingBox<D> world(idx, boxes);
+    scaling_factor.fill(2.0);
+    BoundingBox<D> world(min_scale, corner, boxes, scaling_factor);
 
     // Constructing scaling basis
     int order = 5;

--- a/tests/operators/helmholtz_operator.cpp
+++ b/tests/operators/helmholtz_operator.cpp
@@ -116,15 +116,16 @@ TEST_CASE("Apply Helmholtz' operator", "[apply_helmholtz], [helmholtz_operator],
     double build_prec = 3.0e-3;
 
     // Computational domain [-32.0, 32.0]
-    int scale = -5;
+    int scale = -4;
     std::array<int, 3> corner;
     std::array<int, 3> nbox;
+    std::array<double, 3> scaling_factor;
     corner.fill(-1);
     nbox.fill(2);
-    NodeIndex<3> idx(scale, corner.data());
-    BoundingBox<3> box(idx, nbox);
-
+    scaling_factor.fill(2.0);
+    BoundingBox<3> box(scale, corner, nbox, scaling_factor);
     int order = 5;
+
     InterpolatingBasis basis(order);
     MultiResolutionAnalysis<3> MRA(box, basis);
 


### PR DESCRIPTION
I had forgotten to compensate for the scaling factor included in the basis when evaluating function trees. Fixed this and updated the testes to better handle scaled BoundingBoxes. This revealed errors in the second order PHOperator, thus, this pull request also includes a fix for this.  