### PR TITLE
Regenerate git info

### DIFF
--- a/cmake/custom/binary-info.cmake
+++ b/cmake/custom/binary-info.cmake
@@ -48,11 +48,10 @@ if(GIT_FOUND)
     )
 endif()
 
-message(STATUS "Git last commit hash: ${_git_last_commit_hash}")
+message(STATUS "Git branch: ${_git_branch}")
+message(STATUS "Git last commit hash: ${_git_describe}")
 message(STATUS "Git last commit author: ${_git_last_commit_author}")
 message(STATUS "Git last commit date: ${_git_last_commit_date}")
-message(STATUS "Git branch: ${_git_branch}")
-message(STATUS "Git description of commit: ${_git_describe}")
 
 cmake_host_system_information(RESULT _hostname QUERY HOSTNAME)
 
@@ -76,7 +75,7 @@ string(STRIP "${PROGRAM_VERSION}" PROGRAM_VERSION)
 
 # generate file
 configure_file(
-  ${INPUT_DIR}/config.h.in
-  ${TARGET_DIR}/config.h
+  ${INPUT_DIR}/version.h.in
+  ${TARGET_DIR}/version.h
   @ONLY
   )

--- a/cmake/custom/main.cmake
+++ b/cmake/custom/main.cmake
@@ -7,9 +7,15 @@ set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}")
 
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 
+configure_file(
+  ${PROJECT_SOURCE_DIR}/config.h.in
+  ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h
+  @ONLY
+  )
+
 add_custom_command(
   OUTPUT
-    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h
+    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/version.h
   COMMAND
     ${CMAKE_COMMAND} -DINPUT_DIR=${PROJECT_SOURCE_DIR}
                      -DTARGET_DIR=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
@@ -24,9 +30,9 @@ add_custom_command(
                      -DMW_FILTER_INSTALL_DIR=${MW_FILTER_INSTALL_DIR}
                      -P ${CMAKE_CURRENT_LIST_DIR}/binary-info.cmake
   DEPENDS
-    ${PROJECT_SOURCE_DIR}/config.h.in
+    ${PROJECT_SOURCE_DIR}/version.h.in
   BYPRODUCTS
-    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h
+    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/version.h
   WORKING_DIRECTORY
     ${CMAKE_CURRENT_LIST_DIR}
   )
@@ -35,16 +41,24 @@ add_custom_command(
 add_custom_target(
   binary-info
   ALL
+  COMMAND
+    touch ${PROJECT_SOURCE_DIR}/version.h.in
   DEPENDS
-    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h
+    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/version.h
   )
+
 # See here for the reason why: https://gitlab.kitware.com/cmake/cmake/issues/18399
 set_source_files_properties(${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h
   PROPERTIES
     GENERATED 1
   )
+set_source_files_properties(${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/version.h
+  PROPERTIES
+    GENERATED 1
+  )
 
 list(APPEND mrcpp_headers ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h)
+list(APPEND mrcpp_headers ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/version.h)
 
 include(${PROJECT_SOURCE_DIR}/external/upstream/fetch_eigen3.cmake)
 

--- a/cmake/custom/main.cmake
+++ b/cmake/custom/main.cmake
@@ -48,10 +48,6 @@ add_custom_target(
   )
 
 # See here for the reason why: https://gitlab.kitware.com/cmake/cmake/issues/18399
-set_source_files_properties(${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/config.h
-  PROPERTIES
-    GENERATED 1
-  )
 set_source_files_properties(${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/version.h
   PROPERTIES
     GENERATED 1

--- a/src/utils/Printer.cpp
+++ b/src/utils/Printer.cpp
@@ -26,6 +26,7 @@
 #include <fstream>
 
 #include "MRCPP/config.h"
+#include "MRCPP/version.h"
 
 #include "Printer.h"
 #include "Timer.h"

--- a/version.h.in
+++ b/version.h.in
@@ -26,17 +26,27 @@
 #pragma once
 
 namespace mrcpp {
-inline constexpr auto mwfilters_source_dir() noexcept {
-  return "@MW_FILTER_SOURCE_DIR@";
+inline constexpr auto program_version() noexcept {
+  return "@PROGRAM_VERSION@";
 }
 
-inline constexpr auto mwfilters_install_dir() noexcept {
-  return "@MW_FILTER_INSTALL_DIR@";
+inline constexpr auto git_describe() noexcept {
+  return "@_git_describe@";
+}
+
+inline constexpr auto git_commit_hash() noexcept {
+  return "@_git_last_commit_hash@";
+}
+
+inline constexpr auto git_commit_author() noexcept {
+  return "@_git_last_commit_author@";
+}
+
+inline constexpr auto git_commit_date() noexcept {
+  return "@_git_last_commit_date@";
+}
+
+inline constexpr auto git_branch() noexcept {
+  return "@_git_branch@";
 }
 } // namespace mrcpp
-
-#define BLAS_H "@BLAS_H@"
-
-#cmakedefine HAVE_MPI
-
-#cmakedefine HAVE_BLAS


### PR DESCRIPTION
I made a new `version.h.in` file with the `git` info alongside the old `config.h.in`. The `version.h` file is updated every time we run `make`, but it is only included by `Printer.cpp` so it doesn't trigger a complete rebuild as the old `config.h` file did.

Not sure if the naming is appropriate, or if the configure step of `config.h.in` is correct. I went back to the old and simple configure for this file.