### PR TITLE
MRCPP filter dir can now be specified by export

### DIFF
--- a/src/core/FilterCache.cpp
+++ b/src/core/FilterCache.cpp
@@ -53,7 +53,13 @@ template <int T> FilterCache<T>::FilterCache() {
         default:
             MSG_ERROR("Invalid filter type: " << T);
     }
-    this->libPath = MWFilter::getDefaultLibrary();
+    auto ep = getenv("MRCPP_FILTER_DIR");
+    auto ep_lib = ep != nullptr ? std::string(ep) : "";
+    if (ep_lib.empty()) {
+        this->libPath = MWFilter::getDefaultLibrary();
+    } else {
+        this->libPath = ep_lib;
+    }
 }
 
 template <int T> void FilterCache<T>::load(int order) {

--- a/src/core/MWFilter.cpp
+++ b/src/core/MWFilter.cpp
@@ -58,8 +58,6 @@ MWFilter::MWFilter(int k, int t, const std::string &lib)
         default:
             MSG_ERROR("Unknown filter type: " << this->type);
     }
-    char *ep = getenv("MRCPP_FILTER_DIR");
-    if (ep != nullptr) { default_filter_lib = *ep; }
     int K = this->order + 1;
     setFilterPaths(lib);
 
@@ -192,21 +190,15 @@ void MWFilter::setFilterPaths(const std::string &lib) {
     std::ostringstream oss;
     oss << this->order;
     std::string ordr = oss.str();
-    std::string flib;
 
-    if (lib.empty()) {
-        flib = default_filter_lib;
-    } else {
-        flib = lib;
-    }
     switch (this->type) {
         case (Interpol):
-            this->H_path = flib + "/I_H0_" + ordr;
-            this->G_path = flib + "/I_G0_" + ordr;
+            this->H_path = lib + "/I_H0_" + ordr;
+            this->G_path = lib + "/I_G0_" + ordr;
             break;
         case (Legendre):
-            this->H_path = flib + "/L_H0_" + ordr;
-            this->G_path = flib + "/L_G0_" + ordr;
+            this->H_path = lib + "/L_H0_" + ordr;
+            this->G_path = lib + "/L_G0_" + ordr;
             break;
         default:
             MSG_ABORT("Invalid filter type " << this->type);


### PR DESCRIPTION
Now the `mwfilter` directory can be set by the environment variable `MW_FILTER_DIR`. 
This is useful for our conda packaging of `mrcpp`. 

If this variable is not set, the directory is set to the `default`. 

So the current order of priority is:

1. If environment variable is set, use that 
2. Go for default

I think it could be useful for users of the library should be able to specify this,
if so we should set the order of priority to

1. Code defined path to `MW_FILTER_DIR`
2. If environment variable is set, use that
3. Go for default

 