### PR TITLE
Make bot skippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,10 @@
 language: cpp
 sudo: false
 dist: xenial
-ruby: 2.5.3
 
 notifications:
   slack:
     secure: 1jnJfgRwfuF8dzfN5daTItQ+jrilhRSjz88gKMhMpqvWrpaAZrytTcejs5FELXadeLIiddoT7c5GKLrCngVzadMi60bc/kfE2Lzer8z31i6mfPXGLvd3zWpVa6Tt8Bur2wL/oB/f6herDQurW2t0HcTp6oc6Mv3iI23PPl/MQG4w6oNKc6SOeBIBDykJOSaf3+SY/z4vXBqqF5lbmWHUIngTUkV7UEzmj+c4MukOUn9IyYjNSgvZd1ql4SKG58gzkafB1tbhxPjyJqLcWjokwlhVYTxHulBqemxRj7DGznWAUL72Pbc6ot27R655wvl/OEoL7X8U0aLIJIlIzLl49WDv5c81wGw/iOVjj5leBpfJl6QlyNMJC0jPEEJYPbEWxzgZGNa1eYbZyroOKvBBalcYVzxq018VgwYjMdZL0zFhdTymgFcDnR1p3Z1Lii6fN3oO2QVAsyBq3sN+IVtlyAWnHIGP+eyEGpggKJ1GsnG/Mb8cjBc6hjG8Q3fRQEfB5C5FeWJSU67hTnuGpTWKcF8rcfbtrw5D1JzBkqYjL6PuG5/VLu8Ro/IihBKf0N+sFa5GvdmbWOEWDEpiIMfWvcOpTIabZyRzcLJX7fqP29b2lUjoLVT3g5+cgSYSZcVyCFj+kunL1LZpgsBf9tr6r+OWzXwNVti+fEvF0KqMHHs=
-
-jobs:
-  include:
-    - os: linux
-      addons: &1
-        apt:
-          packages:
-            - g++
-            - lcov
-      env:
-        - BUILD_TYPE='release'
-        - CXX_COMPILER='g++'
-        - EIGEN_VER='3.3.4'
-    - os: linux
-      addons: *1
-      env:
-        - BUILD_TYPE='release'
-        - CXX_COMPILER='g++'
-        - OPENMP='--omp'
-        - EIGEN_VER='3.3.4'
-        - RUN_DANGER=false
-    - os: linux
-      addons: *1
-      env:
-        - BUILD_TYPE='debug'
-        - CXX_COMPILER='g++'
-        - COVERAGE='--coverage'
-        - EIGEN_VER='3.3.4'
-        - RUN_DANGER=false
-    - os: linux
-      addons:
-        apt:
-          packages:
-            - clang
-            - clang-format
-      env:
-        - BUILD_TYPE='release'
-        - CXX_COMPILER='clang++'
-        - EIGEN_VER='3.3.4'
-        - RUN_DANGER=true
 
 env:
   global:
@@ -59,11 +18,57 @@ env:
     - PYENV_ROOT=$HOME/fuffa
 
 cache:
-  timeout: 1000
   pip: true
   directories:
     - $HOME/Deps/cmake/$CMAKE_VERSION
     - $HOME/Deps/eigen
+
+jobs:
+  include:
+    - addons: &1
+        apt:
+          packages:
+            - g++
+            - lcov
+            - libpython3.5-dev
+            - python3.5-dev
+      env:
+        - BUILD_TYPE='release'
+        - CXX_COMPILER='g++'
+        - EIGEN_VER='3.3.4'
+    #- addons: *1
+    #  env:
+    #    - BUILD_TYPE='release'
+    #    - CXX_COMPILER='g++'
+    #    - OPENMP='--omp'
+    #    - EIGEN_VER='3.3.4'
+    #- addons: *1
+    #  env:
+    #    - BUILD_TYPE='debug'
+    #    - CXX_COMPILER='g++'
+    #    - COVERAGE='--coverage'
+    #    - EIGEN_VER='3.3.4'
+    #- addons:
+    #    apt:
+    #      packages:
+    #        - clang
+    #        - libpython3.5-dev
+    #        - python3.5-dev
+    #  env:
+    #    - BUILD_TYPE='release'
+    #    - CXX_COMPILER='clang++'
+    #    - EIGEN_VER='3.3.4'
+    - stage: Danger Bot
+      ruby: 2.5.3
+      addons:
+        apt:
+          packages:
+            - clang-format
+      if: commit_message !~ /(skip bot|bot skip|skip danger|danger skip)/
+      script:
+        - |
+          bundle install --gemfile=.ci/Gemfile
+          BUNDLE_GEMFILE=.ci/Gemfile bundle exec danger --dangerfile=.ci/Dangerfile
 
 before_install:
   # Dependencies are downloaded in $HOME/Downloads and installed in $HOME/Deps
@@ -81,11 +86,6 @@ before_script:
   - test -n $CXX && unset CXX
   - test -n $FC && unset FC
   - source $(pipenv --venv)/bin/activate
-  - |
-    if [[ "${RUN_DANGER}" = true ]]; then
-      bundle install --gemfile=.ci/Gemfile
-      BUNDLE_GEMFILE=.ci/Gemfile bundle exec danger --dangerfile=.ci/Dangerfile
-    fi
 
 script:
   - ./.ci/report_versions.sh
@@ -94,7 +94,7 @@ script:
         --type=${BUILD_TYPE} \
         --cxx=${CXX_COMPILER} \
         --enable-examples \
-        --cmake-options="-DEigen3_DIR=${HOME}/Deps/eigen/share/eigen3/cmake/" \
+        --cmake-options="-DEigen3_DIR=${HOME}/Deps/eigen/share/eigen3/cmake/ -DPYTHON_EXECUTABLE=$(type -P python)" \
         ${COVERAGE} \
         ${OPENMP} \
         build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ notifications:
   slack:
     secure: 1jnJfgRwfuF8dzfN5daTItQ+jrilhRSjz88gKMhMpqvWrpaAZrytTcejs5FELXadeLIiddoT7c5GKLrCngVzadMi60bc/kfE2Lzer8z31i6mfPXGLvd3zWpVa6Tt8Bur2wL/oB/f6herDQurW2t0HcTp6oc6Mv3iI23PPl/MQG4w6oNKc6SOeBIBDykJOSaf3+SY/z4vXBqqF5lbmWHUIngTUkV7UEzmj+c4MukOUn9IyYjNSgvZd1ql4SKG58gzkafB1tbhxPjyJqLcWjokwlhVYTxHulBqemxRj7DGznWAUL72Pbc6ot27R655wvl/OEoL7X8U0aLIJIlIzLl49WDv5c81wGw/iOVjj5leBpfJl6QlyNMJC0jPEEJYPbEWxzgZGNa1eYbZyroOKvBBalcYVzxq018VgwYjMdZL0zFhdTymgFcDnR1p3Z1Lii6fN3oO2QVAsyBq3sN+IVtlyAWnHIGP+eyEGpggKJ1GsnG/Mb8cjBc6hjG8Q3fRQEfB5C5FeWJSU67hTnuGpTWKcF8rcfbtrw5D1JzBkqYjL6PuG5/VLu8Ro/IihBKf0N+sFa5GvdmbWOEWDEpiIMfWvcOpTIabZyRzcLJX7fqP29b2lUjoLVT3g5+cgSYSZcVyCFj+kunL1LZpgsBf9tr6r+OWzXwNVti+fEvF0KqMHHs=
 
-
-matrix:
+jobs:
   include:
     - os: linux
       addons: &1

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,28 +36,28 @@ jobs:
         - BUILD_TYPE='release'
         - CXX_COMPILER='g++'
         - EIGEN_VER='3.3.4'
-    #- addons: *1
-    #  env:
-    #    - BUILD_TYPE='release'
-    #    - CXX_COMPILER='g++'
-    #    - OPENMP='--omp'
-    #    - EIGEN_VER='3.3.4'
-    #- addons: *1
-    #  env:
-    #    - BUILD_TYPE='debug'
-    #    - CXX_COMPILER='g++'
-    #    - COVERAGE='--coverage'
-    #    - EIGEN_VER='3.3.4'
-    #- addons:
-    #    apt:
-    #      packages:
-    #        - clang
-    #        - libpython3.5-dev
-    #        - python3.5-dev
-    #  env:
-    #    - BUILD_TYPE='release'
-    #    - CXX_COMPILER='clang++'
-    #    - EIGEN_VER='3.3.4'
+    - addons: *1
+      env:
+        - BUILD_TYPE='release'
+        - CXX_COMPILER='g++'
+        - OPENMP='--omp'
+        - EIGEN_VER='3.3.4'
+    - addons: *1
+      env:
+        - BUILD_TYPE='debug'
+        - CXX_COMPILER='g++'
+        - COVERAGE='--coverage'
+        - EIGEN_VER='3.3.4'
+    - addons:
+        apt:
+          packages:
+            - clang
+            - libpython3.5-dev
+            - python3.5-dev
+      env:
+        - BUILD_TYPE='release'
+        - CXX_COMPILER='clang++'
+        - EIGEN_VER='3.3.4'
     - stage: Danger Bot
       ruby: 2.5.3
       addons:


### PR DESCRIPTION
It is now possible to skip the bot entirely by adding any of the following to the commit message: `[skip bot]`, `[bot skip]`, `[skip danger]` or `[danger skip]`. Note that the bot is run last in the Travis build matrix.