### PR TITLE
MRA fix

### DIFF
--- a/src/treebuilders/add.cpp
+++ b/src/treebuilders/add.cpp
@@ -99,6 +99,9 @@ void add(double prec,
  *
  */
 template <int D> void add(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter, bool absPrec) {
+    for (auto i = 0; i < inp.size(); i++)
+        if (out.getMRA() != get_func(inp, i).getMRA()) MSG_ABORT("Incompatible MRA");
+
     int maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -69,6 +69,8 @@ void apply(double prec,
            FunctionTree<D> &inp,
            int maxIter,
            bool absPrec) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
+
     Timer pre_t;
     oper.calcBandWidths(prec);
     int maxScale = out.getMRA().getMaxScale();
@@ -109,6 +111,8 @@ void apply(double prec,
  *
  */
 template <int D> void apply(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTree<D> &inp, int dir) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
+
     TreeBuilder<D> builder;
     int maxScale = out.getMRA().getMaxScale();
 
@@ -181,6 +185,8 @@ template <int D> FunctionTreeVector<D> gradient(DerivativeOperator<D> &oper, Fun
  */
 template <int D> void divergence(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTreeVector<D> &inp) {
     if (inp.size() != D) MSG_ABORT("Dimension mismatch");
+    for (auto i = 0; i < inp.size(); i++)
+        if (out.getMRA() != get_func(inp, i).getMRA()) MSG_ABORT("Incompatible MRA");
 
     FunctionTreeVector<D> tmp_vec;
     for (int d = 0; d < D; d++) {

--- a/src/treebuilders/grid.cpp
+++ b/src/treebuilders/grid.cpp
@@ -143,6 +143,7 @@ template <int D> void build_grid(FunctionTree<D> &out, const GaussExp<D> &inp, i
  *
  */
 template <int D> void build_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
     auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, nullptr);
@@ -171,6 +172,9 @@ template <int D> void build_grid(FunctionTree<D> &out, FunctionTree<D> &inp, int
  *
  */
 template <int D> void build_grid(FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter) {
+    for (auto i = 0; i < inp.size(); i++)
+        if (out.getMRA() != get_func(inp, i).getMRA()) MSG_ABORT("Incompatible MRA");
+
     auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, nullptr);
@@ -209,6 +213,7 @@ template <int D> void copy_func(FunctionTree<D> &out, FunctionTree<D> &inp) {
  *
  */
 template <int D> void copy_grid(FunctionTree<D> &out, FunctionTree<D> &inp) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA")
     out.clear();
     build_grid(out, inp);
 }
@@ -284,6 +289,7 @@ template <int D> int refine_grid(FunctionTree<D> &out, double prec, bool absPrec
  *
  */
 template <int D> int refine_grid(FunctionTree<D> &out, FunctionTree<D> &inp) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA")
     auto maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     CopyAdaptor<D> adaptor(inp, maxScale, nullptr);

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -102,6 +102,9 @@ void multiply(double prec,
  */
 template <int D>
 void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int maxIter, bool absPrec) {
+    for (auto i = 0; i < inp.size(); i++)
+        if (out.getMRA() != get_func(inp, i).getMRA()) MSG_ABORT("Incompatible MRA");
+
     int maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
@@ -148,6 +151,8 @@ void multiply(double prec, FunctionTree<D> &out, FunctionTreeVector<D> &inp, int
  *
  */
 template <int D> void square(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, int maxIter, bool absPrec) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
+
     int maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
@@ -193,6 +198,8 @@ template <int D> void square(double prec, FunctionTree<D> &out, FunctionTree<D> 
  */
 template <int D>
 void power(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, double p, int maxIter, bool absPrec) {
+    if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
+
     int maxScale = out.getMRA().getMaxScale();
     TreeBuilder<D> builder;
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
@@ -246,8 +253,6 @@ void dot(double prec,
         double coef_b = get_coef(inp_b, d);
         FunctionTree<D> &tree_a = get_func(inp_a, d);
         FunctionTree<D> &tree_b = get_func(inp_b, d);
-        if (out.getMRA() != tree_a.getMRA()) MSG_ABORT("Trees not compatible");
-        if (out.getMRA() != tree_b.getMRA()) MSG_ABORT("Trees not compatible");
         auto *out_d = new FunctionTree<D>(out.getMRA());
         build_grid(*out_d, out);
         multiply(prec, *out_d, 1.0, tree_a, tree_b, maxIter, absPrec);
@@ -272,7 +277,8 @@ void dot(double prec,
  *
  */
 template <int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket) {
-    if (bra.getMRA() != ket.getMRA()) { MSG_ABORT("Trees not compatible"); }
+    if (bra.getMRA() != ket.getMRA()) MSG_ABORT("Trees not compatible");
+
     MWNodeVector<D> nodeTable;
     HilbertIterator<D> it(&bra);
     it.setReturnGenNodes(false);
@@ -318,6 +324,7 @@ template <int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket) {
  * If the product is zero, the functions are disjoints.
  */
 template <int D> double node_norm_dot(FunctionTree<D> &bra, FunctionTree<D> &ket, bool exact) {
+    if (bra.getMRA() != ket.getMRA()) MSG_ABORT("Incompatible MRA");
 
     double result = 0.0;
     int ncoef = bra.getKp1_d() * bra.getTDim();
@@ -331,7 +338,7 @@ template <int D> double node_norm_dot(FunctionTree<D> &bra, FunctionTree<D> &ket
         if (exact) {
             // convert to interpolating coef, take abs, convert back
             FunctionNode<D> *mwNode = static_cast<FunctionNode<D> *>(ket.findNode(idx));
-            if (mwNode == nullptr) { MSG_ABORT("Trees must have same grid"); }
+            if (mwNode == nullptr) MSG_ABORT("Trees must have same grid");
             node.getAbsCoefs(valA);
             mwNode->getAbsCoefs(valB);
             for (int i = 0; i < ncoef; i++) result += valA[i] * valB[i];

--- a/src/treebuilders/project.cpp
+++ b/src/treebuilders/project.cpp
@@ -131,6 +131,7 @@ void project(double prec,
              std::vector<std::function<double(const Coord<D> &r)>> func,
              int maxIter,
              bool absPrec) {
+    if (out.size() != func.size()) MSG_ABORT("Size mismatch");
     for (auto j = 0; j < D; j++) mrcpp::project<D>(prec, get_func(out, j), func[j], maxIter, absPrec);
 }
 

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -329,6 +329,7 @@ template <int D> void FunctionTree<D>::normalize() {
  *
  */
 template <int D> void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
+    if (this->getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
 #pragma omp parallel firstprivate(c), shared(inp)
     {
@@ -358,6 +359,7 @@ template <int D> void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
  *
  */
 template <int D> void FunctionTree<D>::multiply(double c, FunctionTree<D> &inp) {
+    if (this->getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
 #pragma omp parallel firstprivate(c), shared(inp)
     {


### PR DESCRIPTION
Some small fixes to allow projection of a `FunctionTree` onto a different MRA

- Evaluation of `FunctionTree` outside the world boundaries is now allowed and returns zero. Should be compatible with periodic functions as well, since the coord is _first_ mapped to the unit cell, _then_ checked again for boundaries before returning zero.
- Added sanity checks for compatible MRAs in all API functions

Recommend squash merge for cherry-pickability into `release/1.2`