### PR TITLE
new better definition of getNchunks that works for overwritten trees

### DIFF
--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -602,7 +602,6 @@ template <int D> void SerialFunctionTree<D>::rewritePointers(int nChunks) {
             } else {
                 this->nodeStackStatus[node->serialIx] = 0; // available
             }
-
         }
         this->lastNode = this->nodeChunks[ichunk] + this->nNodes % (this->maxNodesPerChunk);
     }

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -570,7 +570,7 @@ template <int D> void SerialFunctionTree<D>::rewritePointers(int nChunks) {
             if (node->serialIx >= 0) {
                 this->nNodes = ichunk * this->maxNodesPerChunk + (inode + 1);
                 // Node is part of tree, should be processed
-                assert(node->serialIx == this->nNodes-1);
+                assert(node->serialIx == this->nNodes - 1);
                 this->getTree()->incrementNodeCount(node->getScale());
                 if (node->isEndNode()) this->getTree()->squareNorm += node->getSquareNorm();
 

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -569,8 +569,8 @@ template <int D> void SerialFunctionTree<D>::rewritePointers(int nChunks) {
             ProjectedNode<D> *node = (this->nodeChunks[ichunk]) + inode;
             if (node->serialIx >= 0) {
                 this->nNodes = ichunk * this->maxNodesPerChunk + (inode + 1);
-
                 // Node is part of tree, should be processed
+                assert(node->serialIx == this->nNodes-1);
                 this->getTree()->incrementNodeCount(node->getScale());
                 if (node->isEndNode()) this->getTree()->squareNorm += node->getSquareNorm();
 
@@ -599,7 +599,10 @@ template <int D> void SerialFunctionTree<D>::rewritePointers(int nChunks) {
                     node->children[i] = this->nodeChunks[n_ichunk] + n_inode;
                 }
                 this->nodeStackStatus[node->serialIx] = 1; // occupied
+            } else {
+                this->nodeStackStatus[node->serialIx] = 0; // available
             }
+
         }
         this->lastNode = this->nodeChunks[ichunk] + this->nNodes % (this->maxNodesPerChunk);
     }
@@ -618,16 +621,7 @@ template <int D> void SerialFunctionTree<D>::rewritePointers(int nChunks) {
 }
 
 template <int D> int SerialFunctionTree<D>::getNChunksUsed() const {
-    int lastUsed = 0;
-    for (int iChunk = 0; iChunk < getNChunks(); iChunk++) {
-        int iShift = iChunk * this->maxNodesPerChunk;
-        bool chunkUsed = false;
-        for (int i = 0; i < this->maxNodesPerChunk; i++) {
-            if (this->nodeStackStatus[iShift + i] == 1) { chunkUsed = true; }
-        }
-        if (chunkUsed) lastUsed = iChunk + 1;
-    }
-    return lastUsed;
+    return (this->nNodes + this->maxNodesPerChunk - 1) / this->maxNodesPerChunk;
 }
 
 template class SerialFunctionTree<1>;


### PR DESCRIPTION
New defintion of getNChunksUsed. The old one counted all occupied nodes, even if they were not part of the tree. This did not necessarily work for overwritten trees, as they may have nodes closer to the end, that were not overwritten (if the tree had more chunks than what is overwritten).
The new formulation is also simpler and faster.

Also somewhat safer rewritePointers. It would be even better to rewrite the routine, so that it traverse the tree, instead of all chunks; that would clean the trees of possible orphan nodes. Also the "resetendnodetable" could be integrated here.