### PR TITLE
Disallow explicitly use of CMake user package registry

### DIFF
--- a/external/upstream/fetch_eigen3.cmake
+++ b/external/upstream/fetch_eigen3.cmake
@@ -1,10 +1,10 @@
-include(FetchContent)
-
-find_package(Eigen3 3.3 CONFIG QUIET)
+find_package(Eigen3 3.3 CONFIG QUIET NO_CMAKE_PACKAGE_REGISTRY)
 if(TARGET Eigen3::Eigen)
   message(STATUS "Using Eigen3: ${EIGEN3_ROOT_DIR} (version ${Eigen3_VERSION})")
 else()
   message(STATUS "Suitable Eigen3 could not be located. Fetching and building!")
+  include(FetchContent)
+
   FetchContent_Declare(eigen3_sources
     GIT_REPOSITORY
       https://github.com/eigenteam/eigen-git-mirror


### PR DESCRIPTION
Part of the fix (I hope!) for MRChemSoft/mrchem#232 

Eigen register itself to the global CMake user package registry (it's usually under `~/.cmake/packages`) which may confuse the superbuild.