### PR TITLE
Add apply_on_unit_cell method

### DIFF
--- a/src/functions/Gaussian.cpp
+++ b/src/functions/Gaussian.cpp
@@ -120,23 +120,24 @@ template <int D> bool Gaussian<D>::checkScreen(int n, const int *l) const {
 }
 
 template <int D> bool Gaussian<D>::isVisibleAtScale(int scale, int nQuadPts) const {
-
+    if (isPeriodic()) return getPeriodicGaussExp().isVisibleAtScale(scale, nQuadPts);
     for (auto &alp : this->alpha) {
         double stdDeviation = std::pow(2.0 * alp, -0.5);
         auto visibleScale = static_cast<int>(-std::floor(std::log2(nQuadPts * 0.5 * stdDeviation)));
 
-        if (scale < visibleScale) { return false; }
+        if (scale < visibleScale) return false;
     }
 
     return true;
 }
 
 template <int D> bool Gaussian<D>::isZeroOnInterval(const double *a, const double *b) const {
+    if (isPeriodic()) return getPeriodicGaussExp().isZeroOnInterval(a, b);
     for (int i = 0; i < D; i++) {
         double stdDeviation = std::pow(2.0 * this->alpha[i], -0.5);
         double gaussBoxMin = this->pos[i] - 5.0 * stdDeviation;
         double gaussBoxMax = this->pos[i] + 5.0 * stdDeviation;
-        if (a[i] > gaussBoxMax or b[i] < gaussBoxMin) { return true; }
+        if (a[i] > gaussBoxMax or b[i] < gaussBoxMin) return true;
     }
     return false;
 }

--- a/src/functions/Gaussian.h
+++ b/src/functions/Gaussian.h
@@ -49,6 +49,8 @@ public:
     virtual ~Gaussian() = default;
 
     void makePeriodic(const std::array<double, D> &period, double nStdDev = 4.0);
+    bool isPeriodic() const { return (gauss_exp != nullptr); }
+    const GaussExp<D> &getPeriodicGaussExp() const { return *this->gauss_exp; }
 
     virtual double evalfCore(const Coord<D> &r) const = 0;
 

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -87,8 +87,7 @@ template <int D> void ConvolutionOperator<D>::clearKernel() {
     mrcpp::clear(this->kern_exp, true);
 }
 
-template <int D>
-double ConvolutionOperator<D>::calcMinDistance(const MultiResolutionAnalysis<D> &MRA, double epsilon) const {
+template <int D> double ConvolutionOperator<D>::calcMinDistance(const MultiResolutionAnalysis<D> &MRA, double epsilon) const {
     int maxScale = MRA.getMaxScale();
     return std::sqrt(epsilon * std::pow(2.0, -maxScale));
 }
@@ -96,7 +95,14 @@ double ConvolutionOperator<D>::calcMinDistance(const MultiResolutionAnalysis<D> 
 template <int D> double ConvolutionOperator<D>::calcMaxDistance(const MultiResolutionAnalysis<D> &MRA) const {
     const Coord<D> &lb = MRA.getWorldBox().getLowerBounds();
     const Coord<D> &ub = MRA.getWorldBox().getUpperBounds();
-    return math_utils::calc_distance<D>(lb, ub);
+    auto max_distance = math_utils::calc_distance<D>(lb, ub);
+    if (MRA.getWorldBox().isPeriodic()) {
+        auto period = MRA.getWorldBox().getScalingFactor();
+        max_distance *= std::pow(2.0, -MRA.getOperatorScale());
+        if (MRA.getOperatorScale() < 0) max_distance *= 2.0;
+        if (MRA.getOperatorScale() == 0) max_distance *= 2.0 * MRA.getPeriodicOperatorReach() + 1.0;
+    }
+    return max_distance;
 }
 
 template class ConvolutionOperator<1>;

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -97,7 +97,7 @@ template <int D> double ConvolutionOperator<D>::calcMaxDistance(const MultiResol
     const Coord<D> &ub = MRA.getWorldBox().getUpperBounds();
     auto max_distance = math_utils::calc_distance<D>(lb, ub);
     if (MRA.getWorldBox().isPeriodic()) {
-        auto period = MRA.getWorldBox().getScalingFactor();
+        auto period = MRA.getWorldBox().getScalingFactors();
         max_distance *= std::pow(2.0, -MRA.getOperatorScale());
         if (MRA.getOperatorScale() < 0) max_distance *= 2.0;
         if (MRA.getOperatorScale() == 0) max_distance *= 2.0 * MRA.getPeriodicOperatorReach() + 1.0;

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -64,7 +64,7 @@ template <int D> void ConvolutionOperator<D>::initializeOperator(GreensKernel &g
         Gaussian<1> &k_func = *greens_kernel[i];
         auto *k_tree = new FunctionTree<1>(this->kern_mra);
         mrcpp::build_grid(*k_tree, k_func);               // Generate empty grid to hold narrow Gaussian
-        mrcpp::project(this->prec / 10, *k_tree, k_func); // Project Gaussian starting from the empty grid
+        mrcpp::project(this->prec / 100.0, *k_tree, k_func); // Project Gaussian starting from the empty grid
         CrossCorrelationCalculator calculator(*k_tree);
 
         auto *o_tree = new OperatorTree(this->oper_mra, this->prec);

--- a/src/operators/HelmholtzOperator.cpp
+++ b/src/operators/HelmholtzOperator.cpp
@@ -42,7 +42,7 @@ HelmholtzOperator::HelmholtzOperator(const MultiResolutionAnalysis<3> &mra, doub
         : ConvolutionOperator<3>(mra, pr)
         , mu(m) {
     int oldlevel = Printer::setPrintLevel(0);
-    double epsilon = this->prec / 10.0;
+    double epsilon = this->prec / 100.0;
     double r_min = calcMinDistance(mra, epsilon);
     double r_max = calcMaxDistance(mra);
     HelmholtzKernel helmholtz_kernel(this->mu, epsilon, r_min, r_max);

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -53,6 +53,9 @@ public:
     OperatorTree &getComponent(int i);
     const OperatorTree &getComponent(int i) const;
 
+    int getRootScale() const { return this->oper_mra.getRootScale(); }
+    int getOperatorScale() const { return this->oper_mra.getOperatorScale(); }
+
     OperatorTree *operator[](int i) { return this->oper_exp[i]; }
     const OperatorTree *operator[](int i) const { return this->oper_exp[i]; }
 

--- a/src/operators/PoissonOperator.cpp
+++ b/src/operators/PoissonOperator.cpp
@@ -40,7 +40,7 @@ namespace mrcpp {
 PoissonOperator::PoissonOperator(const MultiResolutionAnalysis<3> &mra, double build_prec)
         : ConvolutionOperator<3>(mra, build_prec) {
     int oldlevel = Printer::setPrintLevel(0);
-    double epsilon = this->prec / 10.0;
+    double epsilon = this->prec / 100.0;
     double r_min = calcMinDistance(mra, epsilon);
     double r_max = calcMaxDistance(mra);
     PoissonKernel poisson_kernel(epsilon, r_min, r_max);

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -40,13 +40,17 @@ public:
 
     MWNodeVector<D> *getInitialWorkVector(MWTree<D> &tree) const override;
 
-    void setPrecFunction(const std::function<double(const NodeIndex<D> &idx)> &prec_func) {
-        this->precFunc = prec_func;
+    void setPrecFunction(const std::function<double(const NodeIndex<D> &idx)> &prec_func) { this->precFunc = prec_func; }
+    void startManipulateOperator(bool excUnit) {
+        this->manipulateOperator = true;
+        this->onUnitcell = excUnit;
     }
 
 private:
     int maxDepth;
     double prec;
+    bool manipulateOperator{false};
+    bool onUnitcell{false};
     ConvolutionOperator<D> *oper;
     FunctionTree<D> *fTree;
     std::vector<Timer *> band_t;
@@ -61,11 +65,7 @@ private:
     static const int nComp2 = (1 << D) * (1 << D);
 
     MWNodeVector<D> *makeOperBand(const MWNode<D> &gNode, std::vector<NodeIndex<D>> &idx_band);
-    void fillOperBand(MWNodeVector<D> *band,
-                      std::vector<NodeIndex<D>> &idx_band,
-                      NodeIndex<D> &idx,
-                      const int *nbox,
-                      int dim);
+    void fillOperBand(MWNodeVector<D> *band, std::vector<NodeIndex<D>> &idx_band, NodeIndex<D> &idx, const int *nbox, int dim);
 
     void initTimers();
     void clearTimers();
@@ -89,6 +89,8 @@ private:
     void applyOperComp(OperatorState<D> &os);
     void applyOperator(OperatorState<D> &os);
     void tensorApplyOperComp(OperatorState<D> &os);
+
+    void touchParentNodes(MWTree<D> &tree) const;
 };
 
 } // namespace mrcpp

--- a/src/treebuilders/OperatorAdaptor.h
+++ b/src/treebuilders/OperatorAdaptor.h
@@ -36,19 +36,15 @@ public:
 
 protected:
     bool splitNode(const MWNode<2> &node) const override {
-        int chkCompNorm = 0;
+        const auto &idx = node.getNodeIndex();
+        bool chkTransl = (idx[0] == 0 or idx[1] == 0);
+
+        bool chkCompNorm = false;
         for (int i = 1; i < 4; i++) {
-            if (node.getComponentNorm(i) > 0.0) { chkCompNorm = 1; }
+            if (node.getComponentNorm(i) > 0.0) chkCompNorm = true;
         }
 
-        const auto &idx = node.getNodeIndex();
-        int chkTransl = (idx[0] == 0 or idx[1] == 0);
-
-        int split = 1;
-        split *= chkTransl;
-        split *= chkCompNorm;
-
-        return split;
+        return chkTransl and chkCompNorm;
     }
 };
 

--- a/src/treebuilders/TreeBuilder.cpp
+++ b/src/treebuilders/TreeBuilder.cpp
@@ -55,7 +55,7 @@ void TreeBuilder<D>::build(MWTree<D> &tree, TreeCalculator<D> &calculator, TreeA
         calc_t.stop();
 
         norm_t.resume();
-        if (iter == 0) { sNorm = calcScalingNorm(*workVec); }
+        if (iter == 0) sNorm = calcScalingNorm(*workVec);
         wNorm += calcWaveletNorm(*workVec);
 
         if (sNorm < 0.0 or wNorm < 0.0) {
@@ -152,7 +152,7 @@ template <int D> double TreeBuilder<D>::calcScalingNorm(const MWNodeVector<D> &v
     double sNorm = 0.0;
     for (int i = 0; i < vec.size(); i++) {
         const MWNode<D> &node = *vec[i];
-        sNorm += node.getScalingNorm();
+        if (node.getDepth() >= 0) sNorm += node.getScalingNorm();
     }
     return sNorm;
 }
@@ -161,7 +161,7 @@ template <int D> double TreeBuilder<D>::calcWaveletNorm(const MWNodeVector<D> &v
     double wNorm = 0.0;
     for (int i = 0; i < vec.size(); i++) {
         const MWNode<D> &node = *vec[i];
-        wNorm += node.getWaveletNorm();
+        if (node.getDepth() >= 0) wNorm += node.getWaveletNorm();
     }
     return wNorm;
 }

--- a/src/treebuilders/apply.h
+++ b/src/treebuilders/apply.h
@@ -36,6 +36,8 @@ template <int D> class ConvolutionOperator;
 
 template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, int maxIter = -1, bool absPrec = false);
 template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, FunctionTreeVector<D> &precTrees, int maxIter = -1, bool absPrec = false);
+template <int D> void apply_far_field(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, int maxIter = -1, bool absPrec = false);
+template <int D> void apply_near_field(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, int maxIter = -1, bool absPrec = false);
 template <int D> void apply(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTree<D> &inp, int dir = -1);
 template <int D> void divergence(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTreeVector<D> &inp);
 template <int D> FunctionTreeVector<D> gradient(DerivativeOperator<D> &oper, FunctionTree<D> &inp);

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -71,17 +71,8 @@ template <int D> void build_grid(FunctionTree<D> &out, const Gaussian<D> &inp, i
     TreeBuilder<D> builder;
     DefaultCalculator<D> calculator;
 
-    if (!out.getMRA().getWorldBox().isPeriodic()) {
-        AnalyticAdaptor<D> adaptor(inp, maxScale);
-        builder.build(out, calculator, adaptor, maxIter);
-    } else {
-        auto period = out.getMRA().getWorldBox().getScalingFactor();
-        auto g_exp = function_utils::make_gaussian_periodic<D>(inp, period);
-        for (auto i = 0; i < g_exp->size(); i++) {
-            AnalyticAdaptor<D> adaptor(g_exp->getFunc(i), maxScale);
-            builder.build(out, calculator, adaptor, maxIter);
-        }
-    }
+    AnalyticAdaptor<D> adaptor(inp, maxScale);
+    builder.build(out, calculator, adaptor, maxIter);
     print::separator(10, ' ');
 }
 

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -105,7 +105,7 @@ template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, i
             builder.build(out, calculator, adaptor, maxIter);
         }
     } else {
-        auto period = out.getMRA().getWorldBox().getScalingFactor();
+        auto period = out.getMRA().getWorldBox().getScalingFactors();
         for (auto i = 0; i < inp.size(); i++) {
             auto *gauss = inp.getFunc(i).copy();
             build_grid(out, *gauss, maxIter);

--- a/src/treebuilders/project.cpp
+++ b/src/treebuilders/project.cpp
@@ -56,12 +56,7 @@ namespace mrcpp {
  * no coefs).
  *
  */
-template <int D>
-void project(double prec,
-             FunctionTree<D> &out,
-             std::function<double(const Coord<D> &r)> func,
-             int maxIter,
-             bool absPrec) {
+template <int D> void project(double prec, FunctionTree<D> &out, std::function<double(const Coord<D> &r)> func, int maxIter, bool absPrec) {
     AnalyticFunction<D> inp(func);
     mrcpp::project(prec, out, inp, maxIter, absPrec);
 }
@@ -86,12 +81,12 @@ void project(double prec,
  * no coefs).
  *
  */
-template <int D>
-void project(double prec, FunctionTree<D> &out, RepresentableFunction<D> &inp, int maxIter, bool absPrec) {
+template <int D> void project(double prec, FunctionTree<D> &out, RepresentableFunction<D> &inp, int maxIter, bool absPrec) {
     int maxScale = out.getMRA().getMaxScale();
     const auto scaling_factor = out.getMRA().getWorldBox().getScalingFactor();
     TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
+
     ProjectionCalculator<D> calculator(inp, scaling_factor);
 
     builder.build(out, calculator, adaptor, maxIter);
@@ -125,12 +120,7 @@ void project(double prec, FunctionTree<D> &out, RepresentableFunction<D> &inp, i
  * no coefs).
  *
  */
-template <int D>
-void project(double prec,
-             FunctionTreeVector<D> &out,
-             std::vector<std::function<double(const Coord<D> &r)>> func,
-             int maxIter,
-             bool absPrec) {
+template <int D> void project(double prec, FunctionTreeVector<D> &out, std::vector<std::function<double(const Coord<D> &r)>> func, int maxIter, bool absPrec) {
     if (out.size() != func.size()) MSG_ABORT("Size mismatch");
     for (auto j = 0; j < D; j++) mrcpp::project<D>(prec, get_func(out, j), func[j], maxIter, absPrec);
 }
@@ -138,34 +128,11 @@ void project(double prec,
 template void project<1>(double prec, FunctionTree<1> &out, RepresentableFunction<1> &inp, int maxIter, bool absPrec);
 template void project<2>(double prec, FunctionTree<2> &out, RepresentableFunction<2> &inp, int maxIter, bool absPrec);
 template void project<3>(double prec, FunctionTree<3> &out, RepresentableFunction<3> &inp, int maxIter, bool absPrec);
-template void project<1>(double prec,
-                         FunctionTree<1> &out,
-                         std::function<double(const Coord<1> &r)> func,
-                         int maxIter,
-                         bool absPrec);
-template void project<2>(double prec,
-                         FunctionTree<2> &out,
-                         std::function<double(const Coord<2> &r)> func,
-                         int maxIter,
-                         bool absPrec);
-template void project<3>(double prec,
-                         FunctionTree<3> &out,
-                         std::function<double(const Coord<3> &r)> func,
-                         int maxIter,
-                         bool absPrec);
-template void project<1>(double prec,
-                         FunctionTreeVector<1> &out,
-                         std::vector<std::function<double(const Coord<1> &r)>> inp,
-                         int maxIter,
-                         bool absPrec);
-template void project<2>(double prec,
-                         FunctionTreeVector<2> &out,
-                         std::vector<std::function<double(const Coord<2> &r)>> inp,
-                         int maxIter,
-                         bool absPrec);
-template void project<3>(double prec,
-                         FunctionTreeVector<3> &out,
-                         std::vector<std::function<double(const Coord<3> &r)>> inp,
-                         int maxIter,
-                         bool absPrec);
+
+template void project<1>(double prec, FunctionTree<1> &out, std::function<double(const Coord<1> &r)> func, int maxIter, bool absPrec);
+template void project<2>(double prec, FunctionTree<2> &out, std::function<double(const Coord<2> &r)> func, int maxIter, bool absPrec);
+template void project<3>(double prec, FunctionTree<3> &out, std::function<double(const Coord<3> &r)> func, int maxIter, bool absPrec);
+template void project<1>(double prec, FunctionTreeVector<1> &out, std::vector<std::function<double(const Coord<1> &r)>> inp, int maxIter, bool absPrec);
+template void project<2>(double prec, FunctionTreeVector<2> &out, std::vector<std::function<double(const Coord<2> &r)>> inp, int maxIter, bool absPrec);
+template void project<3>(double prec, FunctionTreeVector<3> &out, std::vector<std::function<double(const Coord<3> &r)>> inp, int maxIter, bool absPrec);
 } // namespace mrcpp

--- a/src/treebuilders/project.cpp
+++ b/src/treebuilders/project.cpp
@@ -83,7 +83,7 @@ template <int D> void project(double prec, FunctionTree<D> &out, std::function<d
  */
 template <int D> void project(double prec, FunctionTree<D> &out, RepresentableFunction<D> &inp, int maxIter, bool absPrec) {
     int maxScale = out.getMRA().getMaxScale();
-    const auto scaling_factor = out.getMRA().getWorldBox().getScalingFactor();
+    const auto scaling_factor = out.getMRA().getWorldBox().getScalingFactors();
     TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
 

--- a/src/treebuilders/project.h
+++ b/src/treebuilders/project.h
@@ -30,18 +30,7 @@
 #include <functional>
 
 namespace mrcpp {
-template <int D>
-void project(double prec, FunctionTree<D> &out, RepresentableFunction<D> &inp, int maxIter = -1, bool absPrec = false);
-template <int D>
-void project(double prec,
-             FunctionTree<D> &out,
-             std::function<double(const Coord<D> &r)> func,
-             int maxIter = -1,
-             bool absPrec = false);
-template <int D>
-void project(double prec,
-             FunctionTreeVector<D> &out,
-             std::vector<std::function<double(const Coord<D> &r)>> func,
-             int maxIter = -1,
-             bool absPrec = false);
+template <int D> void project(double prec, FunctionTree<D> &out, RepresentableFunction<D> &inp, int maxIter = -1, bool absPrec = false);
+template <int D> void project(double prec, FunctionTree<D> &out, std::function<double(const Coord<D> &r)> func, int maxIter = -1, bool absPrec = false);
+template <int D> void project(double prec, FunctionTreeVector<D> &out, std::vector<std::function<double(const Coord<D> &r)>> func, int maxIter = -1, bool absPrec = false);
 } // namespace mrcpp

--- a/src/trees/BandWidth.cpp
+++ b/src/trees/BandWidth.cpp
@@ -37,7 +37,7 @@ bool BandWidth::isEmpty(int depth) const {
 }
 
 void BandWidth::setWidth(int depth, int index, int wd) {
-    assert(depth >= 0 and depth < getDepth());
+    if (depth < 0 or depth >= getDepth()) MSG_ABORT("Depth cannot be negative!");
     assert(index >= 0 and index < 4);
     assert(wd >= 0);
     this->widths(depth, index) = wd;

--- a/src/trees/BoundingBox.cpp
+++ b/src/trees/BoundingBox.cpp
@@ -44,7 +44,7 @@ BoundingBox<D>::BoundingBox(int n, const std::array<int, D> &l, const std::array
         : cornerIndex(n, l) {
     setPeriodic(pbc);
     setNBoxes(nb);
-    setScalingFactor(sf);
+    setScalingFactors(sf);
     setDerivedParameters();
 }
 
@@ -53,7 +53,7 @@ BoundingBox<D>::BoundingBox(const NodeIndex<D> &idx, const std::array<int, D> &n
         : cornerIndex(idx) {
     setPeriodic(false);
     setNBoxes(nb);
-    setScalingFactor(sf);
+    setScalingFactors(sf);
     setDerivedParameters();
 }
 
@@ -62,7 +62,7 @@ BoundingBox<D>::BoundingBox(const std::array<double, D> &sf, bool pbc)
         : cornerIndex() {
     setPeriodic(pbc);
     setNBoxes();
-    setScalingFactor(sf);
+    setScalingFactors(sf);
     setDerivedParameters();
 }
 
@@ -71,7 +71,7 @@ BoundingBox<D>::BoundingBox(const std::array<double, D> &sf, std::array<bool, D>
         : cornerIndex() {
     setPeriodic(pbc);
     setNBoxes();
-    setScalingFactor(sf);
+    setScalingFactors(sf);
     setDerivedParameters();
 }
 
@@ -80,7 +80,7 @@ BoundingBox<D>::BoundingBox(const BoundingBox<D> &box)
         : cornerIndex(box.cornerIndex) {
     setPeriodic(box.periodic);
     setNBoxes(box.nBoxes);
-    setScalingFactor(box.getScalingFactor());
+    setScalingFactors(box.getScalingFactors());
     setDerivedParameters();
 }
 
@@ -89,7 +89,7 @@ template <int D> BoundingBox<D> &BoundingBox<D>::operator=(const BoundingBox<D> 
         this->cornerIndex = box.cornerIndex;
         this->periodic = box.periodic;
         setNBoxes(box.nBoxes);
-        setScalingFactor(box.getScalingFactor());
+        setScalingFactors(box.getScalingFactors());
         setDerivedParameters();
     }
     return *this;
@@ -115,7 +115,7 @@ template <int D> void BoundingBox<D>::setDerivedParameters() {
     }
 }
 
-template <int D> void BoundingBox<D>::setScalingFactor(const std::array<double, D> &sf) {
+template <int D> void BoundingBox<D>::setScalingFactors(const std::array<double, D> &sf) {
     assert(this->totBoxes > 0);
     for (auto &x : sf)
         if (x == 0.0 and sf != std::array<double, D>{}) MSG_ABORT("The scaling factor cannot be zero in any of the directions");

--- a/src/trees/BoundingBox.h
+++ b/src/trees/BoundingBox.h
@@ -50,10 +50,7 @@ namespace mrcpp {
 
 template <int D> class BoundingBox {
 public:
-    BoundingBox(int n = 0,
-                const std::array<int, D> &l = {},
-                const std::array<int, D> &nb = {},
-                const std::array<double, D> &sf = {});
+    BoundingBox(int n = 0, const std::array<int, D> &l = {}, const std::array<int, D> &nb = {}, const std::array<double, D> &sf = {}, bool pbc = false);
     BoundingBox(const NodeIndex<D> &idx, const std::array<int, D> &nb = {}, const std::array<double, D> &sf = {});
     BoundingBox(const std::array<double, D> &sf, bool pbc = true);
     BoundingBox(const std::array<double, D> &sf, std::array<bool, D> pbc);
@@ -66,8 +63,8 @@ public:
 
     NodeIndex<D> getNodeIndex(int bIdx) const;
 
-    int getBoxIndex(const Coord<D> &r) const;
-    int getBoxIndex(const NodeIndex<D> &nIdx) const;
+    int getBoxIndex(Coord<D> r) const;
+    int getBoxIndex(NodeIndex<D> nIdx) const;
 
     int size() const { return this->totBoxes; }
     int size(int d) const { return this->nBoxes[d]; }

--- a/src/trees/BoundingBox.h
+++ b/src/trees/BoundingBox.h
@@ -81,7 +81,7 @@ public:
     const Coord<D> &getLowerBounds() const { return this->lowerBounds; }
     const Coord<D> &getUpperBounds() const { return this->upperBounds; }
     const NodeIndex<D> &getCornerIndex() const { return this->cornerIndex; }
-    const std::array<double, D> &getScalingFactor() const { return this->scalingFactor; }
+    const std::array<double, D> &getScalingFactors() const { return this->scalingFactor; }
     friend std::ostream &operator<<(std::ostream &o, const BoundingBox<D> &box) { return box.print(o); }
 
 protected:
@@ -100,7 +100,7 @@ protected:
 
     void setNBoxes(const std::array<int, D> &nb = {});
     void setDerivedParameters();
-    void setScalingFactor(const std::array<double, D> &sf);
+    void setScalingFactors(const std::array<double, D> &sf);
     void setPeriodic(std::array<bool, D> periodic);
     void setPeriodic(bool periodic);
 

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -42,7 +42,6 @@ using namespace Eigen;
 
 namespace mrcpp {
 
-
 /** Function evaluation.
  * Evaluate all polynomials defined on the node. */
 template <int D> double FunctionNode<D>::evalf(Coord<D> r) {
@@ -50,9 +49,7 @@ template <int D> double FunctionNode<D>::evalf(Coord<D> r) {
 
     // The 1.0 appearing in the if tests comes from the period is always 1.0
     // from the point of view of this function.
-    if (this->getMWTree().getRootBox().isPeriodic()) {
-        periodic::coord_manipulation<D>(r, this->getMWTree().getRootBox().getPeriodic());
-    }
+    if (this->getMWTree().getRootBox().isPeriodic()) { periodic::coord_manipulation<D>(r, this->getMWTree().getRootBox().getPeriodic()); }
 
     this->threadSafeGenChildren();
     int cIdx = this->getChildIndex(r);
@@ -216,7 +213,7 @@ template <int D> void FunctionNode<D>::createChildren(bool coefs) {
     this->childSerialIx = sIdx;
     for (int cIdx = 0; cIdx < nChildren; cIdx++) {
         // construct into allocator memory
-        new (child_p) FunctionNode<D>(*this, cIdx);
+        new (child_p) FunctionNode<D>(this, cIdx);
         this->children[cIdx] = child_p;
 
         child_p->serialIx = sIdx;
@@ -254,11 +251,11 @@ template <int D> void FunctionNode<D>::genChildren() {
     this->childSerialIx = sIdx;
     for (int cIdx = 0; cIdx < nChildren; cIdx++) {
         // construct into allocator memory
-        new (child_p) FunctionNode<D>(*this, cIdx);
+        new (child_p) FunctionNode<D>(this, cIdx);
         this->children[cIdx] = child_p;
 
         child_p->serialIx = sIdx;
-        child_p->parentSerialIx = (this->isGenNode()) ? this->serialIx: -1;
+        child_p->parentSerialIx = (this->isGenNode()) ? this->serialIx : -1;
         child_p->childSerialIx = -1;
 
         child_p->n_coefs = n_coefs;
@@ -274,6 +271,38 @@ template <int D> void FunctionNode<D>::genChildren() {
         coefs_p += n_coefs;
     }
     this->setIsBranchNode();
+}
+
+template <int D> void FunctionNode<D>::genParent() {
+    if (this->parent != nullptr) MSG_ABORT("Node is not an orphan");
+
+    auto &allocator = this->getFuncTree().getNodeAllocator();
+    int sIdx = allocator.alloc(1, true);
+
+    auto n_coefs = allocator.getNCoefs();
+    auto *coefs_p = allocator.getCoef_p(sIdx);
+    auto *parent_p = allocator.getNode_p(sIdx);
+
+    this->parentSerialIx = sIdx;
+
+    // construct into allocator memory
+    new (parent_p) FunctionNode<D>(this->tree, this->getNodeIndex().parent());
+
+    this->parent = parent_p;
+
+    for (int cIdx = 0; cIdx < this->getTDim(); cIdx++) parent_p->children[cIdx] = this;
+    parent_p->serialIx = sIdx;
+    parent_p->parentSerialIx = -1;
+    parent_p->childSerialIx = this->serialIx;
+
+    parent_p->n_coefs = n_coefs;
+    parent_p->coefs = coefs_p;
+
+    parent_p->setIsBranchNode();
+    parent_p->setIsAllocated();
+    parent_p->clearHasCoefs();
+
+    this->getMWTree().incrementNodeCount(parent_p->getScale());
 }
 
 template <int D> void FunctionNode<D>::deleteChildren() {

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -332,7 +332,10 @@ template <int D> void FunctionNode<D>::reCompress() {
 }
 
 template <> void FunctionNode<3>::reCompress() {
-    if (this->isBranchNode()) {
+    if (this->getDepth() < 0) {
+        // This happens for negative scale pbc operators
+        MWNode<3>::reCompress();
+    } else if (this->isBranchNode()) {
         if (not this->isAllocated()) MSG_ABORT("Coefs not allocated");
         // can write directly from children coeff into parent coeff
         int stride = this->getMWChild(0).getNCoefs();

--- a/src/trees/FunctionNode.h
+++ b/src/trees/FunctionNode.h
@@ -27,8 +27,8 @@
 
 #include <Eigen/Core>
 
-#include "MWNode.h"
 #include "FunctionTree.h"
+#include "MWNode.h"
 
 namespace mrcpp {
 
@@ -44,6 +44,7 @@ public:
 
     void createChildren(bool coefs) override;
     void genChildren() override;
+    void genParent() override;
     void deleteChildren() override;
 
     void setValues(const Eigen::VectorXd &vec);
@@ -54,9 +55,14 @@ public:
     friend class NodeAllocator<D>;
 
 protected:
-    FunctionNode() : MWNode<D>() {}
-    FunctionNode(MWTree<D> &tree, int rIdx) : MWNode<D>(tree, rIdx) {}
-    FunctionNode(MWNode<D> &parent, int cIdx) : MWNode<D>(parent, cIdx) {}
+    FunctionNode()
+            : MWNode<D>() {}
+    FunctionNode(MWTree<D> *tree, int rIdx)
+            : MWNode<D>(tree, rIdx) {}
+    FunctionNode(MWNode<D> *parent, int cIdx)
+            : MWNode<D>(parent, cIdx) {}
+    FunctionNode(MWTree<D> *tree, const NodeIndex<D> &idx)
+            : MWNode<D>(tree, idx) {}
     FunctionNode(const FunctionNode<D> &node) = delete;
     FunctionNode<D> &operator=(const FunctionNode<D> &node) = delete;
     ~FunctionNode() = default;

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -195,7 +195,7 @@ template <int D> double FunctionTree<D>::integrate() const {
     }
 
     // Handle potential scaling
-    auto sf = this->getMRA().getWorldBox().getScalingFactor();
+    auto sf = this->getMRA().getWorldBox().getScalingFactors();
     auto jacobian = 1.0;
     for (const auto &sf_i : sf) jacobian *= std::sqrt(sf_i);
     // Square root of scaling factor in each diection. The seemingly missing
@@ -220,7 +220,7 @@ template <int D> double FunctionTree<D>::integrate() const {
 template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 
     // Handle potential scaling
-    const auto sf = this->getMRA().getWorldBox().getScalingFactor();
+    const auto sf = this->getMRA().getWorldBox().getScalingFactors();
     auto arg = r;
     for (auto i = 0; i < D; i++) arg[i] = arg[i] / sf[i];
 

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -96,17 +96,10 @@ public:
     const FunctionNode<D> &getRootFuncNode(int i) const { return static_cast<const FunctionNode<D> &>(this->rootBox.getNode(i)); }
 
     void deleteGenerated();
+    void deleteGeneratedParents();
 
-    void makeCoeffVector(std::vector<double *> &coefs,
-                         std::vector<int> &indices,
-                         std::vector<int> &parent_indices,
-                         std::vector<double> &scalefac,
-                         int &max_index,
-                         MWTree<D> &refTree);
-    void makeTreefromCoeff(MWTree<D> &refTree,
-                           std::vector<double *> coefpVec,
-                           std::map<int, int> &ix2coef,
-                           double absPrec);
+    void makeCoeffVector(std::vector<double *> &coefs, std::vector<int> &indices, std::vector<int> &parent_indices, std::vector<double> &scalefac, int &max_index, MWTree<D> &refTree);
+    void makeTreefromCoeff(MWTree<D> &refTree, std::vector<double *> coefpVec, std::map<int, int> &ix2coef, double absPrec);
     void appendTreeNoCoeff(MWTree<D> &inTree);
 
 protected:

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -322,7 +322,7 @@ template <int D> void MWNode<D>::cvTransform(int operation) {
         out_vec = tmp;
     }
 
-    const auto sf = this->getMWTree().getMRA().getWorldBox().getScalingFactor();
+    const auto sf = this->getMWTree().getMRA().getWorldBox().getScalingFactors();
     double sf_prod = 1.0;
     for (const auto &s : sf) sf_prod *= s;
     if (sf_prod <= MachineZero) sf_prod = 1.0; // When there is no scaling factor
@@ -602,7 +602,7 @@ template <int D> void MWNode<D>::getCenter(double *r) const {
 }
 
 template <int D> void MWNode<D>::getBounds(double *lb, double *ub) const {
-    const auto sf = getMWTree().getMRA().getWorldBox().getScalingFactor();
+    const auto sf = getMWTree().getMRA().getWorldBox().getScalingFactors();
     int n = getScale();
     double p = std::pow(2.0, -n);
     const NodeIndex<D> &l = getNodeIndex();

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -58,10 +58,23 @@ MWNode<D>::MWNode()
 }
 
 template <int D>
-MWNode<D>::MWNode(MWTree<D> &tree, int rIdx)
-        : tree(&tree)
+MWNode<D>::MWNode(MWTree<D> *tree, const NodeIndex<D> &idx)
+        : tree(tree)
         , parent(nullptr)
-        , nodeIndex(tree.getRootBox().getNodeIndex(rIdx))
+        , nodeIndex(idx)
+        , hilbertPath() {
+    for (int i = 0; i < getTDim(); i++) this->children[i] = nullptr;
+    clearNorms();
+    clearIsAllocated();
+    clearHasCoefs();
+    MRCPP_INIT_OMP_LOCK();
+}
+
+template <int D>
+MWNode<D>::MWNode(MWTree<D> *tree, int rIdx)
+        : tree(tree)
+        , parent(nullptr)
+        , nodeIndex(tree->getRootBox().getNodeIndex(rIdx))
         , hilbertPath() {
     for (int i = 0; i < getTDim(); i++) this->children[i] = nullptr;
     clearNorms();
@@ -74,11 +87,11 @@ MWNode<D>::MWNode(MWTree<D> &tree, int rIdx)
 }
 
 template <int D>
-MWNode<D>::MWNode(MWNode<D> &parent, int cIdx)
-        : tree(parent.tree)
-        , parent(&parent)
-        , nodeIndex(parent.getNodeIndex().child(cIdx))
-        , hilbertPath(parent.getHilbertPath(), cIdx) {
+MWNode<D>::MWNode(MWNode<D> *parent, int cIdx)
+        : tree(parent->tree)
+        , parent(parent)
+        , nodeIndex(parent->getNodeIndex().child(cIdx))
+        , hilbertPath(parent->getHilbertPath(), cIdx) {
     for (int i = 0; i < getTDim(); i++) this->children[i] = nullptr;
     clearNorms();
     clearIsAllocated();
@@ -157,8 +170,8 @@ template <int D> void MWNode<D>::printCoefs() const {
     println(0, "\nMW coefs");
     int kp1_d = this->getKp1_d();
     for (int i = 0; i < this->n_coefs; i++) {
-        println(0, this->coefs[i]);
         if (i % kp1_d == 0) println(0, "\n");
+        println(0, this->coefs[i]);
     }
 }
 
@@ -216,6 +229,44 @@ template <int D> void MWNode<D>::giveChildrenCoefs(bool overwrite) {
         getMWChild(i).setHasCoefs();
         getMWChild(i).calcNorms(); // should need to compute only scaling norms
     }
+}
+
+template <int D> void MWNode<D>::giveChildCoefs(int cIdx, bool overwrite) {
+
+    MWNode<D> node_i = *this;
+
+    node_i.mwTransform(Reconstruction);
+
+    int kp1_d = this->getKp1_d();
+    int nChildren = this->getTDim();
+
+    if (this->children[cIdx] == nullptr) MSG_ABORT("Child does not exist!");
+    MWNode<D> &child = getMWChild(cIdx);
+    if (overwrite) {
+        child.setCoefBlock(0, kp1_d, &node_i.getCoefs()[cIdx * kp1_d]);
+    } else {
+        child.addCoefBlock(0, kp1_d, &node_i.getCoefs()[cIdx * kp1_d]);
+    }
+    child.setHasCoefs();
+    child.calcNorms();
+}
+
+/** Takes a MWParent and generates coefficients, reverse operation from
+ * giveChildrenCoefs */
+template <int D> void MWNode<D>::giveParentCoefs(bool overwrite) {
+    MWNode<D> node = *this;
+    MWNode<D> &parent = getMWParent();
+    int kp1_d = this->getKp1_d();
+    if (node.getScale() == 0) {
+        NodeBox<D> &box = this->getMWTree().getRootBox();
+        auto reverse = getTDim() - 1;
+        for (auto i = 0; i < getTDim(); i++) { parent.setCoefBlock(i, kp1_d, &box.getNode(reverse - i).getCoefs()[0]); }
+    } else {
+        for (auto i = 0; i < getTDim(); i++) { parent.setCoefBlock(i, kp1_d, &node.getCoefs()[0]); }
+    }
+    parent.mwTransform(Compression);
+    parent.setHasCoefs();
+    parent.calcNorms();
 }
 
 /** Takes the scaling coefficients of the children and stores them consecutively
@@ -500,6 +551,10 @@ template <int D> void MWNode<D>::genChildren() {
     NOT_REACHED_ABORT;
 }
 
+template <int D> void MWNode<D>::genParent() {
+    NOT_REACHED_ABORT;
+}
+
 /** Recursive deallocation of children and all their descendants.
  * Leaves node as LeafNode and children[] as null pointer. */
 template <int D> void MWNode<D>::deleteChildren() {
@@ -514,6 +569,16 @@ template <int D> void MWNode<D>::deleteChildren() {
     }
     this->childSerialIx = -1;
     this->setIsLeafNode();
+}
+
+/** Recursive deallocation of parent and all their forefathers. */
+template <int D> void MWNode<D>::deleteParent() {
+    if (this->parent == nullptr) return;
+    MWNode<D> &parent = getMWParent();
+    parent.deleteParent();
+    parent.dealloc();
+    this->parentSerialIx = -1;
+    this->parent = nullptr;
 }
 
 template <int D> void MWNode<D>::deleteGenerated() {
@@ -766,11 +831,30 @@ template <int D> MWNode<D> *MWNode<D>::retrieveNode(const NodeIndex<D> &idx) {
         assert(getNodeIndex() == idx);
         return this;
     }
+
     assert(isAncestor(idx));
     threadSafeGenChildren();
     int cIdx = getChildIndex(idx);
     assert(this->children[cIdx] != nullptr);
     return this->children[cIdx]->retrieveNode(idx);
+}
+
+/** Node retriever that ALWAYS returns the requested node.
+ *
+ * WARNING: This routine is NOT thread safe! Must be used within omp critical.
+ *
+ * Recursive routine to find and return the node with a given NodeIndex. This
+ * routine always returns the appropriate node, and will generate nodes that
+ * does not exist. Recursion starts at this node and ASSUMES the requested
+ * node is in fact related to this node. */
+template <int D> MWNode<D> *MWNode<D>::retrieveParent(const NodeIndex<D> &idx) {
+    if (getScale() < idx.getScale()) MSG_ABORT("Scale error")
+    if (getScale() == idx.getScale()) return this;
+    if (this->parent == nullptr) {
+        genParent();
+        giveParentCoefs();
+    }
+    return this->parent->retrieveParent(idx);
 }
 
 /** Gives the norm (absolute value) of the node at the given NodeIndex.

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -108,13 +108,16 @@ public:
 
     virtual void createChildren(bool coefs);
     virtual void genChildren();
+    virtual void genParent();
     virtual void deleteChildren();
+    virtual void deleteParent();
 
     virtual void cvTransform(int kind);
     virtual void mwTransform(int kind);
 
     double getNodeNorm(const NodeIndex<D> &idx) const;
 
+    bool hasParent() const { return (parent != nullptr) ? true : false; }
     bool hasCoefs() const { return (this->status & FlagHasCoefs); }
     bool isEndNode() const { return (this->status & FlagEndNode); }
     bool isGenNode() const { return (this->status & FlagGenNode); }
@@ -171,8 +174,9 @@ protected:
     HilbertPath<D> hilbertPath;
 
     MWNode();
-    MWNode(MWTree<D> &tree, int rIdx);
-    MWNode(MWNode<D> &parent, int cIdx);
+    MWNode(MWTree<D> *tree, int rIdx);
+    MWNode(MWTree<D> *tree, const NodeIndex<D> &idx);
+    MWNode(MWNode<D> *parent, int cIdx);
     virtual void dealloc();
 
     bool crop(double prec, double splitFac, bool absPrec);
@@ -189,6 +193,8 @@ protected:
 
     virtual void reCompress();
     virtual void giveChildrenCoefs(bool overwrite = true);
+    virtual void giveChildCoefs(int cIdx, bool overwrite = true);
+    virtual void giveParentCoefs(bool overwrite = true);
     virtual void copyCoefsFromChildren();
 
     int getChildIndex(const NodeIndex<D> &nIdx) const;
@@ -198,6 +204,7 @@ protected:
 
     MWNode<D> *retrieveNode(const Coord<D> &r, int depth);
     MWNode<D> *retrieveNode(const NodeIndex<D> &idx);
+    MWNode<D> *retrieveParent(const NodeIndex<D> &idx);
 
     const MWNode<D> *retrieveNodeNoGen(const NodeIndex<D> &idx) const;
     MWNode<D> *retrieveNodeNoGen(const NodeIndex<D> &idx);

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -188,15 +188,15 @@ template <int D> void MWTree<D>::incrementNodeCount(int scale) {
 template <int D> void MWTree<D>::decrementNodeCount(int scale) {
     int depth = scale - getRootScale();
     if (depth < 0) {
-        assert(depth < this->nodesAtNegativeDepth.size());
+        assert(-depth - 1 < this->nodesAtNegativeDepth.size());
         this->nodesAtNegativeDepth[-depth - 1]--;
-        assert(this->nodesAtNegativeDepth[depth - 1] >= 0);
-        if (this->nodesAtNegativeDepth[-depth - 1] == 0 and this->nodesAtNegativeDepth.size() > 1) { this->nodesAtNegativeDepth.pop_back(); }
+        assert(this->nodesAtNegativeDepth[-depth - 1] >= 0);
+        if (this->nodesAtNegativeDepth[-depth - 1] == 0 and this->nodesAtNegativeDepth.size() > 1) this->nodesAtNegativeDepth.pop_back();
     } else {
         assert(depth < this->nodesAtDepth.size());
         this->nodesAtDepth[depth]--;
         assert(this->nodesAtDepth[depth] >= 0);
-        if (this->nodesAtDepth[depth] == 0 and this->nodesAtDepth.size() > 1) { this->nodesAtDepth.pop_back(); }
+        if (this->nodesAtDepth[depth] == 0 and this->nodesAtDepth.size() > 1) this->nodesAtDepth.pop_back();
     }
 }
 

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -31,6 +31,7 @@
 #include "utils/omp_utils.h"
 
 #include "MultiResolutionAnalysis.h"
+#include "NodeAllocator.h"
 #include "NodeBox.h"
 
 namespace mrcpp {
@@ -54,10 +55,12 @@ public:
     int getKp1_d() const { return this->kp1_d; }
     int getDim() const { return D; }
     int getTDim() const { return (1 << D); }
-    int getNNodes(int depth = -1) const;
+    int getNNodes() const { return getNodeAllocator().getNNodes(); }
+    int getNNegScales() const { return this->nodesAtNegativeDepth.size(); }
     int getNEndNodes() const { return this->endNodeTable.size(); }
     int getRootScale() const { return this->rootBox.getScale(); }
     int getDepth() const { return this->nodesAtDepth.size(); }
+    int getNNodesAtDepth(int i) const;
     int getSizeNodes() const;
 
     NodeBox<D> &getRootBox() { return this->rootBox; }
@@ -69,8 +72,8 @@ public:
     void setName(const std::string &n) { this->name = n; }
     const std::string &getName() const { return this->name; }
 
-    int getRootIndex(const Coord<D> &r) const { return this->rootBox.getBoxIndex(r); }
-    int getRootIndex(const NodeIndex<D> &nIdx) const { return this->rootBox.getBoxIndex(nIdx); }
+    int getRootIndex(Coord<D> r) const { return this->rootBox.getBoxIndex(r); }
+    int getRootIndex(NodeIndex<D> nIdx) const { return this->rootBox.getBoxIndex(nIdx); }
 
     MWNode<D> *findNode(NodeIndex<D> nIdx);
     const MWNode<D> *findNode(NodeIndex<D> nIdx) const;
@@ -79,7 +82,7 @@ public:
     MWNode<D> &getNodeOrEndNode(NodeIndex<D> nIdx);
     const MWNode<D> &getNodeOrEndNode(NodeIndex<D> nIdx) const;
 
-    MWNode<D> &getNode(const Coord<D> &r, int depth = -1);
+    MWNode<D> &getNode(Coord<D> r, int depth = -1);
     MWNode<D> &getNodeOrEndNode(Coord<D> r, int depth = -1);
     const MWNode<D> &getNodeOrEndNode(Coord<D> r, int depth = -1) const;
 
@@ -88,6 +91,8 @@ public:
 
     const MWNode<D> &getEndMWNode(int i) const { return *this->endNodeTable[i]; }
     const MWNode<D> &getRootMWNode(int i) const { return this->rootBox.getNode(i); }
+
+    int getPeriodicOperatorReach() const { return this->MRA.getPeriodicOperatorReach(); }
 
     MWNodeVector<D> *copyEndNodeTable();
     MWNodeVector<D> *getEndNodeTable() { return &this->endNodeTable; }
@@ -129,9 +134,10 @@ protected:
 
     // Tree data
     double squareNorm;
-    NodeBox<D> rootBox;            ///< The actual container of nodes
-    MWNodeVector<D> endNodeTable;  ///< Final projected nodes
-    std::vector<int> nodesAtDepth; ///< Node counter
+    NodeBox<D> rootBox;                    ///< The actual container of nodes
+    MWNodeVector<D> endNodeTable;          ///< Final projected nodes
+    std::vector<int> nodesAtDepth;         ///< Node counter
+    std::vector<int> nodesAtNegativeDepth; ///< Node counter
 
     virtual void mwTransformDown(bool overwrite);
     virtual void mwTransformUp();

--- a/src/trees/MultiResolutionAnalysis.h
+++ b/src/trees/MultiResolutionAnalysis.h
@@ -61,13 +61,21 @@ public:
     const BoundingBox<D> &getWorldBox() const { return this->world; }
 
     void setPeriodicOperatorReach(int reach) { this->periodic_operator_reach = reach; }
-    int getPeriodicOperatorReach() { return this->periodic_operator_reach; }
+    int getPeriodicOperatorReach() const { return this->periodic_operator_reach; }
+
+    void setPeriodicOperatorCutOff(int periodic_cut_off) { this->periodic_cut_off = periodic_cut_off; }
+    int getPeriodicOperatorCutOff() const { return this->periodic_cut_off; }
+
+    void setOperatorScale(int scale) { this->operator_scale = scale; }
+    int getOperatorScale() const { return this->operator_scale; }
 
     void setStds(double stds) { this->n_gauss_stds = stds; }
     double getStds() { return this->n_gauss_stds; }
 
     MultiResolutionAnalysis<1> getKernelMRA() const;
     MultiResolutionAnalysis<2> getOperatorMRA() const;
+
+    int getRootScale() const { return this->world.getScale(); }
 
     bool operator==(const MultiResolutionAnalysis<D> &mra) const;
     bool operator!=(const MultiResolutionAnalysis<D> &mra) const;
@@ -78,7 +86,9 @@ protected:
     const int maxDepth;
     const ScalingBasis basis;
     const BoundingBox<D> world;
-    int periodic_operator_reach{10};
+    int periodic_operator_reach{2};
+    int periodic_cut_off{1};
+    int operator_scale{0};
     double n_gauss_stds{4};
     MWFilter *filter;
 

--- a/src/trees/NodeBox.cpp
+++ b/src/trees/NodeBox.cpp
@@ -89,12 +89,12 @@ template <int D> void NodeBox<D>::setNode(int bIdx, MWNode<D> **node) {
     *node = nullptr;
 }
 
-template <int D> MWNode<D> &NodeBox<D>::getNode(const NodeIndex<D> &nIdx) {
+template <int D> MWNode<D> &NodeBox<D>::getNode(NodeIndex<D> nIdx) {
     int bIdx = this->getBoxIndex(nIdx);
     return getNode(bIdx);
 }
 
-template <int D> MWNode<D> &NodeBox<D>::getNode(const Coord<D> &r) {
+template <int D> MWNode<D> &NodeBox<D>::getNode(Coord<D> r) {
     int bIdx = this->getBoxIndex(r);
     if (bIdx < 0) MSG_ERROR("Coord out of bounds");
     return getNode(bIdx);
@@ -107,12 +107,12 @@ template <int D> MWNode<D> &NodeBox<D>::getNode(int bIdx) {
     return *this->nodes[bIdx];
 }
 
-template <int D> const MWNode<D> &NodeBox<D>::getNode(const NodeIndex<D> &nIdx) const {
+template <int D> const MWNode<D> &NodeBox<D>::getNode(NodeIndex<D> nIdx) const {
     int bIdx = this->getBoxIndex(nIdx);
     return getNode(bIdx);
 }
 
-template <int D> const MWNode<D> &NodeBox<D>::getNode(const Coord<D> &r) const {
+template <int D> const MWNode<D> &NodeBox<D>::getNode(Coord<D> r) const {
     int bIdx = this->getBoxIndex(r);
     if (bIdx < 0) MSG_ERROR("Coord out of bounds");
     return getNode(bIdx);

--- a/src/trees/NodeBox.h
+++ b/src/trees/NodeBox.h
@@ -23,15 +23,6 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
-/**
- *
- *
- *  \date May 24, 2014
- *  \author Stig Rune Jensen <stig.r.jensen@uit.no> \n
- *          CTCC, University of Tromsø
- *
- */
-
 #pragma once
 
 #include "BoundingBox.h"
@@ -50,12 +41,12 @@ public:
     void setNode(int idx, MWNode<D> **node);
     void clearNode(int idx) { this->nodes[idx] = nullptr; }
 
-    MWNode<D> &getNode(const NodeIndex<D> &idx);
-    MWNode<D> &getNode(const Coord<D> &r);
+    MWNode<D> &getNode(NodeIndex<D> idx);
+    MWNode<D> &getNode(Coord<D> r);
     MWNode<D> &getNode(int i = 0);
 
-    const MWNode<D> &getNode(const NodeIndex<D> &idx) const;
-    const MWNode<D> &getNode(const Coord<D> &r) const;
+    const MWNode<D> &getNode(NodeIndex<D> idx) const;
+    const MWNode<D> &getNode(Coord<D> r) const;
     const MWNode<D> &getNode(int i = 0) const;
 
     int getNOccupied() const { return this->nOccupied; }

--- a/src/trees/OperatorNode.cpp
+++ b/src/trees/OperatorNode.cpp
@@ -87,7 +87,7 @@ void OperatorNode::createChildren(bool coefs) {
     this->childSerialIx = sIdx;
     for (int cIdx = 0; cIdx < nChildren; cIdx++) {
         // construct into allocator memory
-        new (child_p) OperatorNode(*this, cIdx);
+        new (child_p) OperatorNode(this, cIdx);
         this->children[cIdx] = child_p;
 
         child_p->serialIx = sIdx;

--- a/src/trees/OperatorNode.h
+++ b/src/trees/OperatorNode.h
@@ -48,9 +48,12 @@ public:
     friend class NodeAllocator<2>;
 
 protected:
-    OperatorNode() : MWNode<2>() {};
-    OperatorNode(MWTree<2> &tree, int rIdx) : MWNode<2>(tree, rIdx) {};
-    OperatorNode(MWNode<2> &parent, int cIdx) : MWNode<2>(parent, cIdx) {};
+    OperatorNode()
+            : MWNode<2>(){};
+    OperatorNode(MWTree<2> *tree, int rIdx)
+            : MWNode<2>(tree, rIdx){};
+    OperatorNode(MWNode<2> *parent, int cIdx)
+            : MWNode<2>(parent, cIdx){};
     OperatorNode(const OperatorNode &node) = delete;
     OperatorNode &operator=(const OperatorNode &node) = delete;
     ~OperatorNode() = default;

--- a/src/trees/OperatorTree.cpp
+++ b/src/trees/OperatorTree.cpp
@@ -26,8 +26,8 @@
 #include "OperatorTree.h"
 #include "BandWidth.h"
 #include "LebesgueIterator.h"
-#include "OperatorNode.h"
 #include "NodeAllocator.h"
+#include "OperatorNode.h"
 #include "utils/Printer.h"
 #include "utils/tree_utils.h"
 
@@ -64,7 +64,7 @@ void OperatorTree::allocRootNodes() {
     MWNode<2> **roots = rootbox.getNodes();
     for (int rIdx = 0; rIdx < nRoots; rIdx++) {
         // construct into allocator memory
-        new (root_p) OperatorNode(*this, rIdx);
+        new (root_p) OperatorNode(this, rIdx);
         roots[rIdx] = root_p;
 
         root_p->serialIx = sIdx;
@@ -72,7 +72,7 @@ void OperatorTree::allocRootNodes() {
         root_p->childSerialIx = -1;
 
         root_p->n_coefs = n_coefs;
-        root_p->coefs = coef_p;;
+        root_p->coefs = coef_p;
         root_p->setIsAllocated();
 
         root_p->setIsRootNode();

--- a/src/trees/TreeIterator.h
+++ b/src/trees/TreeIterator.h
@@ -40,6 +40,7 @@ public:
 
     void init(MWTree<D> *tree);
     bool next();
+    bool nextParent();
     MWNode<D> &getNode() { return *this->state->node; }
 
     friend class IteratorNode<D>;
@@ -55,9 +56,11 @@ protected:
 
     virtual int getChildIndex(int i) const = 0;
 
-    bool tryNode();
+    bool tryParent();
     bool tryChild(int i);
+    bool tryNode();
     bool tryNextRoot();
+    bool tryNextRootParent();
     void removeState();
     void setDirection(int dir);
     bool checkDepth(const MWNode<D> &node) const;
@@ -69,6 +72,7 @@ public:
     MWNode<D> *node;
     IteratorNode<D> *next;
     bool doneNode;
+    bool doneParent;
     bool doneChild[1 << D];
 
     IteratorNode(MWNode<D> *nd, IteratorNode<D> *nx = nullptr);

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -173,20 +173,7 @@ void math_utils::tensor_self_product(const VectorXd &A, MatrixXd &tprod) {
 
 void math_utils::apply_filter(double *out, double *in, const MatrixXd &filter, int kp1, int kp1_dm1, double fac) {
 #ifdef HAVE_BLAS
-    cblas_dgemm(CblasColMajor,
-                CblasTrans,
-                CblasNoTrans,
-                kp1_dm1,
-                kp1,
-                kp1,
-                1.0,
-                in,
-                kp1,
-                filter.data(),
-                kp1,
-                fac,
-                out,
-                kp1_dm1);
+    cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans, kp1_dm1, kp1, kp1, 1.0, in, kp1, filter.data(), kp1, fac, out, kp1_dm1);
 #else
     Map<MatrixXd> f(in, kp1, kp1_dm1);
     Map<MatrixXd> g(out, kp1_dm1, kp1);
@@ -203,20 +190,13 @@ void math_utils::apply_filter(double *out, double *in, const MatrixXd &filter, i
  * This method uses the "output" vector as initial input, in order to
  * avoid the use of temporaries.
  */
-void math_utils::tensor_expand_coefs(int dim,
-                                     int dir,
-                                     int kp1,
-                                     int kp1_d,
-                                     const MatrixXd &primitive,
-                                     VectorXd &expanded) {
+void math_utils::tensor_expand_coefs(int dim, int dir, int kp1, int kp1_d, const MatrixXd &primitive, VectorXd &expanded) {
     if (dir < dim - 1) {
         int idx = math_utils::ipow(kp1, dir + 1);
         int nelem = idx * kp1;
         int pos = kp1_d - nelem;
         int inpos = kp1_d - idx;
-        for (int i = 0; i < kp1; i++) {
-            expanded.segment(pos + i * idx, idx) = expanded.segment(inpos, idx) * primitive.col(dir + 1)(i);
-        }
+        for (int i = 0; i < kp1; i++) expanded.segment(pos + i * idx, idx) = expanded.segment(inpos, idx) * primitive.col(dir + 1)(i);
         tensor_expand_coefs(dim, dir + 1, kp1, kp1_d, primitive, expanded);
     }
 }
@@ -253,7 +233,52 @@ template <int D> double math_utils::calc_distance(const Coord<D> &a, const Coord
     return std::sqrt(r);
 }
 
+/** Calculate the cartesian_product A x B */
+template <class T> std::vector<std::vector<T>> math_utils::cartesian_product(std::vector<T> A, std::vector<T> B) {
+    std::vector<std::vector<T>> output;
+    for (auto &a : A) {
+        for (auto &b : B) output.push_back(std::vector<T>{a, b});
+    }
+    return output;
+}
+
+/** Calculate the cartesian product between a matrix l_A  and the vector B */
+template <class T> std::vector<std::vector<T>> math_utils::cartesian_product(std::vector<std::vector<T>> l_A, std::vector<T> B) {
+    std::vector<std::vector<T>> output;
+    for (auto A : l_A) {
+        for (auto &b : B) {
+            A.push_back(b);
+            output.push_back(A);
+            A.pop_back();
+        }
+    }
+    return output;
+}
+
+/** Calculate the cartesian product between A vector and itself with A repeater,
+ ie. reapeat 4 is equal to the cartesian product A x A x A x A */
+template <class T> std::vector<std::vector<T>> math_utils::cartesian_product(std::vector<T> A, int dim) {
+    std::vector<std::vector<T>> output;
+    if (dim < 0) MSG_ABORT("Dimension has to be 1 or greater")
+    if (dim == 1) {
+        for (auto v : A) output.push_back(std::vector<T>{v});
+    } else {
+        output = cartesian_product(A, A);
+        for (auto i = 0; i < dim - 2; i++) output = cartesian_product(output, A);
+    }
+    return output;
+}
+
 template double math_utils::calc_distance<1>(const Coord<1> &a, const Coord<1> &b);
 template double math_utils::calc_distance<2>(const Coord<2> &a, const Coord<2> &b);
 template double math_utils::calc_distance<3>(const Coord<3> &a, const Coord<3> &b);
+
+template std::vector<std::vector<int>> math_utils::cartesian_product(std::vector<int> A, std::vector<int> B);
+template std::vector<std::vector<int>> math_utils::cartesian_product(std::vector<std::vector<int>> l_A, std::vector<int> B);
+template std::vector<std::vector<int>> math_utils::cartesian_product(std::vector<int> A, int dim);
+
+template std::vector<std::vector<double>> math_utils::cartesian_product(std::vector<double> A, std::vector<double> B);
+template std::vector<std::vector<double>> math_utils::cartesian_product(std::vector<std::vector<double>> l_A, std::vector<double> B);
+template std::vector<std::vector<double>> math_utils::cartesian_product(std::vector<double> A, int dim);
+
 } // namespace mrcpp

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -57,15 +57,14 @@ double matrix_norm_2(const Eigen::MatrixXd &M);
 
 void apply_filter(double *out, double *in, const Eigen::MatrixXd &filter, int kp1, int kp1_dm1, double fac);
 
-void tensor_expand_coefs(int dim,
-                         int dir,
-                         int kp1,
-                         int kp1_d,
-                         const Eigen::MatrixXd &primitive,
-                         Eigen::VectorXd &expanded);
+void tensor_expand_coefs(int dim, int dir, int kp1, int kp1_d, const Eigen::MatrixXd &primitive, Eigen::VectorXd &expanded);
 
 void tensor_expand_coords_2D(int kp1, const Eigen::MatrixXd &primitive, Eigen::MatrixXd &expanded);
 void tensor_expand_coords_3D(int kp1, const Eigen::MatrixXd &primitive, Eigen::MatrixXd &expanded);
+
+template <class T> std::vector<std::vector<T>> cartesian_product(std::vector<T> A, std::vector<T> B);
+template <class T> std::vector<std::vector<T>> cartesian_product(std::vector<std::vector<T>> l_A, std::vector<T> B);
+template <class T> std::vector<std::vector<T>> cartesian_product(std::vector<T> a, int dim);
 
 template <int D> double calc_distance(const Coord<D> &a, const Coord<D> &b);
 

--- a/src/utils/periodic_utils.cpp
+++ b/src/utils/periodic_utils.cpp
@@ -33,32 +33,71 @@
 namespace mrcpp {
 namespace periodic {
 
-template <int D> void indx_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic) {
-    if (idx.getScale() < 0) MSG_ABORT("Negative value in bit-shift");
-    std::array<int, D> translation;
-    int two_n = 1 << idx.getScale();
+template <int D> bool in_unit_cell(NodeIndex<D> idx) {
+    auto scale = idx.getScale();
+    if (scale < 0) MSG_ABORT("Negative value in bit-shift");
+    int two_n = 1 << (scale + 1);
+
+    int l[D];
     for (auto i = 0; i < D; i++) {
-        translation[i] = idx.getTranslation(i);
-        if (periodic[i]) {
-            if (translation[i] >= two_n) translation[i] = translation[i] % two_n;
-            if (translation[i] < 0) translation[i] = (translation[i] + 1) % two_n + two_n - 1;
-        }
+        l[i] = idx[i] + two_n / 2;
+        if (l[i] >= two_n) return false;
+        if (l[i] < 0) return false;
     }
-    idx.setTranslation(translation);
+
+    return true;
 }
 
+template <int D> void index_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic) {
+    if (not periodic[0]) MSG_ABORT("Only for periodic cases!");
+
+    auto scale = idx.getScale();
+    if (scale < 0) {
+        std::array<int, D> translation;
+        for (auto i = 0; i < D; i++) {
+            if (idx[i] < 0) translation[i] = -1;
+            if (idx[i] >= 0) translation[i] = 0;
+        }
+        idx.setTranslation(translation);
+
+    } else {
+        std::array<int, D> translation;
+        int two_n = 1 << (scale + 1);
+
+        for (auto i = 0; i < D; i++) {
+            translation[i] = idx[i] + two_n / 2;
+            if (periodic[i]) {
+                if (translation[i] >= two_n) translation[i] = translation[i] % two_n;
+                if (translation[i] < 0) translation[i] = (translation[i] + 1) % two_n + two_n - 1;
+            }
+            translation[i] -= two_n / 2;
+        }
+        idx.setTranslation(translation);
+    }
+}
+
+// Assumes a coordiate for a function defined on the [-1, 1] periodic cell.
+// If r[i] is outside the unit-cell the function value is mapped to the unit-cell.
 template <int D> void coord_manipulation(Coord<D> &r, const std::array<bool, D> &periodic) {
     for (auto i = 0; i < D; i++) {
+        r[i] *= 0.5;
+        r[i] += 0.5;
         if (periodic[i]) {
-            if (r[i] > 1.0) r[i] = std::fmod(r[i], 1.0);
+            if (r[i] >= 1.0) r[i] = std::fmod(r[i], 1.0);
             if (r[i] < 0.0) r[i] = std::fmod(r[i], 1.0) + 1.0;
         }
+        r[i] -= 0.5;
+        r[i] /= 0.5;
     }
 }
 
-template void indx_manipulation<1>(NodeIndex<1> &idx, const std::array<bool, 1> &periodic);
-template void indx_manipulation<2>(NodeIndex<2> &idx, const std::array<bool, 2> &periodic);
-template void indx_manipulation<3>(NodeIndex<3> &idx, const std::array<bool, 3> &periodic);
+template bool in_unit_cell<1>(NodeIndex<1> idx);
+template bool in_unit_cell<2>(NodeIndex<2> idx);
+template bool in_unit_cell<3>(NodeIndex<3> idx);
+
+template void index_manipulation<1>(NodeIndex<1> &idx, const std::array<bool, 1> &periodic);
+template void index_manipulation<2>(NodeIndex<2> &idx, const std::array<bool, 2> &periodic);
+template void index_manipulation<3>(NodeIndex<3> &idx, const std::array<bool, 3> &periodic);
 
 template void coord_manipulation<1>(Coord<1> &r, const std::array<bool, 1> &periodic);
 template void coord_manipulation<2>(Coord<2> &r, const std::array<bool, 2> &periodic);

--- a/src/utils/periodic_utils.h
+++ b/src/utils/periodic_utils.h
@@ -28,7 +28,8 @@
 #include "MRCPP/mrcpp_declarations.h"
 namespace mrcpp {
 namespace periodic {
-template <int D> void indx_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic);
+template <int D> bool in_unit_cell(NodeIndex<D> idx);
+template <int D> void index_manipulation(NodeIndex<D> &idx, const std::array<bool, D> &periodic);
 template <int D> void coord_manipulation(Coord<D> &r, const std::array<bool, D> &periodic);
 } // namespace periodic
 } // namespace mrcpp

--- a/src/utils/tree_utils.h
+++ b/src/utils/tree_utils.h
@@ -30,13 +30,13 @@
 namespace mrcpp {
 namespace tree_utils {
 
-template<int D> bool split_check(const MWNode<D> &node, double prec, double split_fac, bool abs_prec);
+template <int D> bool split_check(const MWNode<D> &node, double prec, double split_fac, bool abs_prec);
 
-template<int D> void make_node_table(MWTree<D> &tree, MWNodeVector<D> &table);
-template<int D> void make_node_table(MWTree<D> &tree, std::vector<MWNodeVector<D>> &table);
+template <int D> void make_node_table(MWTree<D> &tree, MWNodeVector<D> &table);
+template <int D> void make_node_table(MWTree<D> &tree, std::vector<MWNodeVector<D>> &table);
 
-template<int D> void mw_transform(const MWTree<D> &tree, double *coeff_in, double *coeff_out, bool readOnlyScaling, int stride, bool overwrite = true);
-template<int D> void mw_transform_back(MWTree<D> &tree, double *coeff_in, double *coeff_out, int stride);
+template <int D> void mw_transform(const MWTree<D> &tree, double *coeff_in, double *coeff_out, bool readOnlyScaling, int stride, bool overwrite = true);
+template <int D> void mw_transform_back(MWTree<D> &tree, double *coeff_in, double *coeff_out, int stride);
 
-} // namespace node_utils
+} // namespace tree_utils
 } // namespace mrcpp

--- a/tests/operators/helmholtz_operator.cpp
+++ b/tests/operators/helmholtz_operator.cpp
@@ -202,23 +202,65 @@ TEST_CASE("Apply Periodic Helmholtz' operator", "[apply_periodic_helmholtz], [he
     double apply_prec = 3.0e-2;
     double build_prec = 3.0e-3;
 
-    // 2.0*pi periodic in all dirs
-    auto scaling_factor = std::array<double, 3>{2.0 * pi, 2.0 * pi, 2.0 * pi};
-    auto periodic = true;
-    BoundingBox<3> box(scaling_factor, periodic);
+    // 2.0*pi periodic in all dirs // UPDATE ME
+    auto scaling_factor = std::array<double, 3>{pi, pi, pi};
+    auto corner = std::array<int, 3>{-1, -1, -1};
+    auto boxes = std::array<int, 3>{2, 2, 2};
+    auto world = mrcpp::BoundingBox<3>(0, corner, boxes, scaling_factor, true);
     int order = 5;
 
     InterpolatingBasis basis(order);
-    MultiResolutionAnalysis<3> MRA(box, basis, 25);
+    MultiResolutionAnalysis<3> MRA(world, basis, 25);
+    MRA.setPeriodicOperatorReach(10);
+    MRA.setPeriodicOperatorCutOff(9);
 
     auto mu = 4.3;
     HelmholtzOperator H(MRA, mu, build_prec);
 
     // Source, Poisson applied to this should yield cos(x)cos(y)cos(z)
-    auto source = [mu](const mrcpp::Coord<3> &r) {
-        return 3.0 * cos(r[0]) * cos(r[1]) * cos(r[2]) / (4.0 * pi) +
-               mu * mu * cos(r[0]) * cos(r[1]) * cos(r[2]) / (4.0 * pi);
-    };
+    auto source = [mu](const mrcpp::Coord<3> &r) { return 3.0 * cos(r[0]) * cos(r[1]) * cos(r[2]) / (4.0 * pi) + mu * mu * cos(r[0]) * cos(r[1]) * cos(r[2]) / (4.0 * pi); };
+
+    FunctionTree<3> source_tree(MRA);
+    project<3>(proj_prec, source_tree, source);
+
+    FunctionTree<3> sol_tree(MRA);
+    FunctionTree<3> in_tree(MRA);
+    FunctionTree<3> out_tree(MRA);
+    FunctionTree<3> in_out_tree(MRA);
+
+    apply(apply_prec, sol_tree, H, source_tree);
+    apply_near_field(apply_prec, in_tree, H, source_tree);
+    apply_far_field(apply_prec, out_tree, H, source_tree);
+
+    add(apply_prec, in_out_tree, 1.0, in_tree, 1.0, out_tree);
+
+    REQUIRE(sol_tree.evalf({0.0, 0.0, 0.0}) == Approx(1.0).epsilon(apply_prec));
+    REQUIRE(sol_tree.evalf({pi, 0.0, 0.0}) == Approx(-1.0).epsilon(apply_prec));
+    REQUIRE(in_out_tree.evalf({0.0, 0.0, 0.0}) == Approx(1.0).epsilon(apply_prec));
+    REQUIRE(in_out_tree.evalf({pi, 0.0, 0.0}) == Approx(-1.0).epsilon(apply_prec));
+}
+
+TEST_CASE("Apply negative scale Helmholtz' operator", "[apply_periodic_helmholtz], [helmholtz_operator], [mw_operator]. [negative_scale]") {
+    double proj_prec = 3.0e-3;
+    double apply_prec = 3.0e-2;
+    double build_prec = 3.0e-3;
+
+    // 2.0*pi periodic in all dirs // UPDATE ME
+    auto scaling_factor = std::array<double, 3>{pi, pi, pi};
+    auto corner = std::array<int, 3>{-1, -1, -1};
+    auto boxes = std::array<int, 3>{2, 2, 2};
+    auto world = mrcpp::BoundingBox<3>(0, corner, boxes, scaling_factor, true);
+    int order = 5;
+
+    InterpolatingBasis basis(order);
+    MultiResolutionAnalysis<3> MRA(world, basis, 25);
+    MRA.setOperatorScale(-4);
+
+    auto mu = 4.3;
+    HelmholtzOperator H(MRA, mu, build_prec);
+
+    // Source, Poisson applied to this should yield cos(x)cos(y)cos(z)
+    auto source = [mu](const mrcpp::Coord<3> &r) { return 3.0 * cos(r[0]) * cos(r[1]) * cos(r[2]) / (4.0 * pi) + mu * mu * cos(r[0]) * cos(r[1]) * cos(r[2]) / (4.0 * pi); };
 
     FunctionTree<3> source_tree(MRA);
     project<3>(proj_prec, source_tree, source);

--- a/tests/operators/poisson_operator.cpp
+++ b/tests/operators/poisson_operator.cpp
@@ -162,14 +162,18 @@ TEST_CASE("Apply Periodic Poisson' operator", "[apply_periodic_Poisson], [poisso
     double apply_prec = 3.0e-2;
     double build_prec = 3.0e-3;
 
-    // 2.0*pi periodic in all dirs
-    auto scaling_factor = std::array<double, 3>{2.0 * pi, 2.0 * pi, 2.0 * pi};
+    // 2.0*pi periodic in all dirs // UPDATE ME
+    auto scaling_factor = std::array<double, 3>{pi, pi, pi};
     auto periodic = true;
-    BoundingBox<3> box(scaling_factor, periodic);
-    int order = 5;
 
+    auto corner = std::array<int, 3>{-1, -1, -1};
+    auto boxes = std::array<int, 3>{2, 2, 2};
+    auto world = mrcpp::BoundingBox<3>(0, corner, boxes, scaling_factor, true);
+    int order = 5;
     InterpolatingBasis basis(order);
-    MultiResolutionAnalysis<3> MRA(box, basis, 25);
+    MultiResolutionAnalysis<3> MRA(world, basis, 25);
+    MRA.setPeriodicOperatorReach(10);
+    MRA.setPeriodicOperatorCutOff(9);
 
     PoissonOperator P(MRA, build_prec);
 


### PR DESCRIPTION
Periodic extension for `mrcpp` including negative scale operators and far/near field applies.

We zero center the unit cell [-a, a]. We added FarField and NearField applies to the operators.  

We added negative scale operators, where we move the point of view of the operator to a negative scale relative to
the unit-cell. This is an alternative to increasing the reach of the operator. We do this by adding fake parent nodes
for the input and output functions. Then exploiting the symmetries that comes from a periodic system.

General updates:
- Update max distance for operator reach to handle periodic operators
- Update coordinate and index manipulation to work for zero centered unit-cells
- Add Cartesian product function, these are useful for n-dimensional nested loops
- New and better split node in the OperatorAdaptor

Negative scale operators:

- Made negative scale nodes (parent nodes for the root).
- Update `HilbertIterator` to work for parent nodes.
- Update `mwTransform` to work for the parent nodes
- Use relative depth in `ConvulutionCalculator`

Far field applies:
- Make near field and far field apply
- Add in_unit_cell check 

Link to a mindmap showing the entire pull request:
https://app.mindmup.com/map/_free/2021/08/c0ae4480f8fe11eb876237459bc5a0d8
