### PR TITLE
Variable prec

### DIFF
--- a/examples/multiplication.cpp
+++ b/examples/multiplication.cpp
@@ -9,7 +9,7 @@ const auto min_scale = -4;
 const auto max_depth = 25;
 
 const auto order = 7;
-const auto prec = 1.0e-5;
+const auto prec = 1.0e-3;
 
 const auto D = 3;
 
@@ -34,28 +34,57 @@ int main(int argc, char **argv) {
     // Setting up analytic Gaussians
     auto beta = 20.0;
     auto alpha = std::pow(beta / mrcpp::pi, 3.0 / 2.0);
-    auto f_pos = mrcpp::Coord<D>{0.0, 0.0, 0.1};
+    auto f_pos = mrcpp::Coord<D>{0.0, 0.0, 0.17};
     auto g_pos = mrcpp::Coord<D>{0.0, 0.0, -0.1};
     auto power = std::array<int, D>{0, 0, 0};
     auto f_func = mrcpp::GaussFunc<D>(beta, alpha, f_pos, power);
     auto g_func = mrcpp::GaussFunc<D>(beta, alpha, g_pos, power);
 
+    // analytic product of two gaussians
+    auto prod_pos =   mrcpp::Coord<D>{};
+    auto beta_prod = beta*2;
+    auto dist_2 = 0.0;
+    for (int i=0;i< D;i++){
+        dist_2 += (f_pos[i]-g_pos[i])*(f_pos[i]-g_pos[i]);//dot product of coordinate diff
+        prod_pos[i] = 0.5*(f_pos[i]+g_pos[i]);
+    }
+    auto alpha_prod = alpha*alpha*exp(-beta*0.5*dist_2);
+    auto prod_func = mrcpp::GaussFunc<D>(beta_prod, alpha_prod, prod_pos, power);
+
     // Initialize MW functions
     mrcpp::FunctionTree<D> f_tree(MRA);
     mrcpp::FunctionTree<D> g_tree(MRA);
     mrcpp::FunctionTree<D> h_tree(MRA);
+    mrcpp::FunctionTree<D> h2_tree(MRA);
+    mrcpp::FunctionTree<D> prod_tree(MRA);
 
     // Projecting f and g
     mrcpp::project<D>(prec, f_tree, f_func);
     mrcpp::project<D>(prec, g_tree, g_func);
+    mrcpp::project<D>(prec/1000, prod_tree, prod_func);
 
     // h = f*g
     mrcpp::multiply(prec, h_tree, 1.0, f_tree, g_tree);
+    mrcpp::multiply(prec, h2_tree, 1.0, f_tree, g_tree, -1, true, true);
 
     auto integral = h_tree.integrate();
     auto sq_norm = h_tree.getSquareNorm();
-    mrcpp::print::value(0, "Integral", integral);
-    mrcpp::print::value(0, "Square norm", sq_norm);
+    mrcpp::print::value(0, "Integral method 1", integral);
+    mrcpp::print::value(0, "Square norm method 1", sq_norm);
+
+    integral = h2_tree.integrate();
+    sq_norm = h2_tree.getSquareNorm();
+    mrcpp::print::value(0, "Integral method 2", integral);
+    mrcpp::print::value(0, "Square norm method 2", sq_norm);
+
+    h_tree.add(-1.0,prod_tree);
+    sq_norm = h_tree.getSquareNorm();
+    mrcpp::print::value(0, "Square norm error method 1" , sq_norm);
+    h2_tree.add(-1.0,prod_tree);
+    sq_norm = h2_tree.getSquareNorm();
+    mrcpp::print::value(0, "Square norm error method 2" , sq_norm);
+
+
     mrcpp::print::footer(0, timer, 2);
 
     return 0;

--- a/examples/multiplication.cpp
+++ b/examples/multiplication.cpp
@@ -41,14 +41,14 @@ int main(int argc, char **argv) {
     auto g_func = mrcpp::GaussFunc<D>(beta, alpha, g_pos, power);
 
     // analytic product of two gaussians
-    auto prod_pos =   mrcpp::Coord<D>{};
-    auto beta_prod = beta*2;
+    auto prod_pos = mrcpp::Coord<D>{};
+    auto beta_prod = beta * 2;
     auto dist_2 = 0.0;
-    for (int i=0;i< D;i++){
-        dist_2 += (f_pos[i]-g_pos[i])*(f_pos[i]-g_pos[i]);//dot product of coordinate diff
-        prod_pos[i] = 0.5*(f_pos[i]+g_pos[i]);
+    for (int i = 0; i < D; i++) {
+        dist_2 += (f_pos[i] - g_pos[i]) * (f_pos[i] - g_pos[i]); // dot product of coordinate diff
+        prod_pos[i] = 0.5 * (f_pos[i] + g_pos[i]);
     }
-    auto alpha_prod = alpha*alpha*exp(-beta*0.5*dist_2);
+    auto alpha_prod = alpha * alpha * exp(-beta * 0.5 * dist_2);
     auto prod_func = mrcpp::GaussFunc<D>(beta_prod, alpha_prod, prod_pos, power);
 
     // Initialize MW functions
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
     // Projecting f and g
     mrcpp::project<D>(prec, f_tree, f_func);
     mrcpp::project<D>(prec, g_tree, g_func);
-    mrcpp::project<D>(prec/1000, prod_tree, prod_func);
+    mrcpp::project<D>(prec / 1000, prod_tree, prod_func);
 
     // h = f*g
     mrcpp::multiply(prec, h_tree, 1.0, f_tree, g_tree);
@@ -77,13 +77,12 @@ int main(int argc, char **argv) {
     mrcpp::print::value(0, "Integral method 2", integral);
     mrcpp::print::value(0, "Square norm method 2", sq_norm);
 
-    h_tree.add(-1.0,prod_tree);
+    h_tree.add(-1.0, prod_tree);
     sq_norm = h_tree.getSquareNorm();
-    mrcpp::print::value(0, "Square norm error method 1" , sq_norm);
-    h2_tree.add(-1.0,prod_tree);
+    mrcpp::print::value(0, "Square norm error method 1", sq_norm);
+    h2_tree.add(-1.0, prod_tree);
     sq_norm = h2_tree.getSquareNorm();
-    mrcpp::print::value(0, "Square norm error method 2" , sq_norm);
-
+    mrcpp::print::value(0, "Square norm error method 2", sq_norm);
 
     mrcpp::print::footer(0, timer, 2);
 

--- a/examples/poisson.cpp
+++ b/examples/poisson.cpp
@@ -61,14 +61,16 @@ int main(int argc, char **argv) {
 
     mrcpp::FunctionTree<D> p_tree(MRA);
     mrcpp::project<D>(prec, p_tree, p_func);
-
+    std::vector<mrcpp::FunctionTree<D> *> p_trees;
+    p_trees.push_back(&p_tree);
+    mrcpp::print::memory(0, "used memory post project p_func");
     // Applying Poisson operator
     auto t2 = mrcpp::Timer();
     mrcpp::print::separator(0, ' ');
     mrcpp::print::memory(0, "used memory pre apply");
     mrcpp::FunctionTree<D> g_tree(MRA);
     //mrcpp::apply(prec, g_tree, P, f_tree);
-    mrcpp::apply(1.0*prec, g_tree, P, f_tree, p_tree);
+    mrcpp::apply(1.0*prec, g_tree, P, f_tree, p_trees,-1,true);
     mrcpp::print::memory(0, "used memory post apply");
     t2.stop();
 

--- a/examples/poisson.cpp
+++ b/examples/poisson.cpp
@@ -55,9 +55,7 @@ int main(int argc, char **argv) {
     mrcpp::print::memory(0, "used memory post project");
     t1.stop();
 
-    auto p_func = [](const mrcpp::Coord<D> &r) -> double {
-        return 1.0e+2;
-    };
+    auto p_func = [](const mrcpp::Coord<D> &r) -> double { return 1.0e+2; };
 
     mrcpp::FunctionTree<D> p_tree(MRA);
     mrcpp::project<D>(prec, p_tree, p_func);
@@ -69,8 +67,8 @@ int main(int argc, char **argv) {
     mrcpp::print::separator(0, ' ');
     mrcpp::print::memory(0, "used memory pre apply");
     mrcpp::FunctionTree<D> g_tree(MRA);
-    //mrcpp::apply(prec, g_tree, P, f_tree);
-    mrcpp::apply(1.0*prec, g_tree, P, f_tree, p_trees,-1,true);
+    // mrcpp::apply(prec, g_tree, P, f_tree);
+    mrcpp::apply(1.0 * prec, g_tree, P, f_tree, p_trees, -1, true);
     mrcpp::print::memory(0, "used memory post apply");
     t2.stop();
 

--- a/examples/poisson.cpp
+++ b/examples/poisson.cpp
@@ -55,12 +55,20 @@ int main(int argc, char **argv) {
     mrcpp::print::memory(0, "used memory post project");
     t1.stop();
 
+    auto p_func = [](const mrcpp::Coord<D> &r) -> double {
+        return 1.0e+2;
+    };
+
+    mrcpp::FunctionTree<D> p_tree(MRA);
+    mrcpp::project<D>(prec, p_tree, p_func);
+
     // Applying Poisson operator
     auto t2 = mrcpp::Timer();
     mrcpp::print::separator(0, ' ');
     mrcpp::print::memory(0, "used memory pre apply");
     mrcpp::FunctionTree<D> g_tree(MRA);
-    mrcpp::apply(prec, g_tree, P, f_tree);
+    //mrcpp::apply(prec, g_tree, P, f_tree);
+    mrcpp::apply(1.0*prec, g_tree, P, f_tree, p_tree);
     mrcpp::print::memory(0, "used memory post apply");
     t2.stop();
 

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -221,17 +221,17 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
     if (gThrs > 0.0) {
         auto nTerms = (double)this->oper->size();
         auto precNorm = 1.0;
-        if(this->precTrees.size() >0) precNorm = 0.0;//initialize
+        if (this->precTrees.size() > 0) precNorm = 0.0; // initialize
         for (int i = 0; i < this->precTrees.size(); i++) {
             auto &pNode = precTrees[i]->getNode(node.getNodeIndex());
             auto n = node.getScale();
-            if(pNode.getMaxSquareNorm()>0.0){
+            if (pNode.getMaxSquareNorm() > 0.0) {
                 precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
-            }else{
+            } else {
                 precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
             }
-	}
-	gThrs = this->prec / precNorm * std::sqrt(gThrs / nTerms);
+        }
+        gThrs = this->prec / precNorm * std::sqrt(gThrs / nTerms);
     }
 
     os.gThreshold = gThrs;

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -220,7 +220,13 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
     double gThrs = gTree.getSquareNorm();
     if (gThrs > 0.0) {
         auto nTerms = (double)this->oper->size();
-        gThrs = this->prec * std::sqrt(gThrs / nTerms);
+        auto precNorm = 1.0;
+        if (this->precTree != nullptr) {
+            auto &pNode = precTree->getNode(node.getNodeIndex());
+            auto n = node.getScale();
+            precNorm = std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm());
+        }
+        gThrs = this->prec / precNorm * std::sqrt(gThrs / nTerms);
     }
     os.gThreshold = gThrs;
 

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -39,14 +39,14 @@ public:
 
     MWNodeVector<D> *getInitialWorkVector(MWTree<D> &tree) const override;
 
-    void setPrecTree(FunctionTree<D> &tree) { this->precTree = &tree; }
+    void setPrecTree(std::vector<FunctionTree<D> *> treevec) { this->precTrees = treevec; }
 
 private:
     int maxDepth;
     double prec;
     ConvolutionOperator<D> *oper;
     FunctionTree<D> *fTree;
-    FunctionTree<D> *precTree{nullptr};
+    std::vector<FunctionTree<D> *> precTrees;
     std::vector<Timer *> band_t;
     std::vector<Timer *> calc_t;
     std::vector<Timer *> norm_t;

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -39,11 +39,14 @@ public:
 
     MWNodeVector<D> *getInitialWorkVector(MWTree<D> &tree) const override;
 
+    void setPrecTree(FunctionTree<D> &tree) { this->precTree = &tree; }
+
 private:
     int maxDepth;
     double prec;
     ConvolutionOperator<D> *oper;
     FunctionTree<D> *fTree;
+    FunctionTree<D> *precTree{nullptr};
     std::vector<Timer *> band_t;
     std::vector<Timer *> calc_t;
     std::vector<Timer *> norm_t;

--- a/src/treebuilders/WaveletAdaptor.h
+++ b/src/treebuilders/WaveletAdaptor.h
@@ -49,47 +49,47 @@ protected:
     bool multiplicationSplit = false;
 
     bool splitNode(const MWNode<D> &node) const override {
-      if(multiplicationSplit and this->precTrees.size()>0){
-	auto multPrec = 1.0;
-        if(this->precTrees.size()!=2)std::cout<<this->precTrees.size()<<" ERROR "<<std::endl;
-        auto &pNode0 = precTrees[0]->getNode(node.getNodeIndex());
-        auto &pNode1 = precTrees[1]->getNode(node.getNodeIndex());
-        double maxW0=std::sqrt(pNode0.getMaxWSquareNorm());
-        double maxW1=std::sqrt(pNode1.getMaxWSquareNorm());
-        double maxS0=std::sqrt(pNode0.getMaxSquareNorm());
-        double maxS1=std::sqrt(pNode1.getMaxSquareNorm());
-        if(pNode0.isGenNode()){
-            maxW0 = 0.0;
-            maxS0 = std::sqrt(std::pow(2.0, D * node.getScale()) *pNode0.getSquareNorm());
-        }
-        if(pNode1.isGenNode()){
-            maxW1 = 0.0;
-            maxS1 = std::sqrt(std::pow(2.0, D * node.getScale()) *pNode1.getSquareNorm());
-        }
-        //The wavelet contribution (in the product of node0 and node1) can be approximated as
-        multPrec =  maxW0*maxS1 +  maxW1*maxS0 + maxW0*maxW1 ;
-
-        // Note: this never refine deeper than one scale more than input tree grids, because when wavelets are zero for both input trees, multPrec=0
-        // In addition, we force not to refine deeper than input tree grids
-	if (multPrec > this->prec and not (pNode0.isLeafNode() and pNode1.isLeafNode())) {
-	  return true;
-	} else {
-	  return false;
-	}
-      }else{
-        auto precNorm = 1.0;
-        if(this->precTrees.size() >0) precNorm = 0.0;//initialize
-        for (int i = 0; i < this->precTrees.size(); i++) {
-            auto &pNode = precTrees[i]->getNode(node.getNodeIndex());
-            auto n = node.getScale();
-            if(not pNode.isGenNode() and pNode.getMaxSquareNorm()>0.0){
-                precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
-            }else{
-                precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
+        if (multiplicationSplit and this->precTrees.size() > 0) {
+            auto multPrec = 1.0;
+            if (this->precTrees.size() != 2) std::cout << this->precTrees.size() << " ERROR " << std::endl;
+            auto &pNode0 = precTrees[0]->getNode(node.getNodeIndex());
+            auto &pNode1 = precTrees[1]->getNode(node.getNodeIndex());
+            double maxW0 = std::sqrt(pNode0.getMaxWSquareNorm());
+            double maxW1 = std::sqrt(pNode1.getMaxWSquareNorm());
+            double maxS0 = std::sqrt(pNode0.getMaxSquareNorm());
+            double maxS1 = std::sqrt(pNode1.getMaxSquareNorm());
+            if (pNode0.isGenNode()) {
+                maxW0 = 0.0;
+                maxS0 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode0.getSquareNorm());
             }
-	}
-        return node.splitCheck(this->prec / precNorm, this->splitFac, this->absPrec);
-      }
+            if (pNode1.isGenNode()) {
+                maxW1 = 0.0;
+                maxS1 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode1.getSquareNorm());
+            }
+            // The wavelet contribution (in the product of node0 and node1) can be approximated as
+            multPrec = maxW0 * maxS1 + maxW1 * maxS0 + maxW0 * maxW1;
+
+            // Note: this never refine deeper than one scale more than input tree grids, because when wavelets are zero
+            // for both input trees, multPrec=0 In addition, we force not to refine deeper than input tree grids
+            if (multPrec > this->prec and not(pNode0.isLeafNode() and pNode1.isLeafNode())) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            auto precNorm = 1.0;
+            if (this->precTrees.size() > 0) precNorm = 0.0; // initialize
+            for (int i = 0; i < this->precTrees.size(); i++) {
+                auto &pNode = precTrees[i]->getNode(node.getNodeIndex());
+                auto n = node.getScale();
+                if (not pNode.isGenNode() and pNode.getMaxSquareNorm() > 0.0) {
+                    precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
+                } else {
+                    precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
+                }
+            }
+            return node.splitCheck(this->prec / precNorm, this->splitFac, this->absPrec);
+        }
     }
 };
 

--- a/src/treebuilders/WaveletAdaptor.h
+++ b/src/treebuilders/WaveletAdaptor.h
@@ -38,13 +38,22 @@ public:
             , splitFac(sf) {}
     ~WaveletAdaptor() override = default;
 
+    void setPrecTree(FunctionTree<D> &tree) { this->precTree = &tree; }
+
 protected:
     bool absPrec;
     double prec;
     double splitFac;
+    FunctionTree<D> *precTree{nullptr};
 
     bool splitNode(const MWNode<D> &node) const override {
-        return node.splitCheck(this->prec, this->splitFac, this->absPrec);
+        auto precNorm = 1.0;
+        if (this->precTree != nullptr) {
+            auto &pNode = precTree->getNode(node.getNodeIndex());
+            auto n = node.getScale();
+            precNorm = std::pow(2.0, D * n) * std::sqrt(pNode.getSquareNorm());
+        }
+        return node.splitCheck(this->prec / precNorm, this->splitFac, this->absPrec);
     }
 };
 

--- a/src/treebuilders/WaveletAdaptor.h
+++ b/src/treebuilders/WaveletAdaptor.h
@@ -38,22 +38,58 @@ public:
             , splitFac(sf) {}
     ~WaveletAdaptor() override = default;
 
-    void setPrecTree(FunctionTree<D> &tree) { this->precTree = &tree; }
+    void setPrecTree(std::vector<FunctionTree<D> *> treevec) { this->precTrees = treevec; }
+    void setMultiplicationSplit(bool multSplit) { this->multiplicationSplit = multSplit; };
 
 protected:
     bool absPrec;
     double prec;
     double splitFac;
-    FunctionTree<D> *precTree{nullptr};
+    std::vector<FunctionTree<D> *> precTrees;
+    bool multiplicationSplit = false;
 
     bool splitNode(const MWNode<D> &node) const override {
-        auto precNorm = 1.0;
-        if (this->precTree != nullptr) {
-            auto &pNode = precTree->getNode(node.getNodeIndex());
-            auto n = node.getScale();
-            precNorm = std::pow(2.0, D * n) * std::sqrt(pNode.getSquareNorm());
+      if(multiplicationSplit and this->precTrees.size()>0){
+	auto multPrec = 1.0;
+        if(this->precTrees.size()!=2)std::cout<<this->precTrees.size()<<" ERROR "<<std::endl;
+        auto &pNode0 = precTrees[0]->getNode(node.getNodeIndex());
+        auto &pNode1 = precTrees[1]->getNode(node.getNodeIndex());
+        double maxW0=std::sqrt(pNode0.getMaxWSquareNorm());
+        double maxW1=std::sqrt(pNode1.getMaxWSquareNorm());
+        double maxS0=std::sqrt(pNode0.getMaxSquareNorm());
+        double maxS1=std::sqrt(pNode1.getMaxSquareNorm());
+        if(pNode0.isGenNode()){
+            maxW0 = 0.0;
+            maxS0 = std::sqrt(std::pow(2.0, D * node.getScale()) *pNode0.getSquareNorm());
         }
+        if(pNode1.isGenNode()){
+            maxW1 = 0.0;
+            maxS1 = std::sqrt(std::pow(2.0, D * node.getScale()) *pNode1.getSquareNorm());
+        }
+        //The wavelet contribution (in the product of node0 and node1) can be approximated as
+        multPrec =  maxW0*maxS1 +  maxW1*maxS0 + maxW0*maxW1 ;
+
+        // Note: this never refine deeper than one scale more than input tree grids, because when wavelets are zero for both input trees, multPrec=0
+        // In addition, we force not to refine deeper than input tree grids
+	if (multPrec > this->prec and not (pNode0.isLeafNode() and pNode1.isLeafNode())) {
+	  return true;
+	} else {
+	  return false;
+	}
+      }else{
+        auto precNorm = 1.0;
+        if(this->precTrees.size() >0) precNorm = 0.0;//initialize
+        for (int i = 0; i < this->precTrees.size(); i++) {
+            auto &pNode = precTrees[i]->getNode(node.getNodeIndex());
+            auto n = node.getScale();
+            if(not pNode.isGenNode() and pNode.getMaxSquareNorm()>0.0){
+                precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
+            }else{
+                precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
+            }
+	}
         return node.splitCheck(this->prec / precNorm, this->splitFac, this->absPrec);
+      }
     }
 };
 

--- a/src/treebuilders/WaveletAdaptor.h
+++ b/src/treebuilders/WaveletAdaptor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "TreeAdaptor.h"
+#include "utils/Printer.h"
 
 namespace mrcpp {
 
@@ -51,7 +52,7 @@ protected:
     bool splitNode(const MWNode<D> &node) const override {
         if (multiplicationSplit and this->precTrees.size() > 0) {
             auto multPrec = 1.0;
-            if (this->precTrees.size() != 2) std::cout << this->precTrees.size() << " ERROR " << std::endl;
+            if (this->precTrees.size() != 2) MSG_ERROR("Invalid precTree size: " << this->precTrees.size());
             auto &pNode0 = precTrees[0]->getNode(node.getNodeIndex());
             auto &pNode1 = precTrees[1]->getNode(node.getNodeIndex());
             double maxW0 = std::sqrt(pNode0.getMaxWSquareNorm());

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -107,9 +107,7 @@ void apply(double prec,
     int maxScale = out.getMRA().getMaxScale();
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
     adaptor.setPrecTree(precTrees);
-    for (int i = 0; i < precTrees.size(); i++) {
- 	precTrees[i]->makeMaxSquareNorms();
-    }
+    for (int i = 0; i < precTrees.size(); i++) { precTrees[i]->makeMaxSquareNorms(); }
     ConvolutionCalculator<D> calculator(prec, oper, inp);
     calculator.setPrecTree(precTrees);
     pre_t.stop();

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -94,6 +94,40 @@ void apply(double prec,
     print::separator(10, ' ');
 }
 
+template <int D>
+void apply(double prec,
+           FunctionTree<D> &out,
+           ConvolutionOperator<D> &oper,
+           FunctionTree<D> &inp,
+           FunctionTree<D> &precTree,
+           int maxIter,
+           bool absPrec) {
+    Timer pre_t;
+    oper.calcBandWidths(prec);
+    int maxScale = out.getMRA().getMaxScale();
+    WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
+    adaptor.setPrecTree(precTree);
+    ConvolutionCalculator<D> calculator(prec, oper, inp);
+    calculator.setPrecTree(precTree);
+    pre_t.stop();
+
+    TreeBuilder<D> builder;
+    builder.build(out, calculator, adaptor, maxIter);
+    precTree.deleteGenerated();
+
+    Timer post_t;
+    oper.clearBandWidths();
+    out.mwTransform(TopDown, false); // add coarse scale contributions
+    out.mwTransform(BottomUp);
+    out.calcSquareNorm();
+    inp.deleteGenerated();
+    post_t.stop();
+
+    print::time(10, "Time pre operator", pre_t);
+    print::time(10, "Time post operator", post_t);
+    print::separator(10, ' ');
+}
+
 /** @brief Application of MW derivative operator
  *
  * @param[out] out: Output function to be built
@@ -217,6 +251,27 @@ template void apply(double prec,
                     FunctionTree<3> &out,
                     ConvolutionOperator<3> &oper,
                     FunctionTree<3> &inp,
+                    int maxIter,
+                    bool absPrec);
+template void apply(double prec,
+                    FunctionTree<1> &out,
+                    ConvolutionOperator<1> &oper,
+                    FunctionTree<1> &inp,
+                    FunctionTree<1> &precTree,
+                    int maxIter,
+                    bool absPrec);
+template void apply(double prec,
+                    FunctionTree<2> &out,
+                    ConvolutionOperator<2> &oper,
+                    FunctionTree<2> &inp,
+                    FunctionTree<2> &precTree,
+                    int maxIter,
+                    bool absPrec);
+template void apply(double prec,
+                    FunctionTree<3> &out,
+                    ConvolutionOperator<3> &oper,
+                    FunctionTree<3> &inp,
+                    FunctionTree<3> &precTree,
                     int maxIter,
                     bool absPrec);
 template void apply(FunctionTree<1> &out, DerivativeOperator<1> &oper, FunctionTree<1> &inp, int dir);

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -99,21 +99,23 @@ void apply(double prec,
            FunctionTree<D> &out,
            ConvolutionOperator<D> &oper,
            FunctionTree<D> &inp,
-           FunctionTree<D> &precTree,
+           std::vector<FunctionTree<D> *> precTrees,
            int maxIter,
            bool absPrec) {
     Timer pre_t;
     oper.calcBandWidths(prec);
     int maxScale = out.getMRA().getMaxScale();
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
-    adaptor.setPrecTree(precTree);
+    adaptor.setPrecTree(precTrees);
+    for (int i = 0; i < precTrees.size(); i++) {
+ 	precTrees[i]->makeMaxSquareNorms();
+    }
     ConvolutionCalculator<D> calculator(prec, oper, inp);
-    calculator.setPrecTree(precTree);
+    calculator.setPrecTree(precTrees);
     pre_t.stop();
 
     TreeBuilder<D> builder;
     builder.build(out, calculator, adaptor, maxIter);
-    precTree.deleteGenerated();
 
     Timer post_t;
     oper.clearBandWidths();
@@ -257,21 +259,21 @@ template void apply(double prec,
                     FunctionTree<1> &out,
                     ConvolutionOperator<1> &oper,
                     FunctionTree<1> &inp,
-                    FunctionTree<1> &precTree,
+                    std::vector<FunctionTree<1> *> precTrees,
                     int maxIter,
                     bool absPrec);
 template void apply(double prec,
                     FunctionTree<2> &out,
                     ConvolutionOperator<2> &oper,
                     FunctionTree<2> &inp,
-                    FunctionTree<2> &precTree,
+                    std::vector<FunctionTree<2> *> precTrees,
                     int maxIter,
                     bool absPrec);
 template void apply(double prec,
                     FunctionTree<3> &out,
                     ConvolutionOperator<3> &oper,
                     FunctionTree<3> &inp,
-                    FunctionTree<3> &precTree,
+                    std::vector<FunctionTree<3> *> precTrees,
                     int maxIter,
                     bool absPrec);
 template void apply(FunctionTree<1> &out, DerivativeOperator<1> &oper, FunctionTree<1> &inp, int dir);

--- a/src/treebuilders/apply.h
+++ b/src/treebuilders/apply.h
@@ -35,6 +35,7 @@ template <int D> class DerivativeOperator;
 template <int D> class ConvolutionOperator;
 
 template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, int maxIter = -1, bool absPrec = false);
+template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, FunctionTree<D> &precTree, int maxIter = -1, bool absPrec = false);
 template <int D> void apply(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTree<D> &inp, int dir = -1);
 template <int D> void divergence(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTreeVector<D> &inp);
 template <int D> FunctionTreeVector<D> gradient(DerivativeOperator<D> &oper, FunctionTree<D> &inp);

--- a/src/treebuilders/apply.h
+++ b/src/treebuilders/apply.h
@@ -35,7 +35,7 @@ template <int D> class DerivativeOperator;
 template <int D> class ConvolutionOperator;
 
 template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, int maxIter = -1, bool absPrec = false);
-template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, FunctionTree<D> &precTree, int maxIter = -1, bool absPrec = false);
+ template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, std::vector<FunctionTree<D> *> precTrees, int maxIter = -1, bool absPrec = false);
 template <int D> void apply(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTree<D> &inp, int dir = -1);
 template <int D> void divergence(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTreeVector<D> &inp);
 template <int D> FunctionTreeVector<D> gradient(DerivativeOperator<D> &oper, FunctionTree<D> &inp);

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -102,8 +102,12 @@ void multiply(double prec,
  *
  */
 template <int D>
-void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter, bool absPrec, bool useMaxNorms) {
-    for (auto i = 0; i < inp.size(); i++)
+void multiply(double prec,
+              FunctionTree<D> &out,
+              FunctionTreeVector<D> &inp,
+              int maxIter,
+              bool absPrec,
+              bool useMaxNorms) {    for (auto i = 0; i < inp.size(); i++)
         if (out.getMRA() != get_func(inp, i).getMRA()) MSG_ABORT("Incompatible MRA");
 
     int maxScale = out.getMRA().getMaxScale();

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -107,7 +107,8 @@ void multiply(double prec,
               FunctionTreeVector<D> &inp,
               int maxIter,
               bool absPrec,
-              bool useMaxNorms) {    for (auto i = 0; i < inp.size(); i++)
+              bool useMaxNorms) {
+    for (auto i = 0; i < inp.size(); i++)
         if (out.getMRA() != get_func(inp, i).getMRA()) MSG_ABORT("Incompatible MRA");
 
     int maxScale = out.getMRA().getMaxScale();

--- a/src/treebuilders/multiply.h
+++ b/src/treebuilders/multiply.h
@@ -48,9 +48,10 @@ void multiply(double prec,
               FunctionTree<D> &inp_a,
               FunctionTree<D> &inp_b,
               int maxIter = -1,
-              bool absPrec = false);
+              bool absPrec = false, bool useMaxNorms = false);
+
 template <int D>
-void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1, bool absPrec = false);
+  void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1, bool absPrec = false, bool useMaxNorms = false);
 template <int D>
 void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double p, int maxIter = -1, bool absPrec = false);
 template <int D>

--- a/src/treebuilders/multiply.h
+++ b/src/treebuilders/multiply.h
@@ -48,10 +48,16 @@ void multiply(double prec,
               FunctionTree<D> &inp_a,
               FunctionTree<D> &inp_b,
               int maxIter = -1,
-              bool absPrec = false, bool useMaxNorms = false);
+              bool absPrec = false,
+              bool useMaxNorms = false);
 
 template <int D>
-  void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter = -1, bool absPrec = false, bool useMaxNorms = false);
+void multiply(double prec,
+              FunctionTree<D> &out,
+              FunctionTreeVector<D> &inp,
+              int maxIter = -1,
+              bool absPrec = false,
+              bool useMaxNorms = false);
 template <int D>
 void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double p, int maxIter = -1, bool absPrec = false);
 template <int D>

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -376,9 +376,7 @@ template <int D> void FunctionTree<D>::absadd(double c, FunctionTree<D> &inp) {
             inp_node.cvTransform(Forward);
             double *out_coefs = out_node.getCoefs();
             const double *inp_coefs = inp_node.getCoefs();
-            for (int i = 0; i < inp_node.getNCoefs(); i++) {
-	      out_coefs[i] = abs(out_coefs[i]) + c * abs(inp_coefs[i]);
-	    }
+            for (int i = 0; i < inp_node.getNCoefs(); i++) { out_coefs[i] = abs(out_coefs[i]) + c * abs(inp_coefs[i]); }
             out_node.cvTransform(Backward);
             out_node.mwTransform(Compression);
             out_node.calcNorms();

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -72,6 +72,7 @@ public:
     void rescale(double c);
     void normalize();
     void add(double c, FunctionTree<D> &inp);
+    void absadd(double c, FunctionTree<D> &inp);
     void multiply(double c, FunctionTree<D> &inp);
     void map(FMap fmap);
 

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -1006,12 +1006,12 @@ template <int D> void MWNode<D>::setMaxSquareNorm() {
     this->maxSquareNorm = std::pow(2.0, D * n) * this->getSquareNorm();
 
     if (not this->isEndNode()) {
-       for (int i = 0; i < this->getTDim(); i++) {
+        for (int i = 0; i < this->getTDim(); i++) {
             MWNode<D> &child = *this->children[i];
             child.setMaxSquareNorm();
             this->maxSquareNorm = std::max(this->maxSquareNorm, child.maxSquareNorm);
             this->maxWSquareNorm = std::max(this->maxWSquareNorm, child.maxWSquareNorm);
-      }
+        }
     }
 }
 
@@ -1020,10 +1020,10 @@ template <int D> void MWNode<D>::resetMaxSquareNorm() {
     this->maxSquareNorm = -1.0;
     this->maxWSquareNorm = -1.0;
     if (not this->isEndNode()) {
-       for (int i = 0; i < this->getTDim(); i++) {
-	 MWNode<D> &child = *this->children[i];
-	 child.resetMaxSquareNorm();
-      }
+        for (int i = 0; i < this->getTDim(); i++) {
+            MWNode<D> &child = *this->children[i];
+            child.resetMaxSquareNorm();
+        }
     }
 }
 

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -50,6 +50,7 @@ MWNode<D>::MWNode()
         , parent(nullptr)
         , squareNorm(-1.0)
         , maxSquareNorm(-1.0)
+        , maxWSquareNorm(-1.0)
         , coefs(nullptr)
         , n_coefs(0)
         , nodeIndex()
@@ -59,7 +60,6 @@ MWNode<D>::MWNode()
     setIsLooseNode();
 
     clearNorms();
-    maxSquareNorm = -1.0;
     for (int i = 0; i < getTDim(); i++) { this->children[i] = nullptr; }
 }
 

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -49,6 +49,7 @@ MWNode<D>::MWNode()
         : tree(nullptr)
         , parent(nullptr)
         , squareNorm(-1.0)
+        , maxSquareNorm(-1.0)
         , coefs(nullptr)
         , n_coefs(0)
         , nodeIndex()
@@ -58,6 +59,7 @@ MWNode<D>::MWNode()
     setIsLooseNode();
 
     clearNorms();
+    maxSquareNorm = -1.0;
     for (int i = 0; i < getTDim(); i++) { this->children[i] = nullptr; }
 }
 
@@ -68,6 +70,7 @@ MWNode<D>::MWNode(const MWNode<D> &node)
         : tree(node.tree)
         , parent(nullptr)
         , squareNorm(-1.0)
+        , maxSquareNorm(-1.0)
         , coefs(nullptr)
         , n_coefs(0)
         , nodeIndex(node.nodeIndex)
@@ -995,6 +998,33 @@ template <int D> std::ostream &MWNode<D>::print(std::ostream &o) const {
         o << getCoefs()[0] << ", " << getCoefs()[getNCoefs() - 1] << "}";
     }
     return o;
+}
+
+template <int D> void MWNode<D>::setMaxSquareNorm() {
+    auto n = this->getScale();
+    this->maxWSquareNorm = std::pow(2.0, D * n) * this->getWaveletNorm();
+    this->maxSquareNorm = std::pow(2.0, D * n) * this->getSquareNorm();
+
+    if (not this->isEndNode()) {
+       for (int i = 0; i < this->getTDim(); i++) {
+            MWNode<D> &child = *this->children[i];
+            child.setMaxSquareNorm();
+            this->maxSquareNorm = std::max(this->maxSquareNorm, child.maxSquareNorm);
+            this->maxWSquareNorm = std::max(this->maxWSquareNorm, child.maxWSquareNorm);
+      }
+    }
+}
+
+template <int D> void MWNode<D>::resetMaxSquareNorm() {
+    auto n = this->getScale();
+    this->maxSquareNorm = -1.0;
+    this->maxWSquareNorm = -1.0;
+    if (not this->isEndNode()) {
+       for (int i = 0; i < this->getTDim(); i++) {
+	 MWNode<D> &child = *this->children[i];
+	 child.resetMaxSquareNorm();
+      }
+    }
 }
 
 template class MWNode<1>;

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -160,12 +160,14 @@ protected:
 
     double squareNorm;
     double componentNorms[1 << D]; ///< 2^D components
-    double maxSquareNorm; // Largest squared norm among itself and descendants.
-    double maxWSquareNorm; // Largest wavelet squared norm among itself and descendants.
-                           // NB: must be set before used.
-                           // NB2: normalization is such that a constant function gives constant value, i.e. *not* same normalization as squareNorm
-    void setMaxSquareNorm(); //recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
-    void resetMaxSquareNorm(); //recursively reset maxSquaredNorm  and maxWSquareNorm of parent and descendants to value -1
+    double maxSquareNorm;          // Largest squared norm among itself and descendants.
+    double maxWSquareNorm;         // Largest wavelet squared norm among itself and descendants.
+                                   // NB: must be set before used.
+                           // NB2: normalization is such that a constant function gives constant value, i.e. *not* same
+                           // normalization as squareNorm
+    void setMaxSquareNorm(); // recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
+    void
+    resetMaxSquareNorm(); // recursively reset maxSquaredNorm  and maxWSquareNorm of parent and descendants to value -1
 
     double *coefs;
     int n_coefs;

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -164,7 +164,7 @@ protected:
     double maxWSquareNorm;         // Largest wavelet squared norm among itself and descendants.
                                    // NB: must be set before used.
     // NB2: normalization is such that a constant function gives constant value, i.e. *not* same
-    // normalization as squareNorm
+    // normalization as a squareNorm
     void setMaxSquareNorm(); // recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
     void
     resetMaxSquareNorm(); // recursively reset maxSquaredNorm  and maxWSquareNorm of parent and descendants to value -1

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -82,6 +82,8 @@ public:
     inline bool isLooseNode() const;
 
     double getSquareNorm() const { return this->squareNorm; }
+    double getMaxSquareNorm() const { return this->maxSquareNorm; }
+    double getMaxWSquareNorm() const { return this->maxWSquareNorm; }
     double getScalingNorm() const;
     virtual double getWaveletNorm() const;
     double getComponentNorm(int i) const { return this->componentNorms[i]; }
@@ -158,6 +160,12 @@ protected:
 
     double squareNorm;
     double componentNorms[1 << D]; ///< 2^D components
+    double maxSquareNorm; // Largest squared norm among itself and descendants.
+    double maxWSquareNorm; // Largest wavelet squared norm among itself and descendants.
+                           // NB: must be set before used.
+                           // NB2: normalization is such that a constant function gives constant value, i.e. *not* same normalization as squareNorm
+    void setMaxSquareNorm(); //recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
+    void resetMaxSquareNorm(); //recursively reset maxSquaredNorm  and maxWSquareNorm of parent and descendants to value -1
 
     double *coefs;
     int n_coefs;

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -163,8 +163,8 @@ protected:
     double maxSquareNorm;          // Largest squared norm among itself and descendants.
     double maxWSquareNorm;         // Largest wavelet squared norm among itself and descendants.
                                    // NB: must be set before used.
-                           // NB2: normalization is such that a constant function gives constant value, i.e. *not* same
-                           // normalization as squareNorm
+    // NB2: normalization is such that a constant function gives constant value, i.e. *not* same
+    // normalization as squareNorm
     void setMaxSquareNorm(); // recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
     void
     resetMaxSquareNorm(); // recursively reset maxSquaredNorm  and maxWSquareNorm of parent and descendants to value -1

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -488,7 +488,6 @@ template <int D> std::ostream &MWTree<D>::print(std::ostream &o) {
     return o;
 }
 
-
 /** set values for maxSquareNorm in all nodes  */
 template <int D> void MWTree<D>::makeMaxSquareNorms() {
     NodeBox<D> &rBox = this->getRootBox();
@@ -496,7 +495,7 @@ template <int D> void MWTree<D>::makeMaxSquareNorms() {
     int DepthMax = 100, slen = 0;
     ProjectedNode<D> *stack[DepthMax * 8];
     for (int rIdx = 0; rIdx < rBox.size(); rIdx++) {
-        //recursively set value of children and descendants
+        // recursively set value of children and descendants
         roots[rIdx]->setMaxSquareNorm();
     }
 }

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -492,8 +492,6 @@ template <int D> std::ostream &MWTree<D>::print(std::ostream &o) {
 template <int D> void MWTree<D>::makeMaxSquareNorms() {
     NodeBox<D> &rBox = this->getRootBox();
     MWNode<D> **roots = rBox.getNodes();
-    int DepthMax = 100, slen = 0;
-    ProjectedNode<D> *stack[DepthMax * 8];
     for (int rIdx = 0; rIdx < rBox.size(); rIdx++) {
         // recursively set value of children and descendants
         roots[rIdx]->setMaxSquareNorm();

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -488,6 +488,19 @@ template <int D> std::ostream &MWTree<D>::print(std::ostream &o) {
     return o;
 }
 
+
+/** set values for maxSquareNorm in all nodes  */
+template <int D> void MWTree<D>::makeMaxSquareNorms() {
+    NodeBox<D> &rBox = this->getRootBox();
+    MWNode<D> **roots = rBox.getNodes();
+    int DepthMax = 100, slen = 0;
+    ProjectedNode<D> *stack[DepthMax * 8];
+    for (int rIdx = 0; rIdx < rBox.size(); rIdx++) {
+        //recursively set value of children and descendants
+        roots[rIdx]->setMaxSquareNorm();
+    }
+}
+
 template class MWTree<1>;
 template class MWTree<2>;
 template class MWTree<3>;

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -122,6 +122,8 @@ public:
     int countNodes(int depth = -1);
     void RecountNodes();
 
+    void makeMaxSquareNorms(); // sets values for maxSquareNorm and maxWSquareNorm in all nodes
+
     SerialTree<D> *getSerialTree() { return this->serialTree_p; }
 
     friend std::ostream &operator<<(std::ostream &o, MWTree<D> &tree) { return tree.print(o); }

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -109,7 +109,7 @@ template <int D> void SerialFunctionTree<D>::clear(int n) {
     this->lastNode = this->nodeChunks[chunk] + n % (this->maxNodesPerChunk);
 
     if (this->isShared()) {
-        this->shMem->sh_end_ptr  =
+        this->shMem->sh_end_ptr =
             this->shMem->sh_start_ptr + (n / this->maxNodesPerChunk + 1) * this->sizeNodeCoeff * this->maxNodesPerChunk;
     }
 }

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -109,7 +109,8 @@ template <int D> void SerialFunctionTree<D>::clear(int n) {
     this->lastNode = this->nodeChunks[chunk] + n % (this->maxNodesPerChunk);
 
     if (this->isShared()) {
-        this->shMem->sh_end_ptr  = this->shMem->sh_start_ptr + (n / this->maxNodesPerChunk + 1) * this->sizeNodeCoeff * this->maxNodesPerChunk;
+        this->shMem->sh_end_ptr  =
+            this->shMem->sh_start_ptr + (n / this->maxNodesPerChunk + 1) * this->sizeNodeCoeff * this->maxNodesPerChunk;
     }
 }
 
@@ -436,7 +437,7 @@ template <int D> int SerialFunctionTree<D>::shrinkChunks() {
 
     if (this->isShared()) {
         // shared coefficients cannot be fully deallocated, only pointer is moved.
-        this->shMem->sh_end_ptr  -= (nChunksStart - nChunks) * this->sizeNodeCoeff * this->maxNodesPerChunk;
+        this->shMem->sh_end_ptr -= (nChunksStart - nChunks) * this->sizeNodeCoeff * this->maxNodesPerChunk;
     } else {
         for (int i = nChunks; i < this->nodeCoeffChunks.size(); i++) delete[] this->nodeCoeffChunks[i];
     }

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -63,6 +63,12 @@ SharedMemory::SharedMemory(MPI_Comm comm, int sh_size)
 #endif
 }
 
+void SharedMemory::clear() {
+#ifdef HAVE_MPI
+    this->sh_end_ptr = this->sh_start_ptr;
+#endif
+}
+
 SharedMemory::~SharedMemory() {
 #ifdef HAVE_MPI
     // deallocates the memory block

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -47,8 +47,10 @@ SharedMemory::SharedMemory(MPI_Comm comm, int sh_size)
 #ifdef HAVE_MPI
     MPI_Comm_rank(comm, &this->rank);
     // MPI_Aint types are used for adresses (can be larger than int)
-    MPI_Aint size = (rank == 0) ? 1024 * 1024 * sh_size : 0; // rank 0 defines length of segment
-    int disp_unit = 16;                                      // in order for the compiler to keep aligned
+    MPI_Aint size = (rank == 0) ? sh_size : 0; // rank 0 defines length of segment
+    size *= 1024 * 1024; // ->MB NB: Must be multiplied separately, for not overflow int type.
+
+    int disp_unit = 16;  // in order for the compiler to keep aligned
     // size is in bytes
     MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, comm, &this->sh_start_ptr, &this->sh_win);
     MPI_Win_fence(0, this->sh_win); // wait until finished

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -48,9 +48,9 @@ SharedMemory::SharedMemory(MPI_Comm comm, int sh_size)
     MPI_Comm_rank(comm, &this->rank);
     // MPI_Aint types are used for adresses (can be larger than int)
     MPI_Aint size = (rank == 0) ? sh_size : 0; // rank 0 defines length of segment
-    size *= 1024 * 1024; // ->MB NB: Must be multiplied separately, for not overflow int type.
+    size *= 1024 * 1024;                       // ->MB NB: Must be multiplied separately, for not overflow int type.
 
-    int disp_unit = 16;  // in order for the compiler to keep aligned
+    int disp_unit = 16; // in order for the compiler to keep aligned
     // size is in bytes
     MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, comm, &this->sh_start_ptr, &this->sh_win);
     MPI_Win_fence(0, this->sh_win); // wait until finished

--- a/src/utils/mpi_utils.h
+++ b/src/utils/mpi_utils.h
@@ -58,7 +58,6 @@ public:
     void clear();         // show shared memory as entirely available
 };
 
-
 template <int D> class FunctionTree;
 
 template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, int nChunks = -1);

--- a/src/utils/mpi_utils.h
+++ b/src/utils/mpi_utils.h
@@ -55,7 +55,9 @@ public:
     double *sh_max_ptr;   // end of shared block
     MPI_Win sh_win;       // MPI window object
     int rank;             // rank among shared group
+    void clear();         // show shared memory as entirely available
 };
+
 
 template <int D> class FunctionTree;
 


### PR DESCRIPTION
Defines (for nodes)  maxSquareNorm and maxWSquareNorm, which are the max value among one node and its descendants. Those are not set by default, so methods that use them must set them first (using makeMaxSquareNorms()). Using those norms instead of the direct node norms is safer, as the direct norms can be larger at a higher scale, thereby the refinement can miss sharp values.
Wavelet.h is adapted to be able to use them.
apply.cpp alows operator application using a precision weighted by norm given in a separate tree.
multiply.cpp give a new method for multiplying, which does not necessarily use the entire union grid if no significant values are present there.
Will be used by the new faster mrchem Poisson application.
(also defined addition of absolute values for trees; not really needed now, but could be useful anyway)