### PR TITLE
Make build from zip or tar.gz work when Git is around

### DIFF
--- a/cmake/custom/git.cmake
+++ b/cmake/custom/git.cmake
@@ -1,13 +1,14 @@
-set(GIT_REVISION)
+set(GIT_REVISION "undefined")
 find_package(Git)
 
 if(GIT_FOUND)
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} rev-list --abbrev-commit --max-count=1 HEAD
-        OUTPUT_VARIABLE GIT_REVISION
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        )
-    string(STRIP
-        ${GIT_REVISION}
-        GIT_REVISION)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-list --abbrev-commit --max-count=1 HEAD
+    OUTPUT_VARIABLE _git_revision
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+  string(STRIP ${_git_revision} _git_revision)
+  if(_git_revision)
+    set(GIT_REVISION ${_git_revision})
+  endif()
 endif()

--- a/cmake/custom/git.cmake
+++ b/cmake/custom/git.cmake
@@ -1,14 +1,13 @@
 set(GIT_REVISION "undefined")
-find_package(Git)
-
+find_package(Git QUIET)
 if(GIT_FOUND)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} rev-list --abbrev-commit --max-count=1 HEAD
     OUTPUT_VARIABLE _git_revision
+    ERROR_QUIET
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
-  string(STRIP ${_git_revision} _git_revision)
   if(_git_revision)
-    set(GIT_REVISION ${_git_revision})
+    string(STRIP ${_git_revision} GIT_REVISION)
   endif()
 endif()


### PR DESCRIPTION
If Git is around but we're not building from the repo, CMake will panic on the `STRIP` command.  This is a quick fix.