### PR TITLE
Overload operator<< for std::array<T, D>

### DIFF
--- a/src/utils/details.cpp
+++ b/src/utils/details.cpp
@@ -23,6 +23,8 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
+#include "details.h"
+
 #include <algorithm>
 #include <array>
 

--- a/src/utils/details.h
+++ b/src/utils/details.h
@@ -46,15 +46,7 @@ template <typename T> auto stream_collection(const T &coll) -> std::string {
 }
 } // namespace details
 
-template <typename T> auto operator<<(std::ostream &os, const std::array<T, 1> &coll) -> std::ostream & {
-    return (os << details::stream_collection(coll));
-}
-
-template <typename T> auto operator<<(std::ostream &os, const std::array<T, 2> &coll) -> std::ostream & {
-    return (os << details::stream_collection(coll));
-}
-
-template <typename T> auto operator<<(std::ostream &os, const std::array<T, 3> &coll) -> std::ostream & {
+template <typename T, size_t D> auto operator<<(std::ostream &os, const std::array<T, D> &coll) -> std::ostream & {
     return (os << details::stream_collection(coll));
 }
 } // namespace mrcpp

--- a/src/utils/details.h
+++ b/src/utils/details.h
@@ -23,23 +23,38 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
+#pragma once
+
 #include <array>
 #include <iostream>
+#include <sstream>
 
 namespace mrcpp {
- 
-template <typename T, int D> inline auto operator<<(std::ostream &os, const std::array<T, D> &coord) -> std::ostream & {
-    os << "[";
-    for (auto elem : coord) { os << elem << ", "; }
-    os << "]";
-    return os;
-}
-  
 namespace details {
-
 int get_memory_usage();
 template <int D> bool are_all_equal(const std::array<double, D> &exponent);
 template <typename T, int D> std::array<T, D> convert_to_std_array(T *arr);
-
+template <typename T> auto stream_collection(const T &coll) -> std::string {
+    std::ostringstream os;
+    os << "[";
+    for (auto elem : coll) {
+        os << elem;
+        if (elem != coll.back()) os << ", ";
+    }
+    os << "]";
+    return os.str();
+}
 } // namespace details
+
+template <typename T> auto operator<<(std::ostream &os, const std::array<T, 1> &coll) -> std::ostream & {
+    return (os << details::stream_collection(coll));
+}
+
+template <typename T> auto operator<<(std::ostream &os, const std::array<T, 2> &coll) -> std::ostream & {
+    return (os << details::stream_collection(coll));
+}
+
+template <typename T> auto operator<<(std::ostream &os, const std::array<T, 3> &coll) -> std::ostream & {
+    return (os << details::stream_collection(coll));
+}
 } // namespace mrcpp

--- a/src/utils/details.h
+++ b/src/utils/details.h
@@ -23,7 +23,18 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
+#include <array>
+#include <iostream>
+
 namespace mrcpp {
+ 
+template <typename T, int D> inline auto operator<<(std::ostream &os, const std::array<T, D> &coord) -> std::ostream & {
+    os << "[";
+    for (auto elem : coord) { os << elem << ", "; }
+    os << "]";
+    return os;
+}
+  
 namespace details {
 
 int get_memory_usage();


### PR DESCRIPTION
This will print the array as `[el0, el1, el2, .., elN]` and is useful to print `Coord<D>` directly.