### PR TITLE
Serialtrees

### DIFF
--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -161,7 +161,7 @@ template <int D> void FunctionTree<D>::loadTree(const std::string &file) {
     Printer::printTime(10, "Time read tree", t1);
 
     Timer t2;
-    sTree.rewritePointers(nChunks);
+    sTree.rewritePointers();
     t2.stop();
     Printer::printTime(10, "Time rewrite pointers", t2);
 }

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -77,6 +77,7 @@ template <int D> void FunctionTree<D>::clear() {
     }
     this->resetEndNodeTable();
     this->clearSquareNorm();
+    this->getSerialFunctionTree()->clear(this->rootBox.size());
 }
 
 /** Write the tree structure to disk, for later use.

--- a/src/trees/GenNode.h
+++ b/src/trees/GenNode.h
@@ -52,7 +52,7 @@ protected:
             : FunctionNode<D>() {}
     GenNode(const GenNode<D> &node) = delete;
     GenNode<D> &operator=(const GenNode<D> &node) = delete;
-    ~GenNode() { assert(this->tree == 0); }
+    ~GenNode() { assert(this->tree == nullptr); }
 
     double calcComponentNorm(int i) const;
     void dealloc();

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -46,8 +46,8 @@ namespace mrcpp {
  *  virtual table pointers for the derived classes. */
 template <int D>
 MWNode<D>::MWNode()
-        : tree(0)
-        , parent(0)
+        : tree(nullptr)
+        , parent(nullptr)
         , squareNorm(-1.0)
         , coefs(nullptr)
         , n_coefs(0)
@@ -58,7 +58,7 @@ MWNode<D>::MWNode()
     setIsLooseNode();
 
     clearNorms();
-    for (int i = 0; i < getTDim(); i++) { this->children[i] = 0; }
+    for (int i = 0; i < getTDim(); i++) { this->children[i] = nullptr; }
 }
 
 /** MWNode copy constructor.
@@ -66,7 +66,7 @@ MWNode<D>::MWNode()
 template <int D>
 MWNode<D>::MWNode(const MWNode<D> &node)
         : tree(node.tree)
-        , parent(0)
+        , parent(nullptr)
         , squareNorm(-1.0)
         , coefs(nullptr)
         , n_coefs(0)
@@ -89,7 +89,7 @@ MWNode<D>::MWNode(const MWNode<D> &node)
         this->clearHasCoefs();
         this->clearNorms();
     }
-    for (int i = 0; i < getTDim(); i++) { this->children[i] = 0; }
+    for (int i = 0; i < getTDim(); i++) { this->children[i] = nullptr; }
 }
 
 /** MWNode destructor.
@@ -119,9 +119,9 @@ template <int D> void MWNode<D>::allocCoefs(int n_blocks, int block_size) {
 template <int D> void MWNode<D>::freeCoefs() {
     if (not this->isLooseNode()) MSG_FATAL("Only loose nodes here!");
 
-    if (this->coefs != 0) delete[] this->coefs;
+    if (this->coefs != nullptr) delete[] this->coefs;
 
-    this->coefs = 0;
+    this->coefs = nullptr;
     this->n_coefs = 0;
 
     this->clearHasCoefs();
@@ -635,12 +635,12 @@ template <int D> void MWNode<D>::genChildren() {
 template <int D> void MWNode<D>::deleteChildren() {
     if (this->isLeafNode()) return;
     for (int cIdx = 0; cIdx < getTDim(); cIdx++) {
-        if (this->children[cIdx] != 0) {
+        if (this->children[cIdx] != nullptr) {
             MWNode<D> &child = getMWChild(cIdx);
             child.deleteChildren();
             child.dealloc();
         }
-        this->children[cIdx] = 0;
+        this->children[cIdx] = nullptr;
     }
     this->childSerialIx = -1;
     this->setIsLeafNode();
@@ -795,7 +795,7 @@ template <int D> const MWNode<D> *MWNode<D>::retrieveNodeNoGen(const NodeIndex<D
         return 0;
     }
     int cIdx = getChildIndex(idx);
-    assert(this->children[cIdx] != 0);
+    assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNodeNoGen(idx);
 }
 
@@ -812,17 +812,17 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNodeNoGen(const NodeIndex<D> &idx
     }
     assert(this->isAncestor(idx));
     if (this->isEndNode()) { // don't return GenNodes
-        return 0;
+        return nullptr;
     }
     int cIdx = getChildIndex(idx);
-    assert(this->children[cIdx] != 0);
+    assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNodeNoGen(idx);
 }
 
 template <int D> const MWNode<D> *MWNode<D>::retrieveNodeOrEndNode(const Coord<D> &r, int depth) const {
     if (getDepth() == depth or this->isEndNode()) { return this; }
     int cIdx = getChildIndex(r);
-    assert(this->children[cIdx] != 0);
+    assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNodeOrEndNode(r, depth);
 }
 
@@ -836,7 +836,7 @@ template <int D> const MWNode<D> *MWNode<D>::retrieveNodeOrEndNode(const Coord<D
 template <int D> MWNode<D> *MWNode<D>::retrieveNodeOrEndNode(const Coord<D> &r, int depth) {
     if (getDepth() == depth or this->isEndNode()) { return this; }
     int cIdx = getChildIndex(r);
-    assert(this->children[cIdx] != 0);
+    assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNodeOrEndNode(r, depth);
 }
 
@@ -850,7 +850,7 @@ template <int D> const MWNode<D> *MWNode<D>::retrieveNodeOrEndNode(const NodeInd
     // and the EndNode status does not change (normally ;)
     if (isEndNode()) { return this; }
     int cIdx = getChildIndex(idx);
-    assert(children[cIdx] != 0);
+    assert(children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNodeOrEndNode(idx);
 }
 
@@ -864,7 +864,7 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNodeOrEndNode(const NodeIndex<D> 
     // and the EndNode status does not change (normally ;)
     if (isEndNode()) { return this; }
     int cIdx = getChildIndex(idx);
-    assert(children[cIdx] != 0);
+    assert(children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNodeOrEndNode(idx);
 }
 
@@ -881,7 +881,7 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNode(const Coord<D> &r, int depth
     assert(hasCoord(r));
     threadSafeGenChildren();
     int cIdx = getChildIndex(r);
-    assert(this->children[cIdx] != 0);
+    assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNode(r, depth);
 }
 
@@ -899,7 +899,7 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNode(const NodeIndex<D> &idx) {
     assert(isAncestor(idx));
     threadSafeGenChildren();
     int cIdx = getChildIndex(idx);
-    assert(this->children[cIdx] != 0);
+    assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNode(idx);
 }
 

--- a/src/trees/NodeBox.cpp
+++ b/src/trees/NodeBox.cpp
@@ -40,7 +40,7 @@ template <int D>
 NodeBox<D>::NodeBox(const NodeIndex<D> &idx, const std::array<int, D> &nb)
         : BoundingBox<D>(idx, nb)
         , nOccupied(0)
-        , nodes(0) {
+        , nodes(nullptr) {
     allocNodePointers();
 }
 
@@ -48,7 +48,7 @@ template <int D>
 NodeBox<D>::NodeBox(const BoundingBox<D> &box)
         : BoundingBox<D>(box)
         , nOccupied(0)
-        , nodes(0) {
+        , nodes(nullptr) {
     allocNodePointers();
 }
 
@@ -56,15 +56,15 @@ template <int D>
 NodeBox<D>::NodeBox(const NodeBox<D> &box)
         : BoundingBox<D>(box)
         , nOccupied(0)
-        , nodes(0) {
+        , nodes(nullptr) {
     allocNodePointers();
 }
 
 template <int D> void NodeBox<D>::allocNodePointers() {
-    assert(this->nodes == 0);
+    assert(this->nodes == nullptr);
     int nNodes = this->size();
     this->nodes = new MWNode<D> *[nNodes];
-    for (int n = 0; n < nNodes; n++) { this->nodes[n] = 0; }
+    for (int n = 0; n < nNodes; n++) { this->nodes[n] = nullptr; }
     this->nOccupied = 0;
 }
 
@@ -73,10 +73,10 @@ template <int D> NodeBox<D>::~NodeBox() {
 }
 
 template <int D> void NodeBox<D>::deleteNodes() {
-    if (this->nodes == 0) { return; }
+    if (this->nodes == nullptr) { return; }
     for (int n = 0; n < this->size(); n++) { clearNode(n); }
     delete[] this->nodes;
-    this->nodes = 0;
+    this->nodes = nullptr;
 }
 
 template <int D> void NodeBox<D>::setNode(int bIdx, MWNode<D> **node) {
@@ -86,7 +86,7 @@ template <int D> void NodeBox<D>::setNode(int bIdx, MWNode<D> **node) {
     this->nodes[bIdx] = *node;
     this->nOccupied++;
     assert(this->nOccupied > 0);
-    *node = 0;
+    *node = nullptr;
 }
 
 template <int D> MWNode<D> &NodeBox<D>::getNode(const NodeIndex<D> &nIdx) {
@@ -103,7 +103,7 @@ template <int D> MWNode<D> &NodeBox<D>::getNode(const Coord<D> &r) {
 template <int D> MWNode<D> &NodeBox<D>::getNode(int bIdx) {
     assert(bIdx >= 0);
     assert(bIdx < this->totBoxes);
-    assert(this->nodes[bIdx] != 0);
+    assert(this->nodes[bIdx] != nullptr);
     return *this->nodes[bIdx];
 }
 
@@ -121,7 +121,7 @@ template <int D> const MWNode<D> &NodeBox<D>::getNode(const Coord<D> &r) const {
 template <int D> const MWNode<D> &NodeBox<D>::getNode(int bIdx) const {
     assert(bIdx >= 0);
     assert(bIdx < this->totBoxes);
-    assert(this->nodes[bIdx] != 0);
+    assert(this->nodes[bIdx] != nullptr);
     return *this->nodes[bIdx];
 }
 

--- a/src/trees/NodeBox.h
+++ b/src/trees/NodeBox.h
@@ -48,7 +48,7 @@ public:
     ~NodeBox();
 
     void setNode(int idx, MWNode<D> **node);
-    void clearNode(int idx) { this->nodes[idx] = 0; }
+    void clearNode(int idx) { this->nodes[idx] = nullptr; }
 
     MWNode<D> &getNode(const NodeIndex<D> &idx);
     MWNode<D> &getNode(const Coord<D> &r);

--- a/src/trees/ProjectedNode.h
+++ b/src/trees/ProjectedNode.h
@@ -42,7 +42,7 @@ protected:
             : FunctionNode<D>() {}
     ProjectedNode(const ProjectedNode<D> &node) = delete;
     ProjectedNode<D> &operator=(const ProjectedNode<D> &node) = delete;
-    ~ProjectedNode() { assert(this->tree == 0); }
+    ~ProjectedNode() { assert(this->tree == nullptr); }
 
     void dealloc();
     void reCompress();

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -100,6 +100,12 @@ template <int D> SerialFunctionTree<D>::~SerialFunctionTree() {
 #endif
 }
 
+/** reset the start node counter */
+template <int D> void SerialFunctionTree<D>::clear(int n) {
+    for (int i = n; i < this->nodeStackStatus.size(); i++) this->nodeStackStatus[i] = 0;
+    this->nNodes = n;
+}
+
 template <int D> void SerialFunctionTree<D>::allocRoots(MWTree<D> &tree) {
     int sIx;
     double *coefs_p;
@@ -575,7 +581,6 @@ template <int D> void SerialFunctionTree<D>::rewritePointers() {
     }
     this->nNodes = 0;
     while (slen) {
-        this->nNodes++;
         ProjectedNode<D> *node = stack[--slen];
         for (int i = 0; i < node->getNChildren(); i++) {
             int n_ichunk = (node->childSerialIx + i) / this->maxNodesPerChunk;

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -47,8 +47,8 @@ template <int D>
 SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *mem)
         : SerialTree<D>(tree, mem)
         , nGenNodes(0)
-        , lastNode(0)
-        , lastGenNode(0) {
+        , lastNode(nullptr)
+        , lastGenNode(nullptr) {
 
     // Size for GenNodes chunks. ProjectedNodes will be 8 times larger
     this->sizeGenNodeCoeff = this->tree_p->getKp1_d();       // One block
@@ -120,8 +120,8 @@ template <int D> void SerialFunctionTree<D>::allocRoots(MWTree<D> &tree) {
         *(char **)(root_p) = this->cvptr_ProjectedNode;
 
         root_p->tree = &tree;
-        root_p->parent = 0;
-        for (int i = 0; i < root_p->getTDim(); i++) { root_p->children[i] = 0; }
+        root_p->parent = nullptr;
+        for (int i = 0; i < root_p->getTDim(); i++) { root_p->children[i] = nullptr; }
 
         root_p->nodeIndex = tree.getRootBox().getNodeIndex(rIdx);
         root_p->hilbertPath = HilbertPath<D>();
@@ -168,7 +168,7 @@ template <int D> void SerialFunctionTree<D>::allocChildren(MWNode<D> &parent) {
 
         child_p->tree = parent.tree;
         child_p->parent = &parent;
-        for (int i = 0; i < child_p->getTDim(); i++) { child_p->children[i] = 0; }
+        for (int i = 0; i < child_p->getTDim(); i++) { child_p->children[i] = nullptr; }
 
         child_p->nodeIndex = NodeIndex<D>(parent.getNodeIndex(), cIdx);
         child_p->hilbertPath = HilbertPath<D>(parent.getHilbertPath(), cIdx);
@@ -214,7 +214,7 @@ template <int D> void SerialFunctionTree<D>::allocGenChildren(MWNode<D> &parent)
 
         child_p->tree = parent.tree;
         child_p->parent = &parent;
-        for (int i = 0; i < child_p->getTDim(); i++) { child_p->children[i] = 0; }
+        for (int i = 0; i < child_p->getTDim(); i++) { child_p->children[i] = nullptr; }
 
         child_p->nodeIndex = NodeIndex<D>(parent.getNodeIndex(), cIdx);
         child_p->hilbertPath = HilbertPath<D>(parent.getHilbertPath(), cIdx);
@@ -611,7 +611,7 @@ template <int D> void SerialFunctionTree<D>::rewritePointers() {
             node->parent = this->nodeChunks[n_ichunk] + n_inode;
             assert(node->parent->serialIx == node->parentSerialIx);
         } else {
-            node->parent = 0;
+            node->parent = nullptr;
         }
 
         for (int i = 0; i < node->getNChildren(); i++) {

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -78,6 +78,8 @@ public:
 
     void rewritePointers();
 
+    void clear(int n);
+
 protected:
     int maxGenNodes;      // max number of Gen nodes that can be defined
     int sizeGenNodeCoeff; // size of coeff for one Gen node

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -76,7 +76,7 @@ public:
     //    int *genNodeStackStatus;
     std::vector<int> genNodeStackStatus;
 
-    void rewritePointers(int nChunks);
+    void rewritePointers();
 
 protected:
     int maxGenNodes;      // max number of Gen nodes that can be defined

--- a/src/trees/SerialOperatorTree.cpp
+++ b/src/trees/SerialOperatorTree.cpp
@@ -44,7 +44,7 @@ int NOtrees = 0;
  * Gen nodes and loose nodes are not counted with MWTree->[in/de]crementNodeCount()
  */
 SerialOperatorTree::SerialOperatorTree(OperatorTree *tree)
-        : SerialTree<2>(tree, 0)
+        : SerialTree<2>(tree, nullptr)
         , sNodes(nullptr)
         , lastNode(nullptr) {
 
@@ -96,8 +96,8 @@ void SerialOperatorTree::allocRoots(MWTree<2> &tree) {
         *(char **)(root_p) = this->cvptr_OperatorNode;
 
         root_p->tree = &tree;
-        root_p->parent = 0;
-        for (int i = 0; i < root_p->getTDim(); i++) { root_p->children[i] = 0; }
+        root_p->parent = nullptr;
+        for (int i = 0; i < root_p->getTDim(); i++) { root_p->children[i] = nullptr; }
 
         root_p->nodeIndex = tree.getRootBox().getNodeIndex(rIdx);
         root_p->hilbertPath = HilbertPath<2>();
@@ -144,7 +144,7 @@ void SerialOperatorTree::allocChildren(MWNode<2> &parent) {
 
         child_p->tree = parent.tree;
         child_p->parent = &parent;
-        for (int i = 0; i < child_p->getTDim(); i++) { child_p->children[i] = 0; }
+        for (int i = 0; i < child_p->getTDim(); i++) { child_p->children[i] = nullptr; }
 
         child_p->nodeIndex = NodeIndex<2>(parent.getNodeIndex(), cIdx);
         child_p->hilbertPath = HilbertPath<2>(parent.getHilbertPath(), cIdx);

--- a/src/trees/SerialTree.h
+++ b/src/trees/SerialTree.h
@@ -51,7 +51,7 @@ public:
     SharedMemory *getMemory() { return this->shMem; }
 
     bool isShared() const {
-        if (this->shMem == 0) return false;
+        if (this->shMem == nullptr) return false;
         return true;
     }
 

--- a/src/trees/TreeIterator.cpp
+++ b/src/trees/TreeIterator.cpp
@@ -32,11 +32,11 @@ namespace mrcpp {
 template <int D>
 TreeIterator<D>::TreeIterator(int dir)
         : mode(dir)
-        , state(0)
-        , initialState(0) {}
+        , state(nullptr)
+        , initialState(nullptr) {}
 
 template <int D> TreeIterator<D>::~TreeIterator() {
-    if (this->initialState != 0) { delete this->initialState; }
+    if (this->initialState != nullptr) { delete this->initialState; }
 }
 
 template <int D> bool TreeIterator<D>::next() {
@@ -98,11 +98,11 @@ template <int D> bool TreeIterator<D>::tryNextRoot() {
 }
 
 template <int D> void TreeIterator<D>::removeState() {
-    if (this->state == this->initialState) { this->initialState = 0; }
-    if (this->state != 0) {
+    if (this->state == this->initialState) { this->initialState = nullptr; }
+    if (this->state != nullptr) {
         IteratorNode<D> *spare = this->state;
         this->state = spare->next;
-        spare->next = 0;
+        spare->next = nullptr;
         delete spare;
     }
 }

--- a/src/trees/TreeIterator.h
+++ b/src/trees/TreeIterator.h
@@ -71,7 +71,7 @@ public:
     bool doneNode;
     bool doneChild[1 << D];
 
-    IteratorNode(MWNode<D> *nd, IteratorNode<D> *nx = 0);
+    IteratorNode(MWNode<D> *nd, IteratorNode<D> *nx = nullptr);
     ~IteratorNode() { delete this->next; }
 };
 

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -129,7 +129,7 @@ template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Com
     println(10, " Time recieve                " << std::setw(30) << t1);
 
     Timer t2;
-    sTree.rewritePointers(nChunks);
+    sTree.rewritePointers();
     t2.stop();
     println(10, " Time rewrite pointers       " << std::setw(30) << t2);
 #endif
@@ -204,7 +204,7 @@ template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Co
                 println(10, " Receiving chunk " << iChunk);
                 MPI_Recv(sTree.nodeChunks[iChunk], count, MPI_BYTE, src, dst_tag + iChunk + 1, comm, &status);
             }
-            sTree.rewritePointers(nChunks);
+            sTree.rewritePointers();
         }
     }
 


### PR DESCRIPTION
New defintion of getNChunksUsed. The old one counted all occupied nodes, even if they were not part of the tree. This did not necessarily work for overwritten trees, as they may have nodes closer to the end, that were not overwritten (if the tree had more chunks than what is overwritten).
The new formulation is also simpler and faster.

RewritePointers is reformulated so that it traverse the tree instead of going through all the chunks. This will then avoid possible problems with orphan nodes, since those will not be counted/included.
Also the call to resetEndNodeTable is now removed, by including it directly. Also simpler and faster.