### PR TITLE
Norm

### DIFF
--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -297,7 +297,7 @@ template <int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket) {
  * @param[in] bra Bra side input function
  * @param[in] ket Ket side input function
  *
- * If exact=true: the grid of bra and ket MUST be equal.
+ * If exact=true: the grid of ket MUST include the grid of bra.
  * If exact=false: does not at any time read the coefficients individually.
  * The product is done for the end nodes of the bra multiplied by the nodes from the
  * ket with either the same idx, or using a lower scale and assuming uniform
@@ -312,13 +312,13 @@ template <int D> double node_norm_dot(FunctionTree<D> &bra, FunctionTree<D> &ket
     double valB[ncoef];
     int nNodes = bra.getNEndNodes();
 
-    if (exact and nNodes != ket.getNEndNodes()) { MSG_ABORT("Trees must have same grid"); }
     for (int n = 0; n < nNodes; n++) {
         FunctionNode<D> &node = bra.getEndFuncNode(n);
         const NodeIndex<D> idx = node.getNodeIndex();
-        FunctionNode<D> *mwNode = static_cast<FunctionNode<D> *>(ket.findNode(idx));
         if (exact) {
             // convert to interpolating coef, take abs, convert back
+            FunctionNode<D> *mwNode = static_cast<FunctionNode<D> *>(ket.findNode(idx));
+            if (mwNode == nullptr) { MSG_ABORT("Trees must have same grid"); }
             node.getAbsCoefs(valA);
             mwNode->getAbsCoefs(valB);
             for (int i = 0; i < ncoef; i++) result += valA[i] * valB[i];

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -23,6 +23,7 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
+#include <Eigen/Core>
 #include "multiply.h"
 #include "MultiplicationCalculator.h"
 #include "PowerCalculator.h"
@@ -32,6 +33,7 @@
 #include "add.h"
 #include "grid.h"
 #include "trees/FunctionNode.h"
+#include "trees/SerialFunctionTree.h"
 #include "trees/FunctionTree.h"
 #include "trees/HilbertIterator.h"
 #include "utils/Printer.h"
@@ -290,6 +292,47 @@ template <int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket) {
     return result;
 }
 
+/** @brief abs-dot product of two MW function representations
+ *
+ * @param[in] bra Bra side input function
+ * @param[in] ket Ket side input function
+ *
+ * If exact=false: does not at any time read the coefficients individually.
+ * The product is done for the end nodes of the bra multiplied by the nodes from the
+ * ket with either the same idx, or using a lower scale and assuming uniform
+ * distribution within the node. If the product is zero, the functions are disjoints.
+ */
+template <int D> double node_norm_dot(FunctionTree<D> &bra, FunctionTree<D> &ket, bool exact) {
+
+    double result = 0.0;
+    int ncoef=bra.getKp1_d()*bra.getTDim();
+    double valA[ncoef];
+    double valB[ncoef];
+    int nNodes = bra.getNEndNodes();
+
+    if (exact and nNodes != ket.getNEndNodes()) { MSG_ABORT("Trees must have same grid"); }
+    for (int n = 0; n < nNodes; n++) {
+        FunctionNode<D> &node = bra.getEndFuncNode(n);
+        const NodeIndex<D> idx = node.getNodeIndex();
+        FunctionNode<D> *mwNode = (FunctionNode<D> *)ket.findNode(idx);
+        if(exact){
+            //convert to interpolating coef, take abs, convert back
+            node.getAbsCoefs(valA);
+            mwNode->getAbsCoefs(valB);
+            for (int i = 0; i < ncoef; i++)  result += valA[i] * valB[i];
+        } else {
+            //approximate by product of node norms
+            int rIdx = ket.getRootBox().getBoxIndex(idx);
+            assert(rIdx >= 0);
+            const MWNode<D> &root = ket.getRootBox().getNode(rIdx);
+            result+=sqrt(node.getSquareNorm())* root.getNodeNorm(idx);
+        }
+    }
+
+    return result;
+
+}
+
 template void multiply(double prec,
                        FunctionTree<1> &out,
                        double c,
@@ -335,5 +378,9 @@ template void dot(double prec,
 template double dot(FunctionTree<1> &bra, FunctionTree<1> &ket);
 template double dot(FunctionTree<2> &bra, FunctionTree<2> &ket);
 template double dot(FunctionTree<3> &bra, FunctionTree<3> &ket);
+
+template double node_norm_dot(FunctionTree<1> &bra, FunctionTree<1> &ket, bool exact);
+template double node_norm_dot(FunctionTree<2> &bra, FunctionTree<2> &ket, bool exact);
+template double node_norm_dot(FunctionTree<3> &bra, FunctionTree<3> &ket, bool exact);
 
 } // namespace mrcpp

--- a/src/treebuilders/multiply.h
+++ b/src/treebuilders/multiply.h
@@ -48,5 +48,6 @@ void dot(double prec,
          FunctionTreeVector<D> &inp_b,
          int maxIter = -1);
 template <int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket);
+template <int D> double node_norm_dot(FunctionTree<D> &bra, FunctionTree<D> &ket, bool exact = false);
 
 } // namespace mrcpp

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -178,6 +178,21 @@ template <int D> void FunctionNode<D>::getValues(VectorXd &vec) {
     this->mwTransform(Compression);
 }
 
+/** get coefficients corresponding to absolute value of function
+ *
+ * Leaves the original coefficients unchanged. */
+template <int D> void FunctionNode<D>::getAbsCoefs(double* absCoefs) {
+    double *coefsTmp = this->coefs;
+    for (int i = 0; i < this->n_coefs; i++) { absCoefs[i]=coefsTmp[i];}//copy
+    this->coefs = absCoefs;//swap coefs
+    this->mwTransform(Reconstruction);
+    this->cvTransform(Forward);
+    for (int i = 0; i < this->n_coefs; i++) {  this->coefs[i] = abs(this->coefs[i]); }
+    this->cvTransform(Backward);
+    this->mwTransform(Compression);
+    this->coefs = coefsTmp;//restore original array (same address)
+}
+
 /** Inner product of the functions represented by the scaling basis of the nodes.
  *
  * Integrates the product of the functions represented by the scaling basis on

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -181,16 +181,16 @@ template <int D> void FunctionNode<D>::getValues(VectorXd &vec) {
 /** get coefficients corresponding to absolute value of function
  *
  * Leaves the original coefficients unchanged. */
-template <int D> void FunctionNode<D>::getAbsCoefs(double* absCoefs) {
+template <int D> void FunctionNode<D>::getAbsCoefs(double *absCoefs) {
     double *coefsTmp = this->coefs;
-    for (int i = 0; i < this->n_coefs; i++) { absCoefs[i]=coefsTmp[i];}//copy
-    this->coefs = absCoefs;//swap coefs
+    for (int i = 0; i < this->n_coefs; i++) { absCoefs[i] = coefsTmp[i]; } // copy
+    this->coefs = absCoefs;                                                // swap coefs
     this->mwTransform(Reconstruction);
     this->cvTransform(Forward);
-    for (int i = 0; i < this->n_coefs; i++) {  this->coefs[i] = abs(this->coefs[i]); }
+    for (int i = 0; i < this->n_coefs; i++) { this->coefs[i] = std::abs(this->coefs[i]); }
     this->cvTransform(Backward);
     this->mwTransform(Compression);
-    this->coefs = coefsTmp;//restore original array (same address)
+    this->coefs = coefsTmp; // restore original array (same address)
 }
 
 /** Inner product of the functions represented by the scaling basis of the nodes.

--- a/src/trees/FunctionNode.h
+++ b/src/trees/FunctionNode.h
@@ -46,7 +46,7 @@ public:
 
     virtual void setValues(const Eigen::VectorXd &vec);
     virtual void getValues(Eigen::VectorXd &vec);
-    virtual void getAbsCoefs(double* absCoefs);
+    virtual void getAbsCoefs(double *absCoefs);
 
     friend class FunctionTree<D>;
 

--- a/src/trees/FunctionNode.h
+++ b/src/trees/FunctionNode.h
@@ -46,6 +46,7 @@ public:
 
     virtual void setValues(const Eigen::VectorXd &vec);
     virtual void getValues(Eigen::VectorXd &vec);
+    virtual void getAbsCoefs(double* absCoefs);
 
     friend class FunctionTree<D>;
 

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -426,6 +426,7 @@ template <int D> void FunctionTree<D>::printSerialIndices() {
     int n = 0;
     for (int iChunk = 0; iChunk < sTree.getNChunks(); iChunk++) {
         int iShift = iChunk * sTree.maxNodesPerChunk;
+        printout(0, "new chunk \n");
         for (int i = 0; i < sTree.maxNodesPerChunk; i++) {
             int status = sTree.nodeStackStatus[iShift + i];
             int sIdx = sTree.nodeChunks[iChunk][i].serialIx;

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -911,11 +911,11 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNode(const NodeIndex<D> &idx) {
 template <int D> double MWNode<D>::getNodeNorm(const NodeIndex<D> &idx) const {
     if (this->getScale() == idx.getScale()) { // we're done
         assert(getNodeIndex() == idx);
-        return sqrt(this->squareNorm);
+        return std::sqrt(this->squareNorm);
     }
     assert(isAncestor(idx));
     if (this->isEndNode()) { // we infer norm at lower scales
-        return sqrt(this->squareNorm * std::pow(2.0,-D*(idx.getScale() - getScale())));
+        return std::sqrt(this->squareNorm * std::pow(2.0, -D * (idx.getScale() - getScale())));
     }
     int cIdx = getChildIndex(idx);
     assert(this->children[cIdx] != nullptr);

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -903,6 +903,25 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNode(const NodeIndex<D> &idx) {
     return this->children[cIdx]->retrieveNode(idx);
 }
 
+/** Gives the norm (absolute value) of the node at the given NodeIndex.
+ *
+ * Recursive routine to find the node with a given NodeIndex. When an EndNode is
+ * found, do not generate any new node, but rather give the value of the norm
+ * assuming the function is uniformly distributed within the node. */
+template <int D> double MWNode<D>::getNodeNorm(const NodeIndex<D> &idx) const {
+    if (this->getScale() == idx.getScale()) { // we're done
+        assert(getNodeIndex() == idx);
+        return sqrt(this->squareNorm);
+    }
+    assert(isAncestor(idx));
+    if (this->isEndNode()) { // we infer norm at lower scales
+        return sqrt(this->squareNorm * std::pow(2.0,-D*(idx.getScale() - getScale())));
+    }
+    int cIdx = getChildIndex(idx);
+    assert(this->children[cIdx] != nullptr);
+    return this->children[cIdx]->getNodeNorm(idx);
+}
+
 /** Test if a given coordinate is within the boundaries of the node. */
 template <int D> bool MWNode<D>::hasCoord(const Coord<D> &r) const {
     double sFac = std::pow(2.0, -getScale());

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -125,6 +125,8 @@ public:
 
     bool splitCheck(double prec, double splitFac, bool absPrec) const;
 
+    double getNodeNorm(const NodeIndex<D> &idx) const;
+
     void setHasCoefs() { SET_BITS(status, FlagHasCoefs | FlagAllocated); }
     void setIsEndNode() { SET_BITS(status, FlagEndNode); }
     void setIsGenNode() { SET_BITS(status, FlagGenNode); }

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -67,8 +67,8 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *m
         this->maxNodesPerChunk = (sizePerChunk / this->sizeNodeCoeff / sizeof(double) / 8) * 8;
     }
 
-    this->lastNode = (ProjectedNode<D> *)this->sNodes; // position of last allocated node
-    this->lastGenNode = this->sGenNodes;               // position of last allocated Gen node
+    this->lastNode = (ProjectedNode<D> *)this->sNodes; // position just after last allocated node, i.e. where to put next node
+    this->lastGenNode = this->sGenNodes;               // position just after last allocated Gen node, i.e. where to put next node
 
     // make virtual table pointers
     auto *tmpNode = new ProjectedNode<D>();
@@ -621,8 +621,8 @@ template <int D> void SerialFunctionTree<D>::rewritePointers() {
         }
         this->nodeStackStatus[node->serialIx] = 1; // occupied
     }
-    int ichunk = (this->nNodes - 1) / this->maxNodesPerChunk;
-    int inode = (this->nNodes - 1) % this->maxNodesPerChunk;
+    int ichunk = this->nNodes / this->maxNodesPerChunk;
+    int inode = this->nNodes % this->maxNodesPerChunk;
     this->lastNode = this->nodeChunks[ichunk] + inode;
 }
 

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -67,8 +67,9 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *m
         this->maxNodesPerChunk = (sizePerChunk / this->sizeNodeCoeff / sizeof(double) / 8) * 8;
     }
 
-    this->lastNode = (ProjectedNode<D> *)this->sNodes; // position just after last allocated node, i.e. where to put next node
-    this->lastGenNode = this->sGenNodes;               // position just after last allocated Gen node, i.e. where to put next node
+    this->lastNode = // position just after last allocated node, i.e. where to put next node
+        static_cast<ProjectedNode<D> *>(this->sNodes);
+    this->lastGenNode = this->sGenNodes;  // position just after last allocated Gen node, i.e. where to put next node
 
     // make virtual table pointers
     auto *tmpNode = new ProjectedNode<D>();

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -69,7 +69,7 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *m
 
     this->lastNode = // position just after last allocated node, i.e. where to put next node
         static_cast<ProjectedNode<D> *>(this->sNodes);
-    this->lastGenNode = this->sGenNodes;  // position just after last allocated Gen node, i.e. where to put next node
+    this->lastGenNode = this->sGenNodes; // position just after last allocated Gen node, i.e. where to put next node
 
     // make virtual table pointers
     auto *tmpNode = new ProjectedNode<D>();

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -87,8 +87,8 @@ protected:
     char *cvptr_ProjectedNode; // virtual table pointer for ProjectedNode
     char *cvptr_GenNode;       // virtual table pointer for GenNode
 
-    ProjectedNode<D> *lastNode; // pointer to the last active node
-    GenNode<D> *lastGenNode;    // pointer to the last active Gen node
+    ProjectedNode<D> *lastNode; // pointer just after the last active node, i.e. where to put next node
+    GenNode<D> *lastGenNode;    // pointer just after the last active Gen node, i.e. where to put next node
 
     ProjectedNode<D> *allocNodes(int nAlloc, int *serialIx, double **coefs_p);
     GenNode<D> *allocGenNodes(int nAlloc, int *serialIx, double **coefs_p);


### PR DESCRIPTION
Contain a bug fix. The "lastNode" was wrongly defined in rewritepointers. Important only when a tree is first received through MPI, then nodes are added, (which is not done normally).

Also routines used for calculation of norms, and product of norm of two functions.

Everything ready to merge. Will not change behaviour of established things.