### PR TITLE
Encapsulate OMP

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -39,4 +39,6 @@ inline constexpr auto mwfilters_install_dir() noexcept {
 
 #cmakedefine HAVE_MPI
 
+#cmakedefine MRCPP_HAS_OMP
+
 #cmakedefine HAVE_BLAS

--- a/config.h.in
+++ b/config.h.in
@@ -37,8 +37,4 @@ inline constexpr auto mwfilters_install_dir() noexcept {
 
 #define BLAS_H "@BLAS_H@"
 
-#cmakedefine HAVE_MPI
-
-#cmakedefine MRCPP_HAS_OMP
-
 #cmakedefine HAVE_BLAS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,10 @@ target_compile_definitions(mrcpp
     $<$<TARGET_EXISTS:MPI::MPI_CXX>:HAVE_MPI>
   )
 
+if (TARGET OpenMP::OpenMP_CXX)
+  target_compile_definitions(mrcpp PUBLIC MRCPP_HAS_OMP)
+endif()
+
 target_include_directories(mrcpp
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}

--- a/src/core/CrossCorrelationCache.cpp
+++ b/src/core/CrossCorrelationCache.cpp
@@ -56,13 +56,13 @@ template <int T> CrossCorrelationCache<T>::CrossCorrelationCache() {
 }
 
 template <int T> void CrossCorrelationCache<T>::load(int order) {
-    SET_CACHE_LOCK();
+    MRCPP_SET_OMP_LOCK();
     if (not hasId(order)) {
         auto *ccc = new CrossCorrelation(order, type);
         int memo = ccc->getLMatrix().size() * 2 * sizeof(double);
         ObjectCache<CrossCorrelation>::load(order, ccc, memo);
     }
-    UNSET_CACHE_LOCK();
+    MRCPP_UNSET_OMP_LOCK();
 }
 
 template <int T> CrossCorrelation &CrossCorrelationCache<T>::get(int order) {

--- a/src/core/FilterCache.cpp
+++ b/src/core/FilterCache.cpp
@@ -56,13 +56,13 @@ template <int T> FilterCache<T>::FilterCache() {
 }
 
 template <int T> void FilterCache<T>::load(int order) {
-    SET_CACHE_LOCK();
+    MRCPP_SET_OMP_LOCK();
     if (not hasId(order)) {
         auto *f = new MWFilter(order, type);
         int memo = f->getFilter().size() * sizeof(double);
         ObjectCache<MWFilter>::load(order, f, memo);
     }
-    UNSET_CACHE_LOCK();
+    MRCPP_UNSET_OMP_LOCK();
 }
 
 template <int T> MWFilter &FilterCache<T>::get(int order) {

--- a/src/core/ObjectCache.h
+++ b/src/core/ObjectCache.h
@@ -34,7 +34,7 @@ namespace mrcpp {
 
 #define getObjectCache(T, X) ObjectCache<T> &X = ObjectCache<T>::getInstance();
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
 #define SET_CACHE_LOCK() omp_set_lock(&this->cache_lock)
 #define UNSET_CACHE_LOCK() omp_unset_lock(&this->cache_lock)
 #define TEST_CACHE_LOCK() omp_test_lock(&this->cache_lock)
@@ -64,7 +64,7 @@ protected:
     ObjectCache() {
         this->objs.push_back(nullptr);
         this->mem.push_back(0);
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
         omp_init_lock(&cache_lock);
 #endif
     }
@@ -73,13 +73,13 @@ protected:
         SET_CACHE_LOCK();
         clear();
         UNSET_CACHE_LOCK();
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
         omp_destroy_lock(&cache_lock);
 #endif
     }
     ObjectCache(ObjectCache<T> const &oc) = delete;
     ObjectCache<T> &operator=(ObjectCache<T> const &oc) = delete;
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_lock_t cache_lock;
 #endif
 private:

--- a/src/core/ObjectCache.h
+++ b/src/core/ObjectCache.h
@@ -34,16 +34,6 @@ namespace mrcpp {
 
 #define getObjectCache(T, X) ObjectCache<T> &X = ObjectCache<T>::getInstance();
 
-#ifdef MRCPP_HAS_OMP
-#define SET_CACHE_LOCK() omp_set_lock(&this->cache_lock)
-#define UNSET_CACHE_LOCK() omp_unset_lock(&this->cache_lock)
-#define TEST_CACHE_LOCK() omp_test_lock(&this->cache_lock)
-#else
-#define SET_CACHE_LOCK()
-#define UNSET_CACHE_LOCK()
-#define TEST_CACHE_LOCK()
-#endif
-
 template <class T> class ObjectCache {
 public:
     static ObjectCache<T> &getInstance();
@@ -64,23 +54,19 @@ protected:
     ObjectCache() {
         this->objs.push_back(nullptr);
         this->mem.push_back(0);
-#ifdef MRCPP_HAS_OMP
-        omp_init_lock(&cache_lock);
-#endif
+        MRCPP_INIT_OMP_LOCK();
     }
 
     virtual ~ObjectCache() {
-        SET_CACHE_LOCK();
+        MRCPP_SET_OMP_LOCK();
         clear();
-        UNSET_CACHE_LOCK();
-#ifdef MRCPP_HAS_OMP
-        omp_destroy_lock(&cache_lock);
-#endif
+        MRCPP_UNSET_OMP_LOCK();
+        MRCPP_DESTROY_OMP_LOCK();
     }
     ObjectCache(ObjectCache<T> const &oc) = delete;
     ObjectCache<T> &operator=(ObjectCache<T> const &oc) = delete;
 #ifdef MRCPP_HAS_OMP
-    omp_lock_t cache_lock;
+    omp_lock_t omp_lock;
 #endif
 private:
     int highWaterMark{0};

--- a/src/core/QuadratureCache.cpp
+++ b/src/core/QuadratureCache.cpp
@@ -47,13 +47,13 @@ QuadratureCache::QuadratureCache() {
 QuadratureCache::~QuadratureCache() = default;
 
 void QuadratureCache::load(int k) {
-    SET_CACHE_LOCK();
+    MRCPP_SET_OMP_LOCK();
     if (not hasId(k)) {
         auto *gp = new GaussQuadrature(k, this->A, this->B, this->intervals);
         int memo = 2 * k * sizeof(double);
         ObjectCache<GaussQuadrature>::load(k, gp, memo);
     }
-    UNSET_CACHE_LOCK();
+    MRCPP_UNSET_OMP_LOCK();
 }
 
 GaussQuadrature &QuadratureCache::get(int k) {

--- a/src/core/ScalingCache.h
+++ b/src/core/ScalingCache.h
@@ -40,13 +40,13 @@ public:
         return theScalingCache;
     }
     void load(int order) {
-        SET_CACHE_LOCK();
+        MRCPP_SET_OMP_LOCK();
         if (not this->hasId(order)) {
             P *f = new P(order);
             int memo = 2 * SQUARE(order + 1) * sizeof(double); // approx
             ObjectCache<P>::load(order, f, memo);
         }
-        UNSET_CACHE_LOCK();
+        MRCPP_UNSET_OMP_LOCK();
     }
 
     P &get(int order) {

--- a/src/operators/OperatorStatistics.cpp
+++ b/src/operators/OperatorStatistics.cpp
@@ -32,7 +32,7 @@ namespace mrcpp {
 
 template <int D>
 OperatorStatistics<D>::OperatorStatistics()
-        : nThreads(omp_get_max_threads())
+        : nThreads(mrcpp_get_max_threads())
         , totFCount(0)
         , totGCount(0)
         , totGenCount(0)
@@ -83,13 +83,13 @@ template <int D> void OperatorStatistics<D>::flushNodeCounters() {
 
 /** Increment g-node usage counter. Needed for load balancing. */
 template <int D> void OperatorStatistics<D>::incrementGNodeCounters(const MWNode<D> &gNode) {
-    int thread = omp_get_thread_num();
+    int thread = mrcpp_get_thread_num();
     this->gCount[thread]++;
 }
 
 /** Increment operator application counter. */
 template <int D> void OperatorStatistics<D>::incrementFNodeCounters(const MWNode<D> &fNode, int ft, int gt) {
-    int thread = omp_get_thread_num();
+    int thread = mrcpp_get_thread_num();
     this->fCount[thread]++;
     (*this->compCount[thread])(ft, gt) += 1;
     if (fNode.isGenNode()) { this->genCount[thread]++; }

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -62,7 +62,7 @@ template <int D> ConvolutionCalculator<D>::~ConvolutionCalculator() {
 }
 
 template <int D> void ConvolutionCalculator<D>::initTimers() {
-    int nThreads = omp_get_max_threads();
+    int nThreads = mrcpp_get_max_threads();
     for (int i = 0; i < nThreads; i++) {
         this->band_t.push_back(new Timer(false));
         this->calc_t.push_back(new Timer(false));
@@ -71,7 +71,7 @@ template <int D> void ConvolutionCalculator<D>::initTimers() {
 }
 
 template <int D> void ConvolutionCalculator<D>::clearTimers() {
-    int nThreads = omp_get_max_threads();
+    int nThreads = mrcpp_get_max_threads();
     for (int i = 0; i < nThreads; i++) {
         delete this->band_t[i];
         delete this->calc_t[i];
@@ -84,7 +84,7 @@ template <int D> void ConvolutionCalculator<D>::clearTimers() {
 
 template <int D> void ConvolutionCalculator<D>::printTimers() const {
     int oldprec = Printer::setPrecision(1);
-    int nThreads = omp_get_max_threads();
+    int nThreads = mrcpp_get_max_threads();
     printout(20, "\n\nthread ");
     for (int i = 0; i < nThreads; i++) printout(20, std::setw(9) << i);
     printout(20, "\nband     ");
@@ -211,10 +211,10 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
     this->operStat.incrementGNodeCounters(gNode);
 
     // Get all nodes in f within the bandwith of O in g
-    this->band_t[omp_get_thread_num()]->resume();
+    this->band_t[mrcpp_get_thread_num()]->resume();
     std::vector<NodeIndex<D>> idx_band;
     MWNodeVector<D> *fBand = makeOperBand(gNode, idx_band);
-    this->band_t[omp_get_thread_num()]->stop();
+    this->band_t[mrcpp_get_thread_num()]->stop();
 
     MWTree<D> &gTree = gNode.getMWTree();
     double gThrs = gTree.getSquareNorm();
@@ -226,7 +226,7 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
 
     os.gThreshold = gThrs;
 
-    this->calc_t[omp_get_thread_num()]->resume();
+    this->calc_t[mrcpp_get_thread_num()]->resume();
     for (int n = 0; n < fBand->size(); n++) {
         MWNode<D> &fNode = *(*fBand)[n];
         NodeIndex<D> &fIdx = idx_band[n];
@@ -244,11 +244,11 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
             }
         }
     }
-    this->calc_t[omp_get_thread_num()]->stop();
+    this->calc_t[mrcpp_get_thread_num()]->stop();
 
-    this->norm_t[omp_get_thread_num()]->resume();
+    this->norm_t[mrcpp_get_thread_num()]->resume();
     gNode.calcNorms();
-    this->norm_t[omp_get_thread_num()]->stop();
+    this->norm_t[mrcpp_get_thread_num()]->stop();
     delete fBand;
 }
 

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -57,7 +57,7 @@ template <int D> DerivativeCalculator<D>::~DerivativeCalculator() {
 }
 
 template <int D> void DerivativeCalculator<D>::initTimers() {
-    int nThreads = omp_get_max_threads();
+    int nThreads = mrcpp_get_max_threads();
     for (int i = 0; i < nThreads; i++) {
         this->band_t.push_back(Timer(false));
         this->calc_t.push_back(Timer(false));
@@ -73,7 +73,7 @@ template <int D> void DerivativeCalculator<D>::clearTimers() {
 
 template <int D> void DerivativeCalculator<D>::printTimers() const {
     int oldprec = Printer::setPrecision(1);
-    int nThreads = omp_get_max_threads();
+    int nThreads = mrcpp_get_max_threads();
     printout(20, "\n\nthread ");
     for (int i = 0; i < nThreads; i++) printout(20, std::setw(9) << i);
     printout(20, "\nband     ");
@@ -95,16 +95,16 @@ template <int D> void DerivativeCalculator<D>::calcNode(MWNode<D> &gNode) {
     this->operStat.incrementGNodeCounters(gNode);
 
     // Get all nodes in f within the bandwith of O in g
-    this->band_t[omp_get_thread_num()].resume();
+    this->band_t[mrcpp_get_thread_num()].resume();
     std::vector<NodeIndex<D>> idx_band;
     MWNodeVector<D> fBand = makeOperBand(gNode, idx_band);
-    this->band_t[omp_get_thread_num()].stop();
+    this->band_t[mrcpp_get_thread_num()].stop();
 
     assert(this->oper->size() == 1);
     const OperatorTree &oTree = this->oper->getComponent(0);
     os.oTree = &oTree;
 
-    this->calc_t[omp_get_thread_num()].resume();
+    this->calc_t[mrcpp_get_thread_num()].resume();
     for (int n = 0; n < fBand.size(); n++) {
         MWNode<D> &fNode = *fBand[n];
         NodeIndex<D> &fIdx = idx_band[n];
@@ -124,11 +124,11 @@ template <int D> void DerivativeCalculator<D>::calcNode(MWNode<D> &gNode) {
     const double sf =
         std::pow(gNode.getMWTree().getMRA().getWorldBox().getScalingFactor(this->applyDir), oper->getOrder());
     for (int i = 0; i < gNode.getNCoefs(); i++) gNode.getCoefs()[i] /= sf;
-    this->calc_t[omp_get_thread_num()].stop();
+    this->calc_t[mrcpp_get_thread_num()].stop();
 
-    this->norm_t[omp_get_thread_num()].resume();
+    this->norm_t[mrcpp_get_thread_num()].resume();
     gNode.calcNorms();
-    this->norm_t[omp_get_thread_num()].stop();
+    this->norm_t[mrcpp_get_thread_num()].stop();
 }
 
 /** Return a vector of nodes in F affected by O, given a node in G */

--- a/src/treebuilders/TreeCalculator.h
+++ b/src/treebuilders/TreeCalculator.h
@@ -37,7 +37,7 @@ public:
     virtual MWNodeVector<D> *getInitialWorkVector(MWTree<D> &tree) const { return tree.copyEndNodeTable(); }
 
     virtual void calcNodeVector(MWNodeVector<D> &nodeVec) {
-#pragma omp parallel shared(nodeVec)
+#pragma omp parallel shared(nodeVec) num_threads(mrcpp_get_num_threads())
         {
             int nNodes = nodeVec.size();
 #pragma omp for schedule(guided)

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -310,7 +310,7 @@ template <int D> double dot(FunctionTree<D> &bra, FunctionTree<D> &ket) {
     // OMP is disabled in order to get EXACT results (to the very last digit), the
     // order of summation makes the result different beyond the 14th digit or so.
     // OMP does improve the performace, but its not worth it for the time being.
-    //#pragma omp parallel firstprivate(n_nodes, locResult)
+    //#pragma omp parallel firstprivate(n_nodes, locResult) num_threads(mrcpp_get_num_threads())
     //		shared(nodeTable,rhs,result)
     //    {
     //#pragma omp for schedule(guided)

--- a/src/trees/FunctionNode.cpp
+++ b/src/trees/FunctionNode.cpp
@@ -73,7 +73,7 @@ template <int D> double FunctionNode<D>::evalScaling(const Coord<D> &r) const {
     basis.evalf(arg, val);
 
     double result = 0.0;
-    //#pragma omp parallel for shared(fact) reduction(+:result)
+    //#pragma omp parallel for shared(fact) reduction(+:result) num_threads(mrcpp_get_num_threads())
     for (int i = 0; i < this->getKp1_d(); i++) {
         double temp = this->coefs[i];
         for (int j = 0; j < D; j++) {

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -237,7 +237,7 @@ template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 template <int D> void FunctionTree<D>::square() {
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
 
-#pragma omp parallel
+#pragma omp parallel num_threads(mrcpp_get_num_threads())
     {
         int nNodes = this->getNEndNodes();
         int nCoefs = this->getTDim() * this->getKp1_d();
@@ -268,7 +268,7 @@ template <int D> void FunctionTree<D>::square() {
 template <int D> void FunctionTree<D>::power(double p) {
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
 
-#pragma omp parallel
+#pragma omp parallel num_threads(mrcpp_get_num_threads())
     {
         int nNodes = this->getNEndNodes();
         int nCoefs = this->getTDim() * this->getKp1_d();
@@ -298,7 +298,7 @@ template <int D> void FunctionTree<D>::power(double p) {
  */
 template <int D> void FunctionTree<D>::rescale(double c) {
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
-#pragma omp parallel firstprivate(c)
+#pragma omp parallel firstprivate(c) num_threads(mrcpp_get_num_threads())
     {
         int nNodes = this->getNEndNodes();
         int nCoefs = this->getTDim() * this->getKp1_d();
@@ -335,7 +335,7 @@ template <int D> void FunctionTree<D>::normalize() {
 template <int D> void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
     if (this->getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
-#pragma omp parallel firstprivate(c), shared(inp)
+#pragma omp parallel firstprivate(c) shared(inp) num_threads(mrcpp_get_num_threads())
     {
         int nNodes = this->getNEndNodes();
 #pragma omp for schedule(guided)
@@ -363,7 +363,7 @@ template <int D> void FunctionTree<D>::add(double c, FunctionTree<D> &inp) {
  */
 template <int D> void FunctionTree<D>::absadd(double c, FunctionTree<D> &inp) {
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
-#pragma omp parallel firstprivate(c), shared(inp)
+#pragma omp parallel firstprivate(c) shared(inp) num_threads(mrcpp_get_num_threads())
     {
         int nNodes = this->getNEndNodes();
 #pragma omp for schedule(guided)
@@ -399,7 +399,7 @@ template <int D> void FunctionTree<D>::absadd(double c, FunctionTree<D> &inp) {
 template <int D> void FunctionTree<D>::multiply(double c, FunctionTree<D> &inp) {
     if (this->getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
-#pragma omp parallel firstprivate(c), shared(inp)
+#pragma omp parallel firstprivate(c) shared(inp) num_threads(mrcpp_get_num_threads())
     {
         int nNodes = this->getNEndNodes();
 #pragma omp for schedule(guided)
@@ -435,7 +435,7 @@ template <int D> void FunctionTree<D>::map(FMap fmap) {
     if (this->getNGenNodes() != 0) MSG_ABORT("GenNodes not cleared");
     {
         int nNodes = this->getNEndNodes();
-#pragma omp for schedule(guided)
+#pragma omp parallel for schedule(guided) num_threads(mrcpp_get_num_threads())
         for (int n = 0; n < nNodes; n++) {
             MWNode<D> &node = *this->endNodeTable[n];
             node.mwTransform(Reconstruction);

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -56,7 +56,7 @@ MWTree<D>::MWTree(const MultiResolutionAnalysis<D> &mra)
     this->nodesAtDepth.push_back(0);
     allocNodeCounters();
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_init_lock(&tree_lock);
 #endif
 }
@@ -69,7 +69,7 @@ template <int D> MWTree<D>::~MWTree() {
     if (this->nodesAtDepth[0] != 0) MSG_ERROR("Nodes at depth 0 != 0 -> " << this->nodesAtDepth[0]);
     deleteNodeCounters();
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_destroy_lock(&tree_lock);
 #endif
 }

--- a/src/trees/MWTree.cpp
+++ b/src/trees/MWTree.cpp
@@ -45,7 +45,7 @@ namespace mrcpp {
  * the parameters are done in derived classes. */
 template <int D>
 MWTree<D>::MWTree(const MultiResolutionAnalysis<D> &mra)
-        : nThreads(omp_get_max_threads())
+        : nThreads(mrcpp_get_max_threads())
         , MRA(mra)
         , order(mra.getOrder())
         , kp1_d(math_utils::ipow(mra.getOrder() + 1, D))
@@ -103,7 +103,7 @@ template <int D> void MWTree<D>::mwTransform(int type, bool overwrite) {
 template <int D> void MWTree<D>::mwTransformUp() {
     std::vector<MWNodeVector<D>> nodeTable;
     makeNodeTable(nodeTable);
-#pragma omp parallel shared(nodeTable)
+#pragma omp parallel shared(nodeTable) num_threads(mrcpp_get_num_threads())
     {
         int start = nodeTable.size() - 2;
         for (int n = start; n >= 0; n--) {
@@ -123,7 +123,7 @@ template <int D> void MWTree<D>::mwTransformUp() {
 template <int D> void MWTree<D>::mwTransformDown(bool overwrite) {
     std::vector<MWNodeVector<D>> nodeTable;
     makeNodeTable(nodeTable);
-#pragma omp parallel shared(nodeTable)
+#pragma omp parallel shared(nodeTable) num_threads(mrcpp_get_num_threads())
     {
         for (int n = 0; n < nodeTable.size(); n++) {
             int n_nodes = nodeTable[n].size();
@@ -204,7 +204,7 @@ template <int D> void MWTree<D>::updateGenNodeCounts() {
 
 /** Adds a GenNode to the count. */
 template <int D> void MWTree<D>::incrementGenNodeCount() {
-    int n = omp_get_thread_num();
+    int n = mrcpp_get_thread_num();
     assert(n >= 0);
     assert(n < this->nThreads);
     this->nGenNodes[n]++;
@@ -212,7 +212,7 @@ template <int D> void MWTree<D>::incrementGenNodeCount() {
 
 /** Removes a GenNode from the count. */
 template <int D> void MWTree<D>::decrementGenNodeCount() {
-    int n = omp_get_thread_num();
+    int n = mrcpp_get_thread_num();
     assert(n >= 0);
     assert(n < this->nThreads);
     this->nGenNodes[n]--;

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -35,7 +35,7 @@
 
 namespace mrcpp {
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
 #define SET_TREE_LOCK() omp_set_lock(&this->tree_lock)
 #define UNSET_TREE_LOCK() omp_unset_lock(&this->tree_lock)
 #define TEST_TREE_LOCK() omp_test_lock(&this->tree_lock)
@@ -176,7 +176,7 @@ protected:
 
     virtual std::ostream &print(std::ostream &o);
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_lock_t tree_lock;
 #endif
 };

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -35,16 +35,6 @@
 
 namespace mrcpp {
 
-#ifdef MRCPP_HAS_OMP
-#define SET_TREE_LOCK() omp_set_lock(&this->tree_lock)
-#define UNSET_TREE_LOCK() omp_unset_lock(&this->tree_lock)
-#define TEST_TREE_LOCK() omp_test_lock(&this->tree_lock)
-#else
-#define SET_TREE_LOCK()
-#define UNSET_TREE_LOCK()
-#define TEST_TREE_LOCK() false
-#endif
-
 template <int D> class MWTree {
 public:
     MWTree(const MultiResolutionAnalysis<D> &mra);
@@ -177,7 +167,7 @@ protected:
     virtual std::ostream &print(std::ostream &o);
 
 #ifdef MRCPP_HAS_OMP
-    omp_lock_t tree_lock;
+    omp_lock_t omp_lock;
 #endif
 };
 

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -80,7 +80,7 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *m
     this->cvptr_GenNode = *(char **)(tmpGenNode);
     delete tmpGenNode;
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_init_lock(&Sfunc_tree_lock);
 #endif
 }
@@ -96,7 +96,7 @@ template <int D> SerialFunctionTree<D>::~SerialFunctionTree() {
     this->nodeStackStatus.clear();
     this->genNodeStackStatus.clear();
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_destroy_lock(&Sfunc_tree_lock);
 #endif
 }

--- a/src/trees/SerialFunctionTree.cpp
+++ b/src/trees/SerialFunctionTree.cpp
@@ -80,9 +80,7 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, SharedMemory *m
     this->cvptr_GenNode = *(char **)(tmpGenNode);
     delete tmpGenNode;
 
-#ifdef MRCPP_HAS_OMP
-    omp_init_lock(&Sfunc_tree_lock);
-#endif
+    MRCPP_INIT_OMP_LOCK();
 }
 
 /** SerialTree destructor. */
@@ -96,9 +94,7 @@ template <int D> SerialFunctionTree<D>::~SerialFunctionTree() {
     this->nodeStackStatus.clear();
     this->genNodeStackStatus.clear();
 
-#ifdef MRCPP_HAS_OMP
-    omp_destroy_lock(&Sfunc_tree_lock);
-#endif
+    MRCPP_DESTROY_OMP_LOCK();
 }
 
 /** reset the start node counter */
@@ -465,7 +461,7 @@ template <int D> int SerialFunctionTree<D>::shrinkChunks() {
 
 // return pointer to the last active node or NULL if failed
 template <int D> GenNode<D> *SerialFunctionTree<D>::allocGenNodes(int nAlloc, int *serialIx, double **coefs_p) {
-    omp_set_lock(&Sfunc_tree_lock);
+    MRCPP_SET_OMP_LOCK();
     *serialIx = this->nGenNodes;
     int chunkIx = *serialIx % (this->maxNodesPerChunk);
 
@@ -527,12 +523,12 @@ template <int D> GenNode<D> *SerialFunctionTree<D>::allocGenNodes(int nAlloc, in
     this->nGenNodes += nAlloc;
     this->lastGenNode += nAlloc;
 
-    omp_unset_lock(&Sfunc_tree_lock);
+    MRCPP_UNSET_OMP_LOCK();
     return newNode;
 }
 
 template <int D> void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
-    omp_set_lock(&Sfunc_tree_lock);
+    MRCPP_SET_OMP_LOCK();
     if (this->nGenNodes < 0) {
         println(0, "minNodes exceeded " << this->nGenNodes);
         this->nGenNodes++;
@@ -553,7 +549,7 @@ template <int D> void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
         int chunk = this->nGenNodes / this->maxNodesPerChunk; // find the right chunk
         this->lastGenNode = this->genNodeChunks[chunk] + this->nGenNodes % (this->maxNodesPerChunk);
     }
-    omp_unset_lock(&Sfunc_tree_lock);
+    MRCPP_UNSET_OMP_LOCK();
 }
 
 template <int D> void SerialFunctionTree<D>::deallocGenNodeChunks() {

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -96,7 +96,7 @@ protected:
 
 private:
 #ifdef MRCPP_HAS_OMP
-    omp_lock_t Sfunc_tree_lock;
+    omp_lock_t omp_lock;
 #endif
 };
 

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "SerialTree.h"
+#include "utils/omp_utils.h"
 
 namespace mrcpp {
 
@@ -94,7 +95,7 @@ protected:
     GenNode<D> *allocGenNodes(int nAlloc, int *serialIx, double **coefs_p);
 
 private:
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_lock_t Sfunc_tree_lock;
 #endif
 };

--- a/src/trees/SerialOperatorTree.cpp
+++ b/src/trees/SerialOperatorTree.cpp
@@ -62,9 +62,7 @@ SerialOperatorTree::SerialOperatorTree(OperatorTree *tree)
     this->cvptr_OperatorNode = *(char **)(tmpNode);
     delete tmpNode;
 
-#ifdef MRCPP_HAS_OMP
-    omp_init_lock(&Soper_tree_lock);
-#endif
+    MRCPP_INIT_OMP_LOCK();
 }
 
 /** SerialTree destructor. */
@@ -77,9 +75,7 @@ SerialOperatorTree::~SerialOperatorTree() {
 
     NOtrees--;
 
-#ifdef MRCPP_HAS_OMP
-    omp_destroy_lock(&Soper_tree_lock);
-#endif
+    MRCPP_DESTROY_OMP_LOCK();
 }
 
 void SerialOperatorTree::allocRoots(MWTree<2> &tree) {

--- a/src/trees/SerialOperatorTree.cpp
+++ b/src/trees/SerialOperatorTree.cpp
@@ -62,7 +62,7 @@ SerialOperatorTree::SerialOperatorTree(OperatorTree *tree)
     this->cvptr_OperatorNode = *(char **)(tmpNode);
     delete tmpNode;
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_init_lock(&Soper_tree_lock);
 #endif
 }
@@ -77,7 +77,7 @@ SerialOperatorTree::~SerialOperatorTree() {
 
     NOtrees--;
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_destroy_lock(&Soper_tree_lock);
 #endif
 }

--- a/src/trees/SerialOperatorTree.h
+++ b/src/trees/SerialOperatorTree.h
@@ -69,7 +69,7 @@ protected:
 
 private:
 #ifdef MRCPP_HAS_OMP
-    omp_lock_t Soper_tree_lock;
+    omp_lock_t omp_lock;
 #endif
 };
 

--- a/src/trees/SerialOperatorTree.h
+++ b/src/trees/SerialOperatorTree.h
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "SerialTree.h"
+#include "utils/omp_utils.h"
 
 namespace mrcpp {
 
@@ -67,7 +68,7 @@ protected:
     OperatorNode *allocNodes(int nAlloc, int *serialIx, double **coefs_p);
 
 private:
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     omp_lock_t Soper_tree_lock;
 #endif
 };

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,25 +1,26 @@
 target_sources(mrcpp
   PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/details.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/math_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/Plotter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mpi_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/omp_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/periodic_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Plotter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Printer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Timer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/mpi_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/details.cpp
   )
 
 get_filename_component(_dirname ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 list(APPEND ${_dirname}_h
-  ${CMAKE_CURRENT_SOURCE_DIR}/Plotter.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/periodic_utils.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/Printer.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/details.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/math_utils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/mpi_utils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/omp_utils.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/math_utils.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/details.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/periodic_utils.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Plotter.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Printer.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
   )
 
 # Sets install directory for all the headers in the list

--- a/src/utils/Plotter.cpp
+++ b/src/utils/Plotter.cpp
@@ -278,7 +278,7 @@ Eigen::VectorXd Plotter<D>::evaluateFunction(const RepresentableFunction<D> &fun
     auto npts = coords.rows();
     if (npts == 0) MSG_ERROR("Empty coordinates");
     Eigen::VectorXd values = VectorXd::Zero(npts);
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for schedule(static) num_threads(mrcpp_get_num_threads())
     for (auto i = 0; i < npts; i++) {
         Coord<D> r{};
         for (auto d = 0; d < D; d++) r[d] = coords(i, d);

--- a/src/utils/Printer.cpp
+++ b/src/utils/Printer.cpp
@@ -109,13 +109,13 @@ void print::environment(int level) {
 #endif
 
 #ifdef HAVE_MPI
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     println(level, " Parallelization       : MPI/OpenMP");
 #else
     println(level, " Parallelization       : MPI");
 #endif
 #else
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
     println(level, " Parallelization       : OpenMP");
 #else
     println(level, " Parallelization       : NONE");

--- a/src/utils/Printer.cpp
+++ b/src/utils/Printer.cpp
@@ -110,13 +110,13 @@ void print::environment(int level) {
 
 #ifdef HAVE_MPI
 #ifdef MRCPP_HAS_OMP
-    println(level, " Parallelization       : MPI/OpenMP");
+    println(level, " Parallelization       : MPI/OpenMP (" << mrcpp_get_num_threads() << " threads)");
 #else
     println(level, " Parallelization       : MPI");
 #endif
 #else
 #ifdef MRCPP_HAS_OMP
-    println(level, " Parallelization       : OpenMP");
+    println(level, " Parallelization       : OpenMP (" << mrcpp_get_num_threads() << " threads)");
 #else
     println(level, " Parallelization       : NONE");
 #endif

--- a/src/utils/omp_utils.cpp
+++ b/src/utils/omp_utils.cpp
@@ -23,32 +23,20 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
-#pragma once
-
-#define EIGEN_DONT_PARALLELIZE
-
-#ifdef MRCPP_HAS_OMP
-#include <omp.h>
-#define mrcpp_get_max_threads() omp_get_max_threads()
-#define mrcpp_get_num_threads() mrcpp::max_threads
-#define mrcpp_get_thread_num() omp_get_thread_num()
-#define MRCPP_INIT_OMP_LOCK() omp_init_lock(&this->omp_lock)
-#define MRCPP_DESTROY_OMP_LOCK() omp_destroy_lock(&this->omp_lock)
-#define MRCPP_SET_OMP_LOCK() omp_set_lock(&this->omp_lock)
-#define MRCPP_UNSET_OMP_LOCK() omp_unset_lock(&this->omp_lock)
-#define MRCPP_TEST_OMP_LOCK() omp_test_lock(&this->omp_lock)
-#else
-#define mrcpp_get_max_threads() 1
-#define mrcpp_get_num_threads() 1
-#define mrcpp_get_thread_num() 0
-#define MRCPP_INIT_OMP_LOCK()
-#define MRCPP_DESTROY_OMP_LOCK()
-#define MRCPP_SET_OMP_LOCK()
-#define MRCPP_UNSET_OMP_LOCK()
-#define MRCPP_TEST_OMP_LOCK()
-#endif
+#include "omp_utils.h"
 
 namespace mrcpp {
-extern int max_threads;
-void set_max_threads(int threads);
+
+// By default we get OMP_NUM_THREADS
+int max_threads = mrcpp_get_max_threads();
+
+void set_max_threads(int threads) {
+    auto omp_max = mrcpp_get_max_threads();
+    if (threads < 1 or threads > omp_max) {
+        mrcpp::max_threads = omp_max;
+    } else {
+        mrcpp::max_threads = threads;
+    }
 }
+
+} // namespace mrcpp

--- a/src/utils/omp_utils.h
+++ b/src/utils/omp_utils.h
@@ -29,12 +29,16 @@
 
 #ifdef MRCPP_HAS_OMP
 #include <omp.h>
+
+#define MRCPP_INIT_OMP_LOCK() omp_init_lock(&this->omp_lock)
+#define MRCPP_DESTROY_OMP_LOCK() omp_destroy_lock(&this->omp_lock)
+#define MRCPP_SET_OMP_LOCK() omp_set_lock(&this->omp_lock)
+#define MRCPP_UNSET_OMP_LOCK() omp_unset_lock(&this->omp_lock)
+#define MRCPP_TEST_OMP_LOCK() omp_test_lock(&this->omp_lock)
 #else
-#define omp_get_max_threads() 1
-#define omp_get_num_threads() 1
-#define omp_get_thread_num() 0
-#define omp_set_dynamic(n)
-#define omp_set_lock(x)
-#define omp_unset_lock(x)
-#define omp_test_lock(x)
+#define MRCPP_INIT_OMP_LOCK()
+#define MRCPP_DESTROY_OMP_LOCK()
+#define MRCPP_SET_OMP_LOCK()
+#define MRCPP_UNSET_OMP_LOCK()
+#define MRCPP_TEST_OMP_LOCK()
 #endif

--- a/src/utils/omp_utils.h
+++ b/src/utils/omp_utils.h
@@ -27,7 +27,7 @@
 
 #define EIGEN_DONT_PARALLELIZE
 
-#ifdef _OPENMP
+#ifdef MRCPP_HAS_OMP
 #include <omp.h>
 #else
 #define omp_get_max_threads() 1

--- a/src/utils/omp_utils.h
+++ b/src/utils/omp_utils.h
@@ -51,4 +51,4 @@
 namespace mrcpp {
 extern int max_threads;
 void set_max_threads(int threads);
-}
+} // namespace mrcpp


### PR DESCRIPTION
The old `_OPENMP` flag has been replaced by `MRCPP_HAS_OMP` in order to distinguish between building MRCPP with/without OMP and building the host program with/without OMP. With this it is possible to compile MRCPP and the host with different OMP support, e.g. serial host with threaded MRCPP, and the threads are correctly picked up only in the library routines. 

Also added option to set `mrcpp::set_max_threads(N)` to limit the number of threads accessible by MRCPP, thus freeing up threads to be used in the host program. Default behavior not changed, i.e. `mrcpp::max_threads = OMP_NUM_THREADS`.