### PR TITLE
Periodic gaussians

### DIFF
--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(mrcpp
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/BoysFunction.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/function_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/LegendrePoly.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Polynomial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RepresentableFunction.cpp
@@ -13,8 +14,9 @@ target_sources(mrcpp
 get_filename_component(_dirname ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 list(APPEND ${_dirname}_h
-  ${CMAKE_CURRENT_SOURCE_DIR}/BoysFunction.h
   ${CMAKE_CURRENT_SOURCE_DIR}/AnalyticFunction.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/BoysFunction.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/function_utils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/LegendrePoly.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Polynomial.h
   ${CMAKE_CURRENT_SOURCE_DIR}/RepresentableFunction.h

--- a/src/functions/GaussExp.cpp
+++ b/src/functions/GaussExp.cpp
@@ -113,9 +113,9 @@ template <int D> GaussExp<D> &GaussExp<D>::operator=(const GaussExp<D> &gexp) {
     return *this;
 }
 
-template <int D> void GaussExp<D>::makePeriodic(const std::array<double, D> &period) {
+template <int D> void GaussExp<D>::makePeriodic(const std::array<double, D> &period, double &nStdDev) {
     this->periodic = true;
-    for (auto &func : this->funcs) { func->makePeriodic(period); }
+    for (auto &func : this->funcs) { func->makePeriodic(period, nStdDev); }
 }
 
 template <int D> double GaussExp<D>::evalf(const Coord<D> &r) const {

--- a/src/functions/GaussExp.cpp
+++ b/src/functions/GaussExp.cpp
@@ -114,12 +114,17 @@ template <int D> GaussExp<D> &GaussExp<D>::operator=(const GaussExp<D> &gexp) {
 }
 
 template <int D> void GaussExp<D>::makePeriodic(const std::array<double, D> &period) {
+    this->periodic = true;
     for (auto &func : this->funcs) { func->makePeriodic(period); }
 }
 
 template <int D> double GaussExp<D>::evalf(const Coord<D> &r) const {
     double val = 0.0;
-    for (int i = 0; i < this->size(); i++) { val += this->getFunc(i).evalfCore(r); }
+    if (!this->periodic) {
+        for (int i = 0; i < this->size(); i++) { val += this->getFunc(i).evalfCore(r); }
+    } else {
+        for (int i = 0; i < this->size(); i++) { val += this->getFunc(i).evalf(r); }
+    }
     return val;
 }
 

--- a/src/functions/GaussExp.cpp
+++ b/src/functions/GaussExp.cpp
@@ -113,7 +113,7 @@ template <int D> GaussExp<D> &GaussExp<D>::operator=(const GaussExp<D> &gexp) {
     return *this;
 }
 
-template <int D> void GaussExp<D>::makePeriodic(const std::array<double, D> &period, double &nStdDev) {
+template <int D> void GaussExp<D>::makePeriodic(const std::array<double, D> &period, double nStdDev) {
     this->periodic = true;
     for (auto &func : this->funcs) { func->makePeriodic(period, nStdDev); }
 }

--- a/src/functions/GaussExp.cpp
+++ b/src/functions/GaussExp.cpp
@@ -113,9 +113,13 @@ template <int D> GaussExp<D> &GaussExp<D>::operator=(const GaussExp<D> &gexp) {
     return *this;
 }
 
+template <int D> void GaussExp<D>::makePeriodic(const std::array<double, D> &period) {
+    for (auto &func : this->funcs) { func->makePeriodic(period); }
+}
+
 template <int D> double GaussExp<D>::evalf(const Coord<D> &r) const {
     double val = 0.0;
-    for (int i = 0; i < this->size(); i++) { val += this->getFunc(i).evalf(r); }
+    for (int i = 0; i < this->size(); i++) { val += this->getFunc(i).evalfCore(r); }
     return val;
 }
 

--- a/src/functions/GaussExp.h
+++ b/src/functions/GaussExp.h
@@ -61,7 +61,7 @@ public:
     GaussExp &operator=(const GaussExp<D> &gExp);
     ~GaussExp() override;
 
-    void makePeriodic(const std::array<double, D> &period);
+    void makePeriodic(const std::array<double, D> &period, double &nStdDev = 4.0);
 
     auto begin() { return funcs.begin(); }
     auto end() { return funcs.end(); }

--- a/src/functions/GaussExp.h
+++ b/src/functions/GaussExp.h
@@ -61,6 +61,11 @@ public:
     GaussExp &operator=(const GaussExp<D> &gExp);
     ~GaussExp() override;
 
+    void makePeriodic(const std::array<double, D> &period);
+
+    auto begin() { return funcs.begin(); }
+    auto end() { return funcs.end(); }
+
     double calcCoulombEnergy();
     double calcSquareNorm();
     void normalize();

--- a/src/functions/GaussExp.h
+++ b/src/functions/GaussExp.h
@@ -61,7 +61,7 @@ public:
     GaussExp &operator=(const GaussExp<D> &gExp);
     ~GaussExp() override;
 
-    void makePeriodic(const std::array<double, D> &period, double &nStdDev = 4.0);
+    void makePeriodic(const std::array<double, D> &period, double nStdDev = 4.0);
 
     auto begin() { return funcs.begin(); }
     auto end() { return funcs.end(); }

--- a/src/functions/GaussExp.h
+++ b/src/functions/GaussExp.h
@@ -132,6 +132,7 @@ protected:
     static double defaultScreening;
     double screening{0.0};
     double squareNorm{-1.0};
+    bool periodic{false};
 
     std::ostream &print(std::ostream &o) const;
 };

--- a/src/functions/GaussFunc.cpp
+++ b/src/functions/GaussFunc.cpp
@@ -52,7 +52,7 @@ template <int D> Gaussian<D> *GaussFunc<D>::copy() const {
     return gauss;
 }
 
-template <int D> double GaussFunc<D>::evalf(const Coord<D> &r) const {
+template <int D> double GaussFunc<D>::evalfCore(const Coord<D> &r) const {
     if (this->getScreen()) {
         for (int d = 0; d < D; d++) {
             if (r[d] < this->A[d] or r[d] > this->B[d]) { return 0.0; }

--- a/src/functions/GaussFunc.h
+++ b/src/functions/GaussFunc.h
@@ -51,7 +51,10 @@ template <int D> class GaussFunc final : public Gaussian<D> {
 public:
     GaussFunc(double alpha, double coef, const Coord<D> &pos = {}, const std::array<int, D> &pow = {})
             : Gaussian<D>(alpha, coef, pos, pow) {}
-    GaussFunc(const std::array<double, D> &alpha, double coef, const Coord<D> &pos, const std::array<int, D> &pow)
+    GaussFunc(const std::array<double, D> &alpha,
+              double coef,
+              const Coord<D> &pos = {},
+              const std::array<int, D> &pow = {})
             : Gaussian<D>(alpha, coef, pos, pow) {}
     GaussFunc(const GaussFunc<D> &gf)
             : Gaussian<D>(gf) {}
@@ -61,8 +64,9 @@ public:
     double calcCoulombEnergy(GaussFunc<D> &gf);
     double calcSquareNorm() override;
 
-    double evalf(const Coord<D> &r) const override;
-    double evalf(double r, int dim) const override;
+    double evalfCore(const Coord<D> &r) const;
+
+    double evalf(double r, int dim) const;
 
     static double calcOverlap(GaussFunc<D> &a, GaussFunc<D> &b);
     double calcOverlap(GaussFunc<D> &b) override;
@@ -85,6 +89,8 @@ public:
         this->power = power;
         this->squareNorm = -1.0;
     }
+
+    using Gaussian<D>::evalf;
 
 private:
     static double ObaraSaika_ab(int power_a, int power_b, double pos_a, double pos_b, double expo_a, double expo_b);

--- a/src/functions/GaussPoly.cpp
+++ b/src/functions/GaussPoly.cpp
@@ -122,7 +122,7 @@ template <int D> double GaussPoly<D>::calcSquareNorm() {
     return this->squareNorm;
 }
 
-template <int D> double GaussPoly<D>::evalf(const Coord<D> &r) const {
+template <int D> double GaussPoly<D>::evalfCore(const Coord<D> &r) const {
     if (this->getScreen()) {
         for (int d = 0; d < D; d++) {
             if (r[d] < this->A[d] or r[d] > this->B[d]) { return 0.0; }

--- a/src/functions/GaussPoly.h
+++ b/src/functions/GaussPoly.h
@@ -58,8 +58,8 @@ public:
 
     double calcSquareNorm() override;
 
-    double evalf(const Coord<D> &r) const override;
-    double evalf(double r, int dim) const override;
+    double evalfCore(const Coord<D> &r) const;
+    double evalf(double r, int dim) const;
 
     double calcOverlap(GaussFunc<D> &b) override;
     double calcOverlap(GaussPoly<D> &b) override;
@@ -88,6 +88,8 @@ public:
                            std::vector<int *> &power,
                            std::array<int, D> &pow,
                            int dir) const;
+
+    using Gaussian<D>::evalf;
 
 private:
     Polynomial *poly[D];

--- a/src/functions/Gaussian.cpp
+++ b/src/functions/Gaussian.cpp
@@ -63,7 +63,7 @@ Gaussian<D>::Gaussian(const std::array<double, D> &a, double c, const Coord<D> &
 
 template <int D> void Gaussian<D>::makePeriodic(const std::array<double, D> &period) {
     for (auto &x : period)
-        if (x <= 0.0) MSG_ERROR("The period has to be greater that zero in all directions");
+        if (x <= 0.0) MSG_ERROR("The period has to be greater than zero in all directions");
     this->period = period;
     this->gauss_exp = function_utils::make_gaussian_periodic<D>(*this, this->period);
 }

--- a/src/functions/Gaussian.cpp
+++ b/src/functions/Gaussian.cpp
@@ -123,7 +123,7 @@ template <int D> bool Gaussian<D>::isVisibleAtScale(int scale, int nQuadPts) con
 
     for (auto &alp : this->alpha) {
         double stdDeviation = std::pow(2.0 * alp, -0.5);
-        auto visibleScale = static_cast<int>(-std::floor(std::log2(nQuadPts * 2.0 * stdDeviation)));
+        auto visibleScale = static_cast<int>(-std::floor(std::log2(nQuadPts * 0.5 * stdDeviation)));
 
         if (scale < visibleScale) { return false; }
     }

--- a/src/functions/Gaussian.cpp
+++ b/src/functions/Gaussian.cpp
@@ -61,11 +61,11 @@ Gaussian<D>::Gaussian(const std::array<double, D> &a, double c, const Coord<D> &
         , pos(r)
         , squareNorm(-1.0) {}
 
-template <int D> void Gaussian<D>::makePeriodic(const std::array<double, D> &period) {
+template <int D> void Gaussian<D>::makePeriodic(const std::array<double, D> &period, double &nStdDev) {
     for (auto &x : period)
         if (x <= 0.0) MSG_ERROR("The period has to be greater than zero in all directions");
     this->period = period;
-    this->gauss_exp = function_utils::make_gaussian_periodic<D>(*this, this->period);
+    this->gauss_exp = function_utils::make_gaussian_periodic<D>(*this, this->period, nStdDev);
 }
 
 template <int D> void Gaussian<D>::multPureGauss(const Gaussian<D> &lhs, const Gaussian<D> &rhs) {

--- a/src/functions/Gaussian.cpp
+++ b/src/functions/Gaussian.cpp
@@ -61,7 +61,7 @@ Gaussian<D>::Gaussian(const std::array<double, D> &a, double c, const Coord<D> &
         , pos(r)
         , squareNorm(-1.0) {}
 
-template <int D> void Gaussian<D>::makePeriodic(const std::array<double, D> &period, double &nStdDev) {
+template <int D> void Gaussian<D>::makePeriodic(const std::array<double, D> &period, double nStdDev) {
     for (auto &x : period)
         if (x <= 0.0) MSG_ERROR("The period has to be greater than zero in all directions");
     this->period = period;

--- a/src/functions/Gaussian.h
+++ b/src/functions/Gaussian.h
@@ -30,10 +30,10 @@
 
 #pragma once
 
+#include <Eigen/Core>
 #include <cmath>
 #include <iostream>
-
-#include <Eigen/Core>
+#include <memory>
 
 #include "MRCPP/mrcpp_declarations.h"
 #include "RepresentableFunction.h"
@@ -48,7 +48,11 @@ public:
     virtual Gaussian<D> *copy() const = 0;
     virtual ~Gaussian() = default;
 
-    virtual double evalf(const Coord<D> &r) const = 0;
+    void makePeriodic(const std::array<double, D> &period);
+
+    virtual double evalfCore(const Coord<D> &r) const = 0;
+
+    double evalf(const Coord<D> &r) const;
     virtual double evalf(double r, int dim) const = 0;
     void evalf(const Eigen::MatrixXd &points, Eigen::MatrixXd &values) const;
 
@@ -81,7 +85,10 @@ public:
     const std::array<int, D> &getPower() const { return power; }
     const std::array<double, D> &getPos() const { return pos; }
     double getCoef() const { return coef; }
-    auto getExp() const { return alpha; }
+    std::array<double, D> getExp() const { return alpha; }
+    std::array<double, D> getPeriod() const { return period; }
+
+    double getMaximumStandardDiviation() const;
 
     virtual void setPower(const std::array<int, D> &power) = 0;
     virtual void setPower(int d, int power) = 0;
@@ -109,8 +116,11 @@ protected:
     double coef;                 /**< constant factor */
     std::array<int, D> power;    /**< max power in each dim  */
     std::array<double, D> alpha; /**< exponent  */
-    std::array<double, D> pos;   /**< center  */
+    Coord<D> pos;                /**< center  */
+    std::array<double, D> period{};
     double squareNorm;
+
+    std::shared_ptr<GaussExp<D>> gauss_exp{nullptr};
 
     bool isVisibleAtScale(int scale, int nQuadPts) const;
     bool isZeroOnInterval(const double *a, const double *b) const;

--- a/src/functions/Gaussian.h
+++ b/src/functions/Gaussian.h
@@ -48,7 +48,7 @@ public:
     virtual Gaussian<D> *copy() const = 0;
     virtual ~Gaussian() = default;
 
-    void makePeriodic(const std::array<double, D> &period, double &nStdDev = 4.0);
+    void makePeriodic(const std::array<double, D> &period, double nStdDev = 4.0);
 
     virtual double evalfCore(const Coord<D> &r) const = 0;
 

--- a/src/functions/Gaussian.h
+++ b/src/functions/Gaussian.h
@@ -48,7 +48,7 @@ public:
     virtual Gaussian<D> *copy() const = 0;
     virtual ~Gaussian() = default;
 
-    void makePeriodic(const std::array<double, D> &period);
+    void makePeriodic(const std::array<double, D> &period, double &nStdDev = 4.0);
 
     virtual double evalfCore(const Coord<D> &r) const = 0;
 

--- a/src/functions/function_utils.cpp
+++ b/src/functions/function_utils.cpp
@@ -39,28 +39,29 @@ namespace mrcpp {
  * @param[out] shared_ptr<GaussExp<D>> semi-periodic version of a Gaussian around a unit-cell
  * @param[in] A Gaussian function that is to be made semi-periodic
  * @param[in] The period of the unit cell
+ * @param[in] Number of standard diviations covered in each direction. Default 4.0
  *
- * The Gaussian function replicated in neighbooring cells, such that atleast
- * 99.99367% if the integral can be captured within the unit-cell.
+ * nStdDev = 1, 2, 3 and 4 ensures atleast 68.27%, 95.45%, 99.73% and 99.99% of the
+ * integral is conserved with respect to the integration limits.
+ *
  */
 template <int D>
 std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(Gaussian<D> &inp,
-                                                                    const std::array<double, D> &period) {
+                                                                    const std::array<double, D> &period,
+                                                                    double nStdDev) {
     auto gauss_exp = std::make_shared<GaussExp<D>>();
     auto pos_vec = std::vector<Coord<D>>();
 
-    // Four standard deviation upp and down from the expectation value of the
-    // gaussian holds approximately 99.99367% of the integral.
-    auto four_std = 4.0 * inp.getMaximumStandardDiviation();
+    auto x_std = nStdDev * inp.getMaximumStandardDiviation();
 
     // This lambda function  calculates the number of neighbooring cells
-    // requred to keep atleast 99.99367% of the integral conserved in the
+    // requred to keep atleast x_stds of the integral conserved in the
     // unit-cell.
-    auto neighbooring_cells = [period, four_std](auto pos) {
+    auto neighbooring_cells = [period, x_std](auto pos) {
         auto needed_cells_vec = std::vector<int>();
         for (auto i = 0; i < D; i++) {
-            auto upper_bound = pos[i] + four_std;
-            auto lower_bound = pos[i] - four_std;
+            auto upper_bound = pos[i] + x_std;
+            auto lower_bound = pos[i] - x_std;
             // number of cells upp and down relative to the center of the Gaussian
             needed_cells_vec.push_back(std::ceil(upper_bound / period[i]));
         }
@@ -113,9 +114,12 @@ std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(Gaussian<D> 
 }
 
 template std::shared_ptr<GaussExp<1>> function_utils::make_gaussian_periodic<1>(Gaussian<1> &inp,
-                                                                                const std::array<double, 1> &period);
+                                                                                const std::array<double, 1> &period,
+                                                                                double nStdDev);
 template std::shared_ptr<GaussExp<2>> function_utils::make_gaussian_periodic<2>(Gaussian<2> &inp,
-                                                                                const std::array<double, 2> &period);
+                                                                                const std::array<double, 2> &period,
+                                                                                double nStdDev);
 template std::shared_ptr<GaussExp<3>> function_utils::make_gaussian_periodic<3>(Gaussian<3> &inp,
-                                                                                const std::array<double, 3> &period);
+                                                                                const std::array<double, 3> &period,
+                                                                                double nStdDev);
 } // namespace mrcpp

--- a/src/functions/function_utils.cpp
+++ b/src/functions/function_utils.cpp
@@ -1,0 +1,121 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#include "function_utils.h"
+#include "utils/details.h"
+
+#include "GaussExp.h"
+#include "Gaussian.h"
+#include "utils/Printer.h"
+
+#include <memory>
+
+namespace mrcpp {
+
+/** @brief Generates a GaussExp that is semi-periodic around a unit-cell
+ *
+ * @param[out] shared_ptr<GaussExp<D>> semi-periodic version of a Gaussian around a unit-cell
+ * @param[in] A Gaussian function that is to be made semi-periodic
+ * @param[in] The period of the unit cell
+ *
+ * The Gaussian function replicated in neighbooring cells, such that atleast
+ * 99.99367% if the integral can be captured within the unit-cell.
+ */
+template <int D>
+std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(Gaussian<D> &inp,
+                                                                    const std::array<double, D> &period) {
+    auto gauss_exp = std::make_shared<GaussExp<D>>();
+    auto pos_vec = std::vector<Coord<D>>();
+
+    // Four standard deviation upp and down from the expectation value of the
+    // gaussian holds approximately 99.99367% of the integral.
+    auto four_std = 4.0 * inp.getMaximumStandardDiviation();
+
+    // This lambda function  calculates the number of neighbooring cells
+    // requred to keep atleast 99.99367% of the integral conserved in the
+    // unit-cell.
+    auto neighbooring_cells = [period, four_std](auto pos) {
+        auto needed_cells_vec = std::vector<int>();
+        for (auto i = 0; i < D; i++) {
+            auto upper_bound = pos[i] + four_std;
+            auto lower_bound = pos[i] - four_std;
+            // number of cells upp and down relative to the center of the Gaussian
+            needed_cells_vec.push_back(std::ceil(upper_bound / period[i]));
+        }
+
+        return *std::max_element(needed_cells_vec.begin(), needed_cells_vec.end());
+    };
+
+    // Finding starting position
+    auto startpos = inp.getPos();
+
+    for (auto d = 0; d < D; d++) {
+        startpos[d] = std::fmod(startpos[d], period[d]);
+        if (startpos[d] < 0) startpos[d] += period[d];
+    }
+
+    inp.setPos(startpos); // The starting position is set to complement build_grid
+                          // ensuring the projection of Gaussians with high exponents
+    auto nr_cells_upp_and_down = neighbooring_cells(startpos);
+    for (auto d = 0; d < D; d++) { startpos[d] -= nr_cells_upp_and_down * period[d]; }
+
+    auto tmp_pos = startpos;
+    for (auto x = 0; x < 2 * nr_cells_upp_and_down + 1; x++) {
+        if (D == 2 or D == 3) {
+            for (auto y = 0; y < 2 * nr_cells_upp_and_down + 1; y++) {
+                if (D == 3) {
+                    for (auto z = 0; z < 2 * nr_cells_upp_and_down + 1; z++) {
+                        pos_vec.push_back(tmp_pos);
+                        tmp_pos[2] += period[2];
+                    }
+                }
+                if (D == 2) pos_vec.push_back(tmp_pos);
+                tmp_pos[1] += period[1];
+                tmp_pos[2] = startpos[2];
+                // This will generate a warning since tmp_pos[2] is not initialized when D > 2
+            }
+        }
+        if (D == 2 or D == 3) tmp_pos[1] = startpos[1];
+        if (D == 1) pos_vec.push_back(tmp_pos);
+        tmp_pos[0] += period[0];
+    }
+
+    for (auto &pos : pos_vec) {
+        auto *gauss = inp.copy();
+        gauss->setPos(pos);
+        gauss_exp->append(*gauss);
+        delete gauss;
+    }
+
+    return gauss_exp;
+}
+
+template std::shared_ptr<GaussExp<1>> function_utils::make_gaussian_periodic<1>(Gaussian<1> &inp,
+                                                                                const std::array<double, 1> &period);
+template std::shared_ptr<GaussExp<2>> function_utils::make_gaussian_periodic<2>(Gaussian<2> &inp,
+                                                                                const std::array<double, 2> &period);
+template std::shared_ptr<GaussExp<3>> function_utils::make_gaussian_periodic<3>(Gaussian<3> &inp,
+                                                                                const std::array<double, 3> &period);
+} // namespace mrcpp

--- a/src/functions/function_utils.cpp
+++ b/src/functions/function_utils.cpp
@@ -77,8 +77,6 @@ std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(const Gaussi
         if (startpos[d] < 0) startpos[d] += period[d];
     }
 
-    // inp.setPos(startpos); // The starting position is set to complement build_grid
-    // ensuring the projection of Gaussians with high exponents
     auto nr_cells_upp_and_down = neighbooring_cells(startpos);
     for (auto d = 0; d < D; d++) { startpos[d] -= nr_cells_upp_and_down * period[d]; }
 

--- a/src/functions/function_utils.cpp
+++ b/src/functions/function_utils.cpp
@@ -46,7 +46,7 @@ namespace mrcpp {
  *
  */
 template <int D>
-std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(Gaussian<D> &inp,
+std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(const Gaussian<D> &inp,
                                                                     const std::array<double, D> &period,
                                                                     double nStdDev) {
     auto gauss_exp = std::make_shared<GaussExp<D>>();
@@ -77,8 +77,8 @@ std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(Gaussian<D> 
         if (startpos[d] < 0) startpos[d] += period[d];
     }
 
-    inp.setPos(startpos); // The starting position is set to complement build_grid
-                          // ensuring the projection of Gaussians with high exponents
+    // inp.setPos(startpos); // The starting position is set to complement build_grid
+    // ensuring the projection of Gaussians with high exponents
     auto nr_cells_upp_and_down = neighbooring_cells(startpos);
     for (auto d = 0; d < D; d++) { startpos[d] -= nr_cells_upp_and_down * period[d]; }
 
@@ -113,13 +113,13 @@ std::shared_ptr<GaussExp<D>> function_utils::make_gaussian_periodic(Gaussian<D> 
     return gauss_exp;
 }
 
-template std::shared_ptr<GaussExp<1>> function_utils::make_gaussian_periodic<1>(Gaussian<1> &inp,
+template std::shared_ptr<GaussExp<1>> function_utils::make_gaussian_periodic<1>(const Gaussian<1> &inp,
                                                                                 const std::array<double, 1> &period,
                                                                                 double nStdDev);
-template std::shared_ptr<GaussExp<2>> function_utils::make_gaussian_periodic<2>(Gaussian<2> &inp,
+template std::shared_ptr<GaussExp<2>> function_utils::make_gaussian_periodic<2>(const Gaussian<2> &inp,
                                                                                 const std::array<double, 2> &period,
                                                                                 double nStdDev);
-template std::shared_ptr<GaussExp<3>> function_utils::make_gaussian_periodic<3>(Gaussian<3> &inp,
+template std::shared_ptr<GaussExp<3>> function_utils::make_gaussian_periodic<3>(const Gaussian<3> &inp,
                                                                                 const std::array<double, 3> &period,
                                                                                 double nStdDev);
 } // namespace mrcpp

--- a/src/functions/function_utils.cpp
+++ b/src/functions/function_utils.cpp
@@ -2,7 +2,7 @@
  * MRCPP, a numerical library based on multiresolution analysis and
  * the multiwavelet basis which provide low-scaling algorithms as well as
  * rigorous error control in numerical computations.
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
  *
  * This file is part of MRCPP.
  *

--- a/src/functions/function_utils.h
+++ b/src/functions/function_utils.h
@@ -29,7 +29,7 @@
 namespace mrcpp {
 namespace function_utils {
 template <int D>
-std::shared_ptr<GaussExp<D>> make_gaussian_periodic(Gaussian<D> &gauss,
+std::shared_ptr<GaussExp<D>> make_gaussian_periodic(const Gaussian<D> &gauss,
                                                     const std::array<double, D> &period,
                                                     double nStdDev = 4.0);
 } // namespace function_utils

--- a/src/functions/function_utils.h
+++ b/src/functions/function_utils.h
@@ -1,0 +1,34 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#include "GaussExp.h"
+#include "Gaussian.h"
+
+namespace mrcpp {
+namespace function_utils {
+template <int D>
+std::shared_ptr<GaussExp<D>> make_gaussian_periodic(Gaussian<D> &gauss, const std::array<double, D> &period);
+} // namespace function_utils
+} // namespace mrcpp

--- a/src/functions/function_utils.h
+++ b/src/functions/function_utils.h
@@ -29,6 +29,8 @@
 namespace mrcpp {
 namespace function_utils {
 template <int D>
-std::shared_ptr<GaussExp<D>> make_gaussian_periodic(Gaussian<D> &gauss, const std::array<double, D> &period);
+std::shared_ptr<GaussExp<D>> make_gaussian_periodic(Gaussian<D> &gauss,
+                                                    const std::array<double, D> &period,
+                                                    double nStdDev = 4.0);
 } // namespace function_utils
 } // namespace mrcpp

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -58,7 +58,7 @@ namespace mrcpp {
  *
  */
 template <int D> void build_grid(FunctionTree<D> &out, const RepresentableFunction<D> &inp, int maxIter) {
-    int maxScale = out.getMRA().getMaxScale();
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     AnalyticAdaptor<D> adaptor(inp, maxScale);
     DefaultCalculator<D> calculator;
@@ -67,7 +67,7 @@ template <int D> void build_grid(FunctionTree<D> &out, const RepresentableFuncti
 }
 
 template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, int maxIter) {
-    int maxScale = out.getMRA().getMaxScale();
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     DefaultCalculator<D> calculator;
 
@@ -76,9 +76,9 @@ template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, i
         builder.build(out, calculator, adaptor, maxIter);
     } else {
         auto period = out.getMRA().getWorldBox().getScalingFactor();
-        auto g_exp = function_utils::make_gaussian_periodic(inp, period);
-        for (auto i = 0; i < g_exp.size(); i++) {
-            AnalyticAdaptor<D> adaptor(g_exp.getFunc(i), maxScale);
+        auto g_exp = function_utils::make_gaussian_periodic<D>(inp, period);
+        for (auto i = 0; i < g_exp->size(); i++) {
+            AnalyticAdaptor<D> adaptor(g_exp->getFunc(i), maxScale);
             builder.build(out, calculator, adaptor, maxIter);
         }
     }
@@ -86,12 +86,18 @@ template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, i
 }
 
 template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, int maxIter) {
-    int maxScale = out.getMRA().getMaxScale();
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     DefaultCalculator<D> calculator;
-    for (int i = 0; i < inp.size(); i++) {
-        AnalyticAdaptor<D> adaptor(inp.getFunc(i), maxScale);
-        builder.build(out, calculator, adaptor, maxIter);
+    if (!out.getMRA().getWorldBox().isPeriodic()) {
+        for (auto i = 0; i < inp.size(); i++) {
+            AnalyticAdaptor<D> adaptor(inp.getFunc(i), maxScale);
+            builder.build(out, calculator, adaptor, maxIter);
+        }
+    } else {
+        auto period = out.getMRA().getWorldBox().getScalingFactor();
+        auto *gauss = inp.getFunc(0).copy();
+        delete gauss;
     }
     print::separator(10, ' ');
 }
@@ -116,7 +122,7 @@ template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, i
  *
  */
 template <int D> void build_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter) {
-    int maxScale = out.getMRA().getMaxScale();
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, nullptr);
     DefaultCalculator<D> calculator;
@@ -144,7 +150,7 @@ template <int D> void build_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int
  *
  */
 template <int D> void build_grid(FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter) {
-    int maxScale = out.getMRA().getMaxScale();
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, nullptr);
     DefaultCalculator<D> calculator;
@@ -208,11 +214,11 @@ template <int D> void clear_grid(FunctionTree<D> &out) {
  *
  */
 template <int D> int refine_grid(FunctionTree<D> &out, int scales) {
-    int nSplit = 0;
-    int maxScale = out.getMRA().getMaxScale();
+    auto nSplit = 0;
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     SplitAdaptor<D> adaptor(maxScale, true); // Splits all nodes
-    for (int n = 0; n < scales; n++) {
+    for (auto n = 0; n < scales; n++) {
         nSplit += builder.split(out, adaptor, true); // Transfers coefs to children
     }
     return nSplit;
@@ -250,10 +256,10 @@ template <int D> int refine_grid(FunctionTree<D> &out, double prec, bool absPrec
  *
  */
 template <int D> int refine_grid(FunctionTree<D> &out, FunctionTree<D> &inp) {
-    int maxScale = out.getMRA().getMaxScale();
+    auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, nullptr);
-    int nSplit = builder.split(out, adaptor, true);
+    auto nSplit = builder.split(out, adaptor, true);
     return nSplit;
 }
 

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -86,18 +86,21 @@ template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, i
 }
 
 template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, int maxIter) {
-    auto maxScale = out.getMRA().getMaxScale();
-    TreeBuilder<D> builder;
-    DefaultCalculator<D> calculator;
     if (!out.getMRA().getWorldBox().isPeriodic()) {
+        auto maxScale = out.getMRA().getMaxScale();
+        TreeBuilder<D> builder;
+        DefaultCalculator<D> calculator;
         for (auto i = 0; i < inp.size(); i++) {
             AnalyticAdaptor<D> adaptor(inp.getFunc(i), maxScale);
             builder.build(out, calculator, adaptor, maxIter);
         }
     } else {
         auto period = out.getMRA().getWorldBox().getScalingFactor();
-        auto *gauss = inp.getFunc(0).copy();
-        delete gauss;
+        for (auto i = 0; i < inp.size(); i++) {
+            auto *gauss = inp.getFunc(i).copy();
+            build_grid(out, *gauss, maxIter);
+            delete gauss;
+        }
     }
     print::separator(10, ' ');
 }

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -82,7 +82,7 @@ template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, i
             builder.build(out, calculator, adaptor, maxIter);
         }
     }
-    Printer::printSeparator(10, ' ');
+    print::separator(10, ' ');
 }
 
 template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, int maxIter) {

--- a/src/treebuilders/grid.h
+++ b/src/treebuilders/grid.h
@@ -32,6 +32,7 @@
 namespace mrcpp {
 template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, int maxIter = -1);
 template <int D> void build_grid(FunctionTree<D> &out, const RepresentableFunction<D> &inp, int maxIter = -1);
+template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, int maxIter = -1);
 template <int D> void build_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter = -1);
 template <int D> void build_grid(FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1);
 template <int D> void copy_func(FunctionTree<D> &out, FunctionTree<D> &inp);

--- a/src/trees/BoundingBox.cpp
+++ b/src/trees/BoundingBox.cpp
@@ -43,8 +43,8 @@ BoundingBox<D>::BoundingBox(int n,
                             const std::array<int, D> &l,
                             const std::array<int, D> &nb,
                             const std::array<double, D> &sf)
-        : cornerIndex(n, l.data())
-        , periodic(false) {
+        : cornerIndex(n, l.data()) {
+    setPeriodic(false);
     setNBoxes(nb);
     setScalingFactor(sf);
     setDerivedParameters();
@@ -52,8 +52,8 @@ BoundingBox<D>::BoundingBox(int n,
 
 template <int D>
 BoundingBox<D>::BoundingBox(const NodeIndex<D> &idx, const std::array<int, D> &nb, const std::array<double, D> &sf)
-        : cornerIndex(idx)
-        , periodic(false) {
+        : cornerIndex(idx) {
+    setPeriodic(false);
     setNBoxes(nb);
     setScalingFactor(sf);
     setDerivedParameters();
@@ -61,8 +61,8 @@ BoundingBox<D>::BoundingBox(const NodeIndex<D> &idx, const std::array<int, D> &n
 
 template <int D>
 BoundingBox<D>::BoundingBox(const std::array<double, D> &sf, bool pbc)
-        : cornerIndex()
-        , periodic(pbc) {
+        : cornerIndex() {
+    setPeriodic(pbc);
     setNBoxes();
     setScalingFactor(sf);
     setDerivedParameters();
@@ -70,8 +70,8 @@ BoundingBox<D>::BoundingBox(const std::array<double, D> &sf, bool pbc)
 
 template <int D>
 BoundingBox<D>::BoundingBox(const BoundingBox<D> &box)
-        : cornerIndex(box.cornerIndex)
-        , periodic(box.periodic) {
+        : cornerIndex(box.cornerIndex) {
+    setPeriodic(box.periodic);
     setNBoxes(box.nBoxes);
     setScalingFactor(box.getScalingFactor());
     setDerivedParameters();
@@ -117,6 +117,14 @@ template <int D> void BoundingBox<D>::setScalingFactor(const std::array<double, 
             MSG_ERROR("The scaling factor cannot be zero in any of the directions");
     this->scalingFactor = sf;
     if (scalingFactor == std::array<double, D>{}) scalingFactor.fill(1.0);
+}
+
+template <int D> void BoundingBox<D>::setPeriodic(bool pbc) {
+    this->periodic.fill(pbc);
+}
+
+template <int D> void BoundingBox<D>::setPeriodic(std::array<bool, D> pbc) {
+    this->periodic = pbc;
 }
 
 // Specialized for D=1 below

--- a/src/trees/BoundingBox.cpp
+++ b/src/trees/BoundingBox.cpp
@@ -112,6 +112,9 @@ template <int D> void BoundingBox<D>::setDerivedParameters() {
 
 template <int D> void BoundingBox<D>::setScalingFactor(const std::array<double, D> &sf) {
     assert(this->totBoxes > 0);
+    for (auto &x : sf)
+        if (x == 0.0 and sf != std::array<double, D>{})
+            MSG_ERROR("The scaling factor cannot be zero in any of the directions");
     this->scalingFactor = sf;
     if (scalingFactor == std::array<double, D>{}) scalingFactor.fill(1.0);
 }

--- a/src/trees/BoundingBox.cpp
+++ b/src/trees/BoundingBox.cpp
@@ -69,6 +69,15 @@ BoundingBox<D>::BoundingBox(const std::array<double, D> &sf, bool pbc)
 }
 
 template <int D>
+BoundingBox<D>::BoundingBox(const std::array<double, D> &sf, std::array<bool, D> pbc)
+        : cornerIndex() {
+    setPeriodic(pbc);
+    setNBoxes();
+    setScalingFactor(sf);
+    setDerivedParameters();
+}
+
+template <int D>
 BoundingBox<D>::BoundingBox(const BoundingBox<D> &box)
         : cornerIndex(box.cornerIndex) {
     setPeriodic(box.periodic);

--- a/src/trees/BoundingBox.h
+++ b/src/trees/BoundingBox.h
@@ -47,6 +47,7 @@ public:
                 const std::array<double, D> &sf = {});
     BoundingBox(const NodeIndex<D> &idx, const std::array<int, D> &nb = {}, const std::array<double, D> &sf = {});
     BoundingBox(const std::array<double, D> &sf, bool pbc = true);
+    BoundingBox(const std::array<double, D> &sf, std::array<bool, D> pbc);
     BoundingBox(const BoundingBox<D> &box);
     BoundingBox<D> &operator=(const BoundingBox<D> &box);
     virtual ~BoundingBox() = default;
@@ -68,6 +69,7 @@ public:
     double getLowerBound(int d) const { return this->lowerBounds[d]; }
     double getUpperBound(int d) const { return this->upperBounds[d]; }
     bool isPeriodic() const { return details::are_any(this->periodic, true); }
+    const std::array<bool, D> &getPeriodic() const { return this->periodic; }
     const Coord<D> &getUnitLengths() const { return this->unitLengths; }
     const Coord<D> &getBoxLengths() const { return this->boxLengths; }
     const Coord<D> &getLowerBounds() const { return this->lowerBounds; }

--- a/src/trees/BoundingBox.h
+++ b/src/trees/BoundingBox.h
@@ -35,6 +35,7 @@
 #include <iomanip>
 
 #include "NodeIndex.h"
+#include "utils/details.h"
 
 namespace mrcpp {
 
@@ -66,7 +67,7 @@ public:
     double getBoxLength(int d) const { return this->boxLengths[d]; }
     double getLowerBound(int d) const { return this->lowerBounds[d]; }
     double getUpperBound(int d) const { return this->upperBounds[d]; }
-    bool isPeriodic() const { return this->periodic; }
+    bool isPeriodic() const { return details::are_any(this->periodic, true); }
     const Coord<D> &getUnitLengths() const { return this->unitLengths; }
     const Coord<D> &getBoxLengths() const { return this->boxLengths; }
     const Coord<D> &getLowerBounds() const { return this->lowerBounds; }
@@ -80,7 +81,7 @@ protected:
     NodeIndex<D> cornerIndex;    ///< Index defining the lower corner of the box
     std::array<int, D> nBoxes{}; ///< Number of boxes in each dim, last entry total
     std::array<double, D> scalingFactor{};
-    bool periodic;
+    std::array<bool, D> periodic{};
 
     // Derived parameters
     int totBoxes{1};
@@ -92,6 +93,8 @@ protected:
     void setNBoxes(const std::array<int, D> &nb = {});
     void setDerivedParameters();
     void setScalingFactor(const std::array<double, D> &sf);
+    void setPeriodic(std::array<bool, D> periodic);
+    void setPeriodic(bool periodic);
 
     std::ostream &print(std::ostream &o) const;
 };

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -48,7 +48,7 @@ template <int D> double FunctionNode<D>::evalf(Coord<D> r) {
     // The 1.0 appearing in the if tests comes from the period is always 1.0
     // from the point of view of this function.
     if (this->getMWTree().getRootBox().isPeriodic()) {
-        periodic::coord_mainpulation<D>(r, this->getMWTree().getRootBox().getPeriodic());
+        periodic::coord_manipulation<D>(r, this->getMWTree().getRootBox().getPeriodic());
     }
 
     this->threadSafeGenChildren();

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -28,6 +28,7 @@
 #include "core/QuadratureCache.h"
 #include "utils/Printer.h"
 #include "utils/math_utils.h"
+#include "utils/periodic_utils.h"
 
 #ifdef HAVE_BLAS
 extern "C" {
@@ -46,12 +47,7 @@ template <int D> double FunctionNode<D>::evalf(Coord<D> r) {
 
     // The 1.0 appearing in the if tests comes from the period is always 1.0
     // from the point of view of this function.
-    if (this->getMWTree().getRootBox().isPeriodic()) {
-        for (auto i = 0; i < D; i++) {
-            if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
-            if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
-        }
-    }
+    if (this->getMWTree().getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r); }
 
     this->threadSafeGenChildren();
     int cIdx = this->getChildIndex(r);

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -47,7 +47,9 @@ template <int D> double FunctionNode<D>::evalf(Coord<D> r) {
 
     // The 1.0 appearing in the if tests comes from the period is always 1.0
     // from the point of view of this function.
-    if (this->getMWTree().getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r); }
+    if (this->getMWTree().getRootBox().isPeriodic()) {
+        periodic::coord_mainpulation<D>(r, this->getMWTree().getRootBox().getPeriodic());
+    }
 
     this->threadSafeGenChildren();
     int cIdx = this->getChildIndex(r);

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -205,7 +205,7 @@ template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 
     // The 1.0 appearing in the if tests comes from the period is
     // always 1.0 from the point of view of this function.
-    if (this->getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(arg); }
+    if (this->getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(arg, this->getRootBox().getPeriodic()); }
 
     const MWNode<D> &mw_node = this->getNodeOrEndNode(arg);
     auto &f_node = static_cast<const FunctionNode<D> &>(mw_node);

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -38,6 +38,7 @@
 #include "utils/Printer.h"
 #include "utils/Timer.h"
 #include "utils/mpi_utils.h"
+#include "utils/periodic_utils.h"
 
 using namespace Eigen;
 
@@ -204,12 +205,7 @@ template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 
     // The 1.0 appearing in the if tests comes from the period is
     // always 1.0 from the point of view of this function.
-    if (this->getRootBox().isPeriodic()) {
-        for (auto i = 0; i < D; i++) {
-            if (arg[i] > 1.0) arg[i] = std::fmod(arg[i], 1.0);
-            if (arg[i] < 0.0) arg[i] = std::fmod(arg[i], 1.0) + 1.0;
-        }
-    }
+    if (this->getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(arg); }
 
     const MWNode<D> &mw_node = this->getNodeOrEndNode(arg);
     auto &f_node = static_cast<const FunctionNode<D> &>(mw_node);

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -205,7 +205,7 @@ template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 
     // The 1.0 appearing in the if tests comes from the period is
     // always 1.0 from the point of view of this function.
-    if (this->getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(arg, this->getRootBox().getPeriodic()); }
+    if (this->getRootBox().isPeriodic()) { periodic::coord_manipulation<D>(arg, this->getRootBox().getPeriodic()); }
 
     const MWNode<D> &mw_node = this->getNodeOrEndNode(arg);
     auto &f_node = static_cast<const FunctionNode<D> &>(mw_node);

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -331,7 +331,7 @@ template <int D> MWNode<D> &MWTree<D>::getNode(const Coord<D> &r, int depth) {
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) {
 
-    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r, getRootBox().getPeriodic()); }
+    if (getRootBox().isPeriodic()) { periodic::coord_manipulation<D>(r, getRootBox().getPeriodic()); }
 
     MWNode<D> &root = getRootBox().getNode(r);
     return *root.retrieveNodeOrEndNode(r, depth);
@@ -344,7 +344,7 @@ template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) {
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> const MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) const {
 
-    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r, getRootBox().getPeriodic()); }
+    if (getRootBox().isPeriodic()) { periodic::coord_manipulation<D>(r, getRootBox().getPeriodic()); }
     const MWNode<D> &root = getRootBox().getNode(r);
     return *root.retrieveNodeOrEndNode(r, depth);
 }

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -251,7 +251,7 @@ template <int D> int MWTree<D>::getSizeNodes() const {
  * the node does not exist, or if it is a GenNode. Recursion starts at the
  * appropriate rootNode. */
 template <int D> const MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) const {
-    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation<D>(idx, getRootBox().getPeriodic()); }
     int rIdx = getRootBox().getBoxIndex(idx);
     if (rIdx < 0) return nullptr;
     const MWNode<D> &root = this->rootBox.getNode(rIdx);
@@ -266,7 +266,7 @@ template <int D> const MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) const {
  * the node does not exist, or if it is a GenNode. Recursion starts at the
  * appropriate rootNode. */
 template <int D> MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) {
-    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation<D>(idx, getRootBox().getPeriodic()); }
     int rIdx = getRootBox().getBoxIndex(idx);
     if (rIdx < 0) return nullptr;
     MWNode<D> &root = this->rootBox.getNode(rIdx);
@@ -280,7 +280,7 @@ template <int D> MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) {
  * that does not exist. Recursion starts at the appropriate rootNode and
  * decends from this.*/
 template <int D> MWNode<D> &MWTree<D>::getNode(NodeIndex<D> idx) {
-    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation<D>(idx, getRootBox().getPeriodic()); }
     MWNode<D> &root = getRootBox().getNode(idx);
     assert(root.isAncestor(idx));
     return *root.retrieveNode(idx);
@@ -292,7 +292,7 @@ template <int D> MWNode<D> &MWTree<D>::getNode(NodeIndex<D> idx) {
  * the path to the requested node, and will never create or return GenNodes.
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(NodeIndex<D> idx) {
-    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation<D>(idx, getRootBox().getPeriodic()); }
     MWNode<D> &root = getRootBox().getNode(idx);
     assert(root.isAncestor(idx));
     return *root.retrieveNodeOrEndNode(idx);
@@ -304,7 +304,7 @@ template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(NodeIndex<D> idx) {
  * the path to the requested node, and will never create or return GenNodes.
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> const MWNode<D> &MWTree<D>::getNodeOrEndNode(NodeIndex<D> idx) const {
-    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation<D>(idx, getRootBox().getPeriodic()); }
     const MWNode<D> &root = getRootBox().getNode(idx);
     assert(root.isAncestor(idx));
     return *root.retrieveNodeOrEndNode(idx);
@@ -331,7 +331,7 @@ template <int D> MWNode<D> &MWTree<D>::getNode(const Coord<D> &r, int depth) {
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) {
 
-    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r); }
+    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r, getRootBox().getPeriodic()); }
 
     MWNode<D> &root = getRootBox().getNode(r);
     return *root.retrieveNodeOrEndNode(r, depth);
@@ -344,7 +344,7 @@ template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) {
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> const MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) const {
 
-    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r); }
+    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r, getRootBox().getPeriodic()); }
     const MWNode<D> &root = getRootBox().getNode(r);
     return *root.retrieveNodeOrEndNode(r, depth);
 }

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -34,6 +34,7 @@
 #include "MultiResolutionAnalysis.h"
 #include "utils/Printer.h"
 #include "utils/math_utils.h"
+#include "utils/periodic_utils.h"
 
 using namespace Eigen;
 
@@ -250,16 +251,7 @@ template <int D> int MWTree<D>::getSizeNodes() const {
  * the node does not exist, or if it is a GenNode. Recursion starts at the
  * appropriate rootNode. */
 template <int D> const MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) const {
-    if (getRootBox().isPeriodic()) {
-        int l[D];
-        int two_n = 1 << idx.getScale();
-        for (auto i = 0; i < D; i++) {
-            l[i] = idx.getTranslation(i);
-            if (l[i] >= two_n) l[i] = l[i] % two_n;
-            if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
-        }
-        idx.setTranslation(l);
-    }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
     int rIdx = getRootBox().getBoxIndex(idx);
     if (rIdx < 0) return nullptr;
     const MWNode<D> &root = this->rootBox.getNode(rIdx);
@@ -274,16 +266,7 @@ template <int D> const MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) const {
  * the node does not exist, or if it is a GenNode. Recursion starts at the
  * appropriate rootNode. */
 template <int D> MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) {
-    if (getRootBox().isPeriodic()) {
-        int l[D];
-        int two_n = 1 << idx.getScale();
-        for (auto i = 0; i < D; i++) {
-            l[i] = idx.getTranslation(i);
-            if (l[i] >= two_n) l[i] = l[i] % two_n;
-            if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
-        }
-        idx.setTranslation(l);
-    }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
     int rIdx = getRootBox().getBoxIndex(idx);
     if (rIdx < 0) return nullptr;
     MWNode<D> &root = this->rootBox.getNode(rIdx);
@@ -297,16 +280,7 @@ template <int D> MWNode<D> *MWTree<D>::findNode(NodeIndex<D> idx) {
  * that does not exist. Recursion starts at the appropriate rootNode and
  * decends from this.*/
 template <int D> MWNode<D> &MWTree<D>::getNode(NodeIndex<D> idx) {
-    if (getRootBox().isPeriodic()) {
-        int l[D];
-        int two_n = 1 << idx.getScale();
-        for (auto i = 0; i < D; i++) {
-            l[i] = idx.getTranslation(i);
-            if (l[i] >= two_n) l[i] = l[i] % two_n;
-            if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
-        }
-        idx.setTranslation(l);
-    }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
     MWNode<D> &root = getRootBox().getNode(idx);
     assert(root.isAncestor(idx));
     return *root.retrieveNode(idx);
@@ -318,16 +292,7 @@ template <int D> MWNode<D> &MWTree<D>::getNode(NodeIndex<D> idx) {
  * the path to the requested node, and will never create or return GenNodes.
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(NodeIndex<D> idx) {
-    if (getRootBox().isPeriodic()) {
-        int l[D];
-        int two_n = 1 << idx.getScale();
-        for (auto i = 0; i < D; i++) {
-            l[i] = idx.getTranslation(i);
-            if (l[i] >= two_n) l[i] = l[i] % two_n;
-            if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
-        }
-        idx.setTranslation(l);
-    }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
     MWNode<D> &root = getRootBox().getNode(idx);
     assert(root.isAncestor(idx));
     return *root.retrieveNodeOrEndNode(idx);
@@ -339,16 +304,7 @@ template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(NodeIndex<D> idx) {
  * the path to the requested node, and will never create or return GenNodes.
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> const MWNode<D> &MWTree<D>::getNodeOrEndNode(NodeIndex<D> idx) const {
-    if (getRootBox().isPeriodic()) {
-        int l[D];
-        int two_n = 1 << idx.getScale();
-        for (auto i = 0; i < D; i++) {
-            l[i] = idx.getTranslation(i);
-            if (l[i] >= two_n) l[i] = l[i] % two_n;
-            if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
-        }
-        idx.setTranslation(l);
-    }
+    if (getRootBox().isPeriodic()) { periodic::indx_manipulation(idx); }
     const MWNode<D> &root = getRootBox().getNode(idx);
     assert(root.isAncestor(idx));
     return *root.retrieveNodeOrEndNode(idx);
@@ -375,12 +331,7 @@ template <int D> MWNode<D> &MWTree<D>::getNode(const Coord<D> &r, int depth) {
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) {
 
-    if (getRootBox().isPeriodic()) {
-        for (auto i = 0; i < D; i++) {
-            if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
-            if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
-        }
-    }
+    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r); }
 
     MWNode<D> &root = getRootBox().getNode(r);
     return *root.retrieveNodeOrEndNode(r, depth);
@@ -393,12 +344,7 @@ template <int D> MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) {
  * Recursion starts at the appropriate rootNode and decends from this. */
 template <int D> const MWNode<D> &MWTree<D>::getNodeOrEndNode(Coord<D> r, int depth) const {
 
-    if (getRootBox().isPeriodic()) {
-        for (auto i = 0; i < D; i++) {
-            if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
-            if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
-        }
-    }
+    if (getRootBox().isPeriodic()) { periodic::coord_mainpulation<D>(r); }
     const MWNode<D> &root = getRootBox().getNode(r);
     return *root.retrieveNodeOrEndNode(r, depth);
 }

--- a/src/trees/MultiResolutionAnalysis.cpp
+++ b/src/trees/MultiResolutionAnalysis.cpp
@@ -67,7 +67,7 @@ template <int D> MultiResolutionAnalysis<1> MultiResolutionAnalysis<D>::getKerne
         MSG_ABORT("Invalid scaling type");
     }
 
-    int max_l = (box.isPeriodic()) ? 10 : 0;
+    int max_l = (box.isPeriodic()) ? this->periodic_operator_reach : 0;
     for (int i = 0; i < D; i++) {
         if (box.size(i) > max_l) { max_l = box.size(i); }
     }
@@ -86,7 +86,7 @@ template <int D> MultiResolutionAnalysis<2> MultiResolutionAnalysis<D>::getOpera
     const BoundingBox<D> &box = getWorldBox();
     const ScalingBasis &basis = getScalingBasis();
 
-    int maxn = (box.isPeriodic()) ? 10 : 0;
+    int maxn = (box.isPeriodic()) ? this->periodic_operator_reach : 0;
     for (int i = 0; i < D; i++) {
         if (box.size(i) > maxn) { maxn = box.size(i); }
     }

--- a/src/trees/MultiResolutionAnalysis.h
+++ b/src/trees/MultiResolutionAnalysis.h
@@ -48,6 +48,7 @@ public:
     const BoundingBox<D> &getWorldBox() const { return this->world; }
 
     void setPeriodicOperatorReach(int reach) { this->periodic_operator_reach = reach; }
+    int getPeriodicOperatorReach() { return this->periodic_operator_reach; }
 
     MultiResolutionAnalysis<1> getKernelMRA() const;
     MultiResolutionAnalysis<2> getOperatorMRA() const;

--- a/src/trees/MultiResolutionAnalysis.h
+++ b/src/trees/MultiResolutionAnalysis.h
@@ -50,6 +50,9 @@ public:
     void setPeriodicOperatorReach(int reach) { this->periodic_operator_reach = reach; }
     int getPeriodicOperatorReach() { return this->periodic_operator_reach; }
 
+    void setStds(double stds) { this->n_gauss_stds = stds; }
+    double getStds() { return this->n_gauss_stds; }
+
     MultiResolutionAnalysis<1> getKernelMRA() const;
     MultiResolutionAnalysis<2> getOperatorMRA() const;
 
@@ -63,6 +66,7 @@ protected:
     const ScalingBasis basis;
     const BoundingBox<D> world;
     int periodic_operator_reach{10};
+    double n_gauss_stds{4};
     MWFilter *filter;
 
     void setupFilter();

--- a/src/trees/MultiResolutionAnalysis.h
+++ b/src/trees/MultiResolutionAnalysis.h
@@ -47,6 +47,8 @@ public:
     const ScalingBasis &getScalingBasis() const { return this->basis; }
     const BoundingBox<D> &getWorldBox() const { return this->world; }
 
+    void setPeriodicOperatorReach(int reach) { this->periodic_operator_reach = reach; }
+
     MultiResolutionAnalysis<1> getKernelMRA() const;
     MultiResolutionAnalysis<2> getOperatorMRA() const;
 
@@ -59,6 +61,7 @@ protected:
     const int maxDepth;
     const ScalingBasis basis;
     const BoundingBox<D> world;
+    int periodic_operator_reach{10};
     MWFilter *filter;
 
     void setupFilter();

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(mrcpp
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/math_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Plotter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/periodic_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Printer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Timer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mpi_utils.cpp
@@ -12,6 +13,7 @@ get_filename_component(_dirname ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 list(APPEND ${_dirname}_h
   ${CMAKE_CURRENT_SOURCE_DIR}/Plotter.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/periodic_utils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Printer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/mpi_utils.h

--- a/src/utils/details.h
+++ b/src/utils/details.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <iostream>
 #include <sstream>
@@ -34,6 +35,9 @@ namespace details {
 bool directory_exists(std::string path);
 int get_memory_usage();
 template <int D> bool are_all_equal(const std::array<double, D> &exponent);
+template <typename T, size_t D> bool are_any(const std::array<T, D> &col, const T eq) {
+    return std::any_of(col.cbegin(), col.cend(), [eq](const T &el) { return el == eq; });
+};
 template <typename T, int D> std::array<T, D> convert_to_std_array(T *arr);
 template <typename T> auto stream_collection(const T &coll) -> std::string {
     std::ostringstream os;

--- a/src/utils/periodic_utils.cpp
+++ b/src/utils/periodic_utils.cpp
@@ -31,7 +31,7 @@
 namespace mrcpp {
 namespace periodic {
 
-template <int D> void indx_manipulation(NodeIndex<D> &idx, std::array<bool, D> periodic) {
+template <int D> void indx_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic) {
     int translation[D];
     int two_n = 1 << idx.getScale();
     for (auto i = 0; i < D; i++) {
@@ -44,7 +44,7 @@ template <int D> void indx_manipulation(NodeIndex<D> &idx, std::array<bool, D> p
     idx.setTranslation(translation);
 }
 
-template <int D> void coord_mainpulation(Coord<D> &r, std::array<bool, D> periodic) {
+template <int D> void coord_manipulation(Coord<D> &r, const std::array<bool, D> &periodic) {
     for (auto i = 0; i < D; i++) {
         if (periodic[i]) {
             if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
@@ -53,13 +53,13 @@ template <int D> void coord_mainpulation(Coord<D> &r, std::array<bool, D> period
     }
 }
 
-template void indx_manipulation<1>(NodeIndex<1> &idx, std::array<bool, 1> periodic);
-template void indx_manipulation<2>(NodeIndex<2> &idx, std::array<bool, 2> periodic);
-template void indx_manipulation<3>(NodeIndex<3> &idx, std::array<bool, 3> periodic);
+template void indx_manipulation<1>(NodeIndex<1> &idx, const std::array<bool, 1> &periodic);
+template void indx_manipulation<2>(NodeIndex<2> &idx, const std::array<bool, 2> &periodic);
+template void indx_manipulation<3>(NodeIndex<3> &idx, const std::array<bool, 3> &periodic);
 
-template void coord_mainpulation<1>(Coord<1> &r, std::array<bool, 1> periodic);
-template void coord_mainpulation<2>(Coord<2> &r, std::array<bool, 2> periodic);
-template void coord_mainpulation<3>(Coord<3> &r, std::array<bool, 3> periodic);
+template void coord_manipulation<1>(Coord<1> &r, const std::array<bool, 1> &periodic);
+template void coord_manipulation<2>(Coord<2> &r, const std::array<bool, 2> &periodic);
+template void coord_manipulation<3>(Coord<3> &r, const std::array<bool, 3> &periodic);
 
 } // namespace periodic
 } // namespace mrcpp

--- a/src/utils/periodic_utils.cpp
+++ b/src/utils/periodic_utils.cpp
@@ -23,6 +23,8 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
+#include "MRCPP/Printer"
+
 #include "periodic_utils.h"
 #include "trees/NodeIndex.h"
 
@@ -33,10 +35,11 @@ namespace periodic {
 
 template <int D> void indx_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic) {
     int translation[D];
+    if (idx.getScale() < 0) MSG_ABORT("Negative value in bit-shift");
     int two_n = 1 << idx.getScale();
     for (auto i = 0; i < D; i++) {
+        translation[i] = idx.getTranslation(i);
         if (periodic[i]) {
-            translation[i] = idx.getTranslation(i);
             if (translation[i] >= two_n) translation[i] = translation[i] % two_n;
             if (translation[i] < 0) translation[i] = (translation[i] + 1) % two_n + two_n - 1;
         }

--- a/src/utils/periodic_utils.cpp
+++ b/src/utils/periodic_utils.cpp
@@ -23,14 +23,39 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
-#include "GaussExp.h"
-#include "Gaussian.h"
+#include "periodic_utils.h"
+#include "trees/NodeIndex.h"
+
+#include <cmath>
 
 namespace mrcpp {
-namespace function_utils {
-template <int D>
-std::shared_ptr<GaussExp<D>> make_gaussian_periodic(const Gaussian<D> &gauss,
-                                                    const std::array<double, D> &period,
-                                                    double nStdDev = 4.0);
-} // namespace function_utils
+namespace periodic {
+
+template <int D> void indx_manipulation(NodeIndex<D> &idx) {
+    int l[D];
+    int two_n = 1 << idx.getScale();
+    for (auto i = 0; i < D; i++) {
+        l[i] = idx.getTranslation(i);
+        if (l[i] >= two_n) l[i] = l[i] % two_n;
+        if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
+    }
+    idx.setTranslation(l);
+}
+
+template <int D> void coord_mainpulation(Coord<D> &r) {
+    for (auto i = 0; i < D; i++) {
+        if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
+        if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
+    }
+}
+
+template void indx_manipulation<1>(NodeIndex<1> &idx);
+template void indx_manipulation<2>(NodeIndex<2> &idx);
+template void indx_manipulation<3>(NodeIndex<3> &idx);
+
+template void coord_mainpulation<1>(Coord<1> &r);
+template void coord_mainpulation<2>(Coord<2> &r);
+template void coord_mainpulation<3>(Coord<3> &r);
+
+} // namespace periodic
 } // namespace mrcpp

--- a/src/utils/periodic_utils.cpp
+++ b/src/utils/periodic_utils.cpp
@@ -31,31 +31,35 @@
 namespace mrcpp {
 namespace periodic {
 
-template <int D> void indx_manipulation(NodeIndex<D> &idx) {
-    int l[D];
+template <int D> void indx_manipulation(NodeIndex<D> &idx, std::array<bool, D> periodic) {
+    int translation[D];
     int two_n = 1 << idx.getScale();
     for (auto i = 0; i < D; i++) {
-        l[i] = idx.getTranslation(i);
-        if (l[i] >= two_n) l[i] = l[i] % two_n;
-        if (l[i] < 0) l[i] = (l[i] + 1) % two_n + two_n - 1;
+        if (periodic[i]) {
+            translation[i] = idx.getTranslation(i);
+            if (translation[i] >= two_n) translation[i] = translation[i] % two_n;
+            if (translation[i] < 0) translation[i] = (translation[i] + 1) % two_n + two_n - 1;
+        }
     }
-    idx.setTranslation(l);
+    idx.setTranslation(translation);
 }
 
-template <int D> void coord_mainpulation(Coord<D> &r) {
+template <int D> void coord_mainpulation(Coord<D> &r, std::array<bool, D> periodic) {
     for (auto i = 0; i < D; i++) {
-        if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
-        if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
+        if (periodic[i]) {
+            if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
+            if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
+        }
     }
 }
 
-template void indx_manipulation<1>(NodeIndex<1> &idx);
-template void indx_manipulation<2>(NodeIndex<2> &idx);
-template void indx_manipulation<3>(NodeIndex<3> &idx);
+template void indx_manipulation<1>(NodeIndex<1> &idx, std::array<bool, 1> periodic);
+template void indx_manipulation<2>(NodeIndex<2> &idx, std::array<bool, 2> periodic);
+template void indx_manipulation<3>(NodeIndex<3> &idx, std::array<bool, 3> periodic);
 
-template void coord_mainpulation<1>(Coord<1> &r);
-template void coord_mainpulation<2>(Coord<2> &r);
-template void coord_mainpulation<3>(Coord<3> &r);
+template void coord_mainpulation<1>(Coord<1> &r, std::array<bool, 1> periodic);
+template void coord_mainpulation<2>(Coord<2> &r, std::array<bool, 2> periodic);
+template void coord_mainpulation<3>(Coord<3> &r, std::array<bool, 3> periodic);
 
 } // namespace periodic
 } // namespace mrcpp

--- a/src/utils/periodic_utils.h
+++ b/src/utils/periodic_utils.h
@@ -23,14 +23,12 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
-#include "GaussExp.h"
-#include "Gaussian.h"
+#pragma once
 
+#include "MRCPP/mrcpp_declarations.h"
 namespace mrcpp {
-namespace function_utils {
-template <int D>
-std::shared_ptr<GaussExp<D>> make_gaussian_periodic(const Gaussian<D> &gauss,
-                                                    const std::array<double, D> &period,
-                                                    double nStdDev = 4.0);
-} // namespace function_utils
+namespace periodic {
+template <int D> void indx_manipulation(NodeIndex<D> &idx);
+template <int D> void coord_mainpulation(Coord<D> &r);
+} // namespace periodic
 } // namespace mrcpp

--- a/src/utils/periodic_utils.h
+++ b/src/utils/periodic_utils.h
@@ -28,7 +28,7 @@
 #include "MRCPP/mrcpp_declarations.h"
 namespace mrcpp {
 namespace periodic {
-template <int D> void indx_manipulation(NodeIndex<D> &idx);
-template <int D> void coord_mainpulation(Coord<D> &r);
+template <int D> void indx_manipulation(NodeIndex<D> &idx, std::array<bool, D> periodic);
+template <int D> void coord_mainpulation(Coord<D> &r, std::array<bool, D> periodic);
 } // namespace periodic
 } // namespace mrcpp

--- a/src/utils/periodic_utils.h
+++ b/src/utils/periodic_utils.h
@@ -28,7 +28,7 @@
 #include "MRCPP/mrcpp_declarations.h"
 namespace mrcpp {
 namespace periodic {
-template <int D> void indx_manipulation(NodeIndex<D> &idx, std::array<bool, D> periodic);
-template <int D> void coord_mainpulation(Coord<D> &r, std::array<bool, D> periodic);
+template <int D> void indx_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic);
+template <int D> void coord_manipulation(Coord<D> &r, const std::array<bool, D> &periodic);
 } // namespace periodic
 } // namespace mrcpp

--- a/tests/factory_functions.h
+++ b/tests/factory_functions.h
@@ -42,18 +42,21 @@ template <int D> void testInitial(const mrcpp::NodeIndex<D> *idx) {
     }
 }
 
-template <int D> void initialize(mrcpp::BoundingBox<D> **box) {
-    if (box == nullptr) INVALID_ARG_ABORT;
+template <int D>
+void initialize(mrcpp::BoundingBox<D> **box, bool periodic = false, const std::array<double, D> &period = {}) {
+    if (box == nullptr)  INVALID_ARG_ABORT;
     if (*box != nullptr) INVALID_ARG_ABORT;
 
-    std::array<int, D> nb;
-    for (int d = 0; d < D; d++) nb[d] = d + 1;
-
-    mrcpp::NodeIndex<D> *nIdx = nullptr;
-    initialize(&nIdx);
-
-    *box = new mrcpp::BoundingBox<D>(*nIdx, nb);
-    finalize(&nIdx);
+    if (not periodic) {
+        std::array<int, D> nb;
+        for (int d = 0; d < D; d++) nb[d] = d + 1;
+        mrcpp::NodeIndex<D> *nIdx = nullptr;
+        initialize<D>(&nIdx);
+        *box = new mrcpp::BoundingBox<D>(*nIdx, nb);
+        finalize(&nIdx);
+    } else {
+        *box = new mrcpp::BoundingBox<D>(period);
+    }
 }
 
 template <int D> void testInitial(const mrcpp::BoundingBox<D> *box) {
@@ -82,20 +85,24 @@ template <int D> void testInitial(const mrcpp::BoundingBox<D> *box) {
     REQUIRE((box->size() == tot_boxes));
 }
 
-template <int D> void initialize(mrcpp::MultiResolutionAnalysis<D> **mra) {
+template <int D>
+void initialize(mrcpp::MultiResolutionAnalysis<D> **mra,
+                bool periodic = false,
+                const std::array<double, D> &period = {}) {
     if (mra == nullptr) INVALID_ARG_ABORT;
     if (*mra != nullptr) INVALID_ARG_ABORT;
 
     int k = 5;
     mrcpp::InterpolatingBasis basis(k);
     mrcpp::BoundingBox<D> *world = nullptr;
-    initialize(&world);
+    initialize<D>(&world, periodic, period);
     *mra = new mrcpp::MultiResolutionAnalysis<D>(*world, basis);
     finalize(&world);
 }
 
 /* Initializing a D-dimensional Gaussian of unit charge */
-template <int D> void initialize(mrcpp::GaussFunc<D> **func) {
+template <int D>
+void initialize(mrcpp::GaussFunc<D> **func, bool periodic = false, const std::array<double, D> &period = {}) {
     double beta = 1.0e4;
     double alpha = std::pow(beta / mrcpp::pi, D / 2.0);
     double pos_data[3] = {-0.2, 0.5, 1.0};
@@ -104,6 +111,7 @@ template <int D> void initialize(mrcpp::GaussFunc<D> **func) {
     auto pos = mrcpp::details::convert_to_std_array<double, D>(pos_data);
 
     *func = new mrcpp::GaussFunc<D>(beta, alpha, pos);
+    if (periodic) (*func)->makePeriodic(period);
 }
 
 #endif // FACTORY_FUNCTIONS_H

--- a/tests/factory_functions.h
+++ b/tests/factory_functions.h
@@ -44,7 +44,7 @@ template <int D> void testInitial(const mrcpp::NodeIndex<D> *idx) {
 
 template <int D>
 void initialize(mrcpp::BoundingBox<D> **box, bool periodic = false, const std::array<double, D> &period = {}) {
-    if (box == nullptr)  INVALID_ARG_ABORT;
+    if (box == nullptr) INVALID_ARG_ABORT;
     if (*box != nullptr) INVALID_ARG_ABORT;
 
     if (not periodic) {

--- a/tests/functions/CMakeLists.txt
+++ b/tests/functions/CMakeLists.txt
@@ -2,8 +2,12 @@ target_sources(mrcpp-tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/legendre_poly.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/polynomial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gaussians.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/periodify_gaussians.cpp
     )
 
 add_Catch_test(NAME legendre_poly           LABELS legendre_poly)
 add_Catch_test(NAME polynomials             LABELS polynomials)
 add_Catch_test(NAME gaussians               LABELS gaussians)
+add_Catch_test(NAME periodic_narrow_gaussian       LABELS periodic_narrow_gaussian)
+add_Catch_test(NAME periodic_wide_gaussian       LABELS periodic_wide_gaussian)
+add_Catch_test(NAME periodic_gaussExp       LABELS periodic_gausExp)

--- a/tests/functions/periodify_gaussians.cpp
+++ b/tests/functions/periodify_gaussians.cpp
@@ -82,7 +82,7 @@ template <int D> void testIsNarrowGaussiansMadePeriodic() {
         THEN("The Gaussian should be close to zero at the bondary of the unit cell") {
             REQUIRE(gauss.evalf(new_pos) == Approx(0.0));
         }
-        AND_WHEN("The gaussian is made periodc, it is periodic") {
+        AND_WHEN("The gaussian is made periodic, it is periodic") {
             gauss.makePeriodic(period);
             REQUIRE(isPeriodic<D>(gauss));
             THEN("The gaussian should have the same value at -0.2 and 1.8") {

--- a/tests/functions/periodify_gaussians.cpp
+++ b/tests/functions/periodify_gaussians.cpp
@@ -1,0 +1,152 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#include "catch.hpp"
+
+#include "functions/GaussExp.h"
+#include "functions/GaussFunc.h"
+
+#include "utils/details.h"
+
+using namespace mrcpp;
+
+namespace periodify_gaussians {
+
+template <int D> void testIsNarrowGaussiansMadePeriodic();
+template <int D> void testIsWideGaussiansMadePeriodic();
+template <int D> void testIsGaussExpMadePeriodic();
+
+template <int D> bool isPeriodic(const Gaussian<D> &func) {
+    if (func.getPeriod() == std::array<double, D>{})
+        return false;
+    else
+        return true;
+}
+
+SCENARIO("Given a narrow Gaussian is it periodic?", "[periodic_narrow_gaussian]") {
+    GIVEN("Narrow Gaussian in 1D") { testIsNarrowGaussiansMadePeriodic<1>(); }
+    GIVEN("Narrow Gaussian in 2D") { testIsNarrowGaussiansMadePeriodic<2>(); }
+    GIVEN("Narrow Gaussian in 3D") { testIsNarrowGaussiansMadePeriodic<3>(); }
+}
+
+SCENARIO("Given a wide Gaussian is it periodic?", "[periodic_wide_gaussian]") {
+    GIVEN("Wide Gaussian in 1D") { testIsWideGaussiansMadePeriodic<1>(); }
+    GIVEN("Wide Gaussian in 2D") { testIsWideGaussiansMadePeriodic<2>(); }
+    GIVEN("Wide Gaussian in 3D") { testIsWideGaussiansMadePeriodic<3>(); }
+}
+
+SCENARIO("Given a GaussExp, can the Gaussians be made periodic?", "[periodic_gaussExp]") {
+    GIVEN("GaussExp in 1D") { testIsGaussExpMadePeriodic<1>(); }
+    GIVEN("GaussExp in 2D") { testIsGaussExpMadePeriodic<2>(); }
+    GIVEN("GaussExp in 3D") { testIsGaussExpMadePeriodic<3>(); }
+}
+
+template <int D> void testIsNarrowGaussiansMadePeriodic() {
+
+    auto beta = 1.0e4;
+    auto alpha = std::pow(beta / mrcpp::pi, D / 2.0);
+    double pos_data[3] = {-0.2, 0.5, 1.0};
+
+    auto period = std::array<double, D>{};
+    period.fill(2.0);
+
+    auto pos = mrcpp::details::convert_to_std_array<double, D>(pos_data);
+    auto new_pos = pos;
+    new_pos[0] += period[0]; // Zero is selected such that it will work inn 1, 2 and 3D
+
+    WHEN("The gaussian is generated it is constructed, it is not periodic") {
+        auto gauss = GaussFunc<D>(beta, alpha, pos);
+        REQUIRE(not isPeriodic<D>(gauss));
+        THEN("The Gaussian should be close to zero at the bondary of the unit cell") {
+            REQUIRE(gauss.evalf(new_pos) == Approx(0.0));
+        }
+        AND_WHEN("The gaussian is made periodc, it is periodic") {
+            gauss.makePeriodic(period);
+            REQUIRE(isPeriodic<D>(gauss));
+            THEN("The gaussian should have the same value at -0.2 and 1.8") {
+                REQUIRE(gauss.evalf(pos) == gauss.evalf(new_pos));
+            }
+        }
+    }
+}
+
+template <int D> void testIsWideGaussiansMadePeriodic() {
+
+    auto beta = 1.0;
+    auto alpha = std::pow(beta / mrcpp::pi, D / 2.0);
+    double pos_data[3] = {-0.2, 0.5, 1.0};
+
+    auto period = std::array<double, D>{};
+    period.fill(2.0);
+
+    auto pos = mrcpp::details::convert_to_std_array<double, D>(pos_data);
+    auto new_pos = pos;
+    new_pos[0] += period[0]; // Zero is selected such that it will work inn 1, 2 and 3D
+
+    WHEN("The gaussian is generated it is constructed, it is not periodic") {
+        auto gauss = GaussFunc<D>(beta, alpha, pos);
+        REQUIRE(not isPeriodic<D>(gauss));
+        THEN("The Gaussian should be close to zero at the bondary of the unit cell") {
+            REQUIRE(gauss.evalf(new_pos) != Approx(0.0));
+        }
+        AND_WHEN("The gaussian is made periodc, it is periodic") {
+            gauss.makePeriodic(period);
+            REQUIRE(isPeriodic<D>(gauss));
+            THEN("The gaussian should have the same value at -0.2 and 1.8") {
+                REQUIRE(gauss.evalf(pos) == Approx(gauss.evalf(new_pos)));
+            }
+        }
+    }
+}
+
+template <int D> void testIsGaussExpMadePeriodic() {
+
+    auto beta = 1.0e4;
+    auto alpha = std::pow(beta / mrcpp::pi, D / 2.0);
+    double pos_1_data[3] = {-0.2, 0.5, 1.0};
+    double pos_2_data[3] = {-0.1, 0.3, 1.2};
+
+    auto period = std::array<double, D>{};
+    period.fill(2.0);
+
+    auto pos_1 = mrcpp::details::convert_to_std_array<double, D>(pos_1_data);
+    auto pos_2 = mrcpp::details::convert_to_std_array<double, D>(pos_2_data);
+    auto gauss_1 = GaussFunc<D>(beta, alpha, pos_1);
+    auto gauss_2 = GaussFunc<D>(beta, alpha, pos_2);
+
+    auto gauss_exp = GaussExp<D>();
+    WHEN("The gaussians are added they are non-periodic") {
+        gauss_exp.append(gauss_1);
+        gauss_exp.append(gauss_2);
+        for (auto &func : gauss_exp) REQUIRE(not isPeriodic<D>(*func));
+
+        AND_WHEN("The gaussians are make periodic") {
+            gauss_exp.makePeriodic(period);
+            for (auto &func : gauss_exp) REQUIRE(isPeriodic<D>(*func));
+        }
+    }
+}
+
+} // namespace periodify_gaussians

--- a/tests/functions/periodify_gaussians.cpp
+++ b/tests/functions/periodify_gaussians.cpp
@@ -2,7 +2,7 @@
  * MRCPP, a numerical library based on multiresolution analysis and
  * the multiwavelet basis which provide low-scaling algorithms as well as
  * rigorous error control in numerical computations.
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
  *
  * This file is part of MRCPP.
  *

--- a/tests/treebuilders/build_grid.cpp
+++ b/tests/treebuilders/build_grid.cpp
@@ -43,10 +43,10 @@ SCENARIO("Building empty grids", "[build_grid], [tree_builder], [trees]") {
 
 template <int D> void testBuildGrid() {
     GaussFunc<D> *f_func = nullptr;
-    initialize(&f_func);
+    initialize<D>(&f_func);
 
     MultiResolutionAnalysis<D> *mra = nullptr;
-    initialize(&mra);
+    initialize<D>(&mra);
 
     WHEN("the GridGenerator is given no argument") {
         FunctionTree<D> f_tree(*mra);

--- a/tests/treebuilders/clear_grid.cpp
+++ b/tests/treebuilders/clear_grid.cpp
@@ -44,9 +44,9 @@ SCENARIO("Projected trees can be cleared and reused", "[clear_grid], [tree_build
 
 template <int D> void testClearGrid() {
     GaussFunc<D> *func = nullptr;
-    initialize(&func);
+    initialize<D>(&func);
     MultiResolutionAnalysis<D> *mra = nullptr;
-    initialize(&mra);
+    initialize<D>(&mra);
 
     const double prec = 1.0e-4;
     FunctionTree<D> tree(*mra);

--- a/tests/treebuilders/multiplication.cpp
+++ b/tests/treebuilders/multiplication.cpp
@@ -63,7 +63,7 @@ template <int D> void testMultiplication() {
     GaussPoly<D> ref_func = a_func * b_func;
 
     MultiResolutionAnalysis<D> *mra = nullptr;
-    initialize(&mra);
+    initialize<D>(&mra);
 
     // Initialize trees
     FunctionTree<D> a_tree(*mra);
@@ -133,7 +133,7 @@ template <int D> void testSquare() {
     GaussPoly<D> ref_func = f_func * f_func;
 
     MultiResolutionAnalysis<D> *mra = nullptr;
-    initialize(&mra);
+    initialize<D>(&mra);
 
     // Initialize trees
     FunctionTree<D> f_tree(*mra);
@@ -205,7 +205,7 @@ template <int D> void testSquare() {
 
 TEST_CASE("Dot product FunctionTreeVectors", "[multiplication], [tree_vector_dot]") {
     MultiResolutionAnalysis<3> *mra = nullptr;
-    initialize(&mra);
+    initialize<3>(&mra);
 
     double prec = 1.0e-4;
 


### PR DESCRIPTION
    Periodic Gaussians
    
    Gaussians can now be made semi-periodic around the
    unit-cell of a given period. When these are projected
    onto a function tree, they are true periodic functions
    where the integral of the Gaussian is conserved within
    the unit-cell.

To make the Gaussian semi-periodic use the method
`makePeriodic`. The same also works for `GaussExp`.


EDIT:

We can now specify periodicity arbitrarily in each direction, I need to add some 
tests, but preliminary results seem promising.


- [x] Ready for review