### PR TITLE
Mapping of a function tree through a lambda function

### DIFF
--- a/api/mrcpp_declarations.h
+++ b/api/mrcpp_declarations.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <set>
 #include <vector>
 
@@ -108,5 +109,8 @@ template <int D> class OperatorState;
 using OperatorTreeVector = std::vector<OperatorTree *>;
 template <int D> using Coord = std::array<double, D>;
 template <int D> using MWNodeVector = std::vector<MWNode<D> *>;
+
+template <typename T, typename U> using FMap_ = std::function<T(U)>;
+typedef FMap_<double, double> FMap;
 
 } // namespace mrcpp

--- a/src/treebuilders/CMakeLists.txt
+++ b/src/treebuilders/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(mrcpp
     ${CMAKE_CURRENT_SOURCE_DIR}/add.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apply.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/grid.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multiply.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/project.cpp
   )
@@ -29,6 +30,7 @@ list(APPEND ${_dirname}_h
   ${CMAKE_CURRENT_SOURCE_DIR}/CrossCorrelationCalculator.h
   ${CMAKE_CURRENT_SOURCE_DIR}/DefaultCalculator.h
   ${CMAKE_CURRENT_SOURCE_DIR}/DerivativeCalculator.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/MapCalculator.h
   ${CMAKE_CURRENT_SOURCE_DIR}/MultiplicationCalculator.h
   ${CMAKE_CURRENT_SOURCE_DIR}/OperatorAdaptor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/PHCalculator.h
@@ -43,6 +45,7 @@ list(APPEND ${_dirname}_h
   ${CMAKE_CURRENT_SOURCE_DIR}/add.h
   ${CMAKE_CURRENT_SOURCE_DIR}/apply.h
   ${CMAKE_CURRENT_SOURCE_DIR}/grid.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/map.h
   ${CMAKE_CURRENT_SOURCE_DIR}/multiply.h
   ${CMAKE_CURRENT_SOURCE_DIR}/project.h
   )

--- a/src/treebuilders/MapCalculator.h
+++ b/src/treebuilders/MapCalculator.h
@@ -1,0 +1,58 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#pragma once
+
+#include "TreeCalculator.h"
+
+namespace mrcpp {
+
+template <int D> class MapCalculator final : public TreeCalculator<D> {
+public:
+    MapCalculator(FMap fm, FunctionTree<D> &inp)
+            : func(&inp)
+            , fmap(std::move(fm)) {}
+
+private:
+    FunctionTree<D> *func;
+    FMap fmap;
+    void calcNode(MWNode<D> &node_o) override {
+        const NodeIndex<D> &idx = node_o.getNodeIndex();
+        int n_coefs = node_o.getNCoefs();
+        double *coefs_o = node_o.getCoefs();
+        // This generates missing nodes
+        MWNode<D> node_i = func->getNode(idx); // Copy node
+        node_i.mwTransform(Reconstruction);
+        node_i.cvTransform(Forward);
+        const double *coefs_i = node_i.getCoefs();
+        for (int j = 0; j < n_coefs; j++) { coefs_o[j] = fmap(coefs_i[j]); }
+        node_o.cvTransform(Backward);
+        node_o.mwTransform(Compression);
+        node_o.setHasCoefs();
+        node_o.calcNorms();
+    }
+};
+
+} // namespace mrcpp

--- a/src/treebuilders/map.cpp
+++ b/src/treebuilders/map.cpp
@@ -1,0 +1,98 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#include "map.h"
+#include "MapCalculator.h"
+#include "MultiplicationCalculator.h"
+#include "TreeBuilder.h"
+#include "WaveletAdaptor.h"
+#include "add.h"
+#include "grid.h"
+#include "trees/FunctionNode.h"
+#include "trees/FunctionTree.h"
+#include "trees/HilbertIterator.h"
+#include "trees/SerialFunctionTree.h"
+#include "utils/Printer.h"
+#include "utils/Timer.h"
+#include <Eigen/Core>
+
+namespace mrcpp {
+
+/** @brief map a MW function onto another representations, adaptive grid
+ *
+ * @param[in] prec: Build precision of output function
+ * @param[out] out: Output function to be built
+ * @param[in] inp: Input function
+ * @param[in] fmap: mapping function
+ * @param[in] maxIter: Maximum number of refinement iterations in output tree
+ * @param[in] absPrec: Build output tree based on absolute precision
+ *
+ * @details The output function tree will be computed by mapping the input tree values through the fmap function,
+ * using the general algorithm:
+ * - Compute MW coefs on current grid
+ * - Refine grid where necessary based on `prec`
+ * - Repeat until convergence or `maxIter` is reached
+ * - `prec < 0` or `maxIter = 0` means NO refinement
+ * - `maxIter < 0` means no bound
+ *
+ * No assumption is made for how the mapping function looks. It is
+ * left to the end-user to guarantee that the mapping function does
+ * not lead to numerically unstable/inaccurate situations (e.g. divide
+ * by zero, overflow, etc...)
+ *
+ * @note This algorithm will start at whatever grid is present in the `out`
+ * tree when the function is called (this grid should however be EMPTY, e.i.
+ * no coefs).
+ *
+ */
+template <int D>
+void map(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, FMap fmap, int maxIter, bool absPrec) {
+
+    int maxScale = out.getMRA().getMaxScale();
+    TreeBuilder<D> builder;
+    WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
+    MapCalculator<D> calculator(fmap, inp);
+
+    builder.build(out, calculator, adaptor, maxIter);
+
+    Timer trans_t;
+    out.mwTransform(BottomUp);
+    out.calcSquareNorm();
+    trans_t.stop();
+
+    Timer clean_t;
+    inp.deleteGenerated();
+    clean_t.stop();
+
+    print::time(10, "Time transform", trans_t);
+    print::time(10, "Time cleaning", clean_t);
+    print::separator(10, ' ');
+}
+
+template void map(double prec, FunctionTree<1> &out, FunctionTree<1> &inp, FMap fmap, int maxIter, bool absPrec);
+template void map(double prec, FunctionTree<2> &out, FunctionTree<2> &inp, FMap fmap, int maxIter, bool absPrec);
+template void map(double prec, FunctionTree<3> &out, FunctionTree<3> &inp, FMap fmap, int maxIter, bool absPrec);
+
+} // Namespace mrcpp

--- a/src/treebuilders/map.h
+++ b/src/treebuilders/map.h
@@ -1,0 +1,37 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#pragma once
+
+#include "trees/FunctionTreeVector.h"
+
+namespace mrcpp {
+template <int D> class RepresentableFunction;
+template <int D> class FunctionTree;
+
+template <int D>
+void map(double prec, FunctionTree<D> &out, FunctionTree<D> &inp, FMap fmap, int maxIter = -1, bool absPrec = false);
+
+} // namespace mrcpp

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -73,6 +73,7 @@ public:
     void normalize();
     void add(double c, FunctionTree<D> &inp);
     void multiply(double c, FunctionTree<D> &inp);
+    void map(FMap fmap);
 
     int getNChunks();
     int getNChunksUsed();

--- a/tests/treebuilders/CMakeLists.txt
+++ b/tests/treebuilders/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(mrcpp-tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/clear_grid.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/build_grid.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/addition.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multiplication.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/projection.cpp
     )
@@ -9,6 +10,7 @@ target_sources(mrcpp-tests PRIVATE
 add_Catch_test(NAME clear_grid              LABELS clear_grid)
 add_Catch_test(NAME build_grid              LABELS build_grid)
 add_Catch_test(NAME addition                LABELS addition)
+add_Catch_test(NAME map                     LABELS map)
 add_Catch_test(NAME multiplication          LABELS multiplication)
 add_Catch_test(NAME square                  LABELS square)
 add_Catch_test(NAME projection              LABELS projection)

--- a/tests/treebuilders/map.cpp
+++ b/tests/treebuilders/map.cpp
@@ -1,0 +1,107 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#include "catch.hpp"
+
+#include "factory_functions.h"
+
+#include "functions/GaussPoly.h"
+#include "treebuilders/WaveletAdaptor.h"
+#include "treebuilders/grid.h"
+#include "treebuilders/map.h"
+#include "treebuilders/project.h"
+
+using namespace mrcpp;
+
+namespace mapping {
+
+template <int D> void testMapping();
+
+SCENARIO("Map a MW tree", "[map], [tree_builder]") {
+    GIVEN("One MW functions in 1D") { testMapping<1>(); }
+    GIVEN("One MW functions in 2D") { testMapping<2>(); }
+    GIVEN("One MW functions in 3D") { testMapping<3>(); }
+}
+
+template <int D> void testMapping() {
+    const double prec = 1.0e-4;
+    double alpha = 1.0;
+    double beta = 50.0;
+    double beta_ref = 100.0;
+
+    double pos_c[3] = {-0.25, 0.35, 1.05};
+    auto pos = details::convert_to_std_array<double, D>(pos_c);
+
+    GaussFunc<D> inp_func(beta, alpha, pos);
+    GaussFunc<D> ref_func(beta_ref, alpha, pos);
+
+    MultiResolutionAnalysis<D> *mra = nullptr;
+    initialize<D>(&mra);
+
+    // Initialize trees
+    FunctionTree<D> inp_tree(*mra);
+    FunctionTree<D> ref_tree(*mra);
+
+    // Build empty grids
+    build_grid(inp_tree, inp_func);
+    build_grid(ref_tree, ref_func);
+
+    // Project functions
+    project(prec, inp_tree, inp_func);
+    project(prec, ref_tree, ref_func);
+
+    const double ref_int = ref_tree.integrate();
+    const double ref_norm = ref_tree.getSquareNorm();
+    const double inp_int = inp_tree.integrate();
+    const double inp_norm = inp_tree.getSquareNorm();
+
+    auto fmap = [](double val) { return val * val; };
+
+    WHEN("the function is mapped") {
+        FunctionTree<D> out_tree(*mra);
+
+        map(prec, out_tree, inp_tree, fmap);
+
+        THEN("the MW map equals the analytic map") {
+            double out_int = out_tree.integrate();
+            double out_norm = out_tree.getSquareNorm();
+            REQUIRE(out_int == Approx(ref_int));
+            REQUIRE(out_norm == Approx(ref_norm));
+            REQUIRE(inp_norm == Approx(out_int));
+        }
+    }
+    WHEN("the functions is mapped in-place") {
+        inp_tree.map(fmap);
+        THEN("the first function equals the analytic product") {
+            double inp_int = inp_tree.integrate();
+            double inp_norm = inp_tree.getSquareNorm();
+            REQUIRE(inp_int == Approx(ref_int));
+            REQUIRE(inp_norm == Approx(ref_norm));
+        }
+    }
+    finalize(&mra);
+}
+
+} // namespace mapping


### PR DESCRIPTION
Maps a `FunctionTree` through a g(x) as g(f(x)). This functionality is needed for ZORA to obtain
k(x) = 1/(1-V(x)/2c^2), but it is a nice thing to have in general.

- [X] tree builder for the mapping 
- [X] testing of the tree builder
- [x] in-place mapping
- [x] testing of the in-place mapping
