### PR TITLE
Encapsulate MPI

### DIFF
--- a/api/Parallel
+++ b/api/Parallel
@@ -24,3 +24,4 @@
  */
 
 #include "utils/mpi_utils.h"
+#include "utils/omp_utils.h"

--- a/examples/mpi_matrix.cpp
+++ b/examples/mpi_matrix.cpp
@@ -15,18 +15,17 @@ int main(int argc, char **argv) {
     mrcpp::Timer tot_t;
 
     // Initialize MPI
-    MPI_Comm comm;
-    int wrank, wsize;
 #ifdef MRCPP_HAS_MPI
     MPI_Init(&argc, &argv);
 
-    comm = MPI_COMM_WORLD;
+    int wrank, wsize;
+    MPI_Comm comm = MPI_COMM_WORLD;
     MPI_Comm_rank(comm, &wrank);
     MPI_Comm_size(comm, &wsize);
 #else
-    comm = 0;
-    wrank = 0;
-    wsize = 1;
+    int comm = 0;
+    int wrank = 0;
+    int wsize = 1;
 #endif
 
     // Initialize printing

--- a/examples/mpi_matrix.cpp
+++ b/examples/mpi_matrix.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
     // Initialize MPI
     MPI_Comm comm;
     int wrank, wsize;
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Init(&argc, &argv);
 
     comm = MPI_COMM_WORLD;
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     println(0, S);
 
     // Finalize MPI
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Finalize();
 #endif
 

--- a/examples/mpi_send_tree.cpp
+++ b/examples/mpi_send_tree.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     auto wrank = int();
     auto wsize = int();
 
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Init(&argc, &argv);
 
     comm = MPI_COMM_WORLD;
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     }
 
     // Finalize MPI
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Finalize();
 #endif
 

--- a/examples/mpi_send_tree.cpp
+++ b/examples/mpi_send_tree.cpp
@@ -15,20 +15,17 @@ int main(int argc, char **argv) {
     mrcpp::Timer tot_t;
 
     // Initialize MPI
-    auto comm = MPI_Comm();
-    auto wrank = int();
-    auto wsize = int();
-
 #ifdef MRCPP_HAS_MPI
     MPI_Init(&argc, &argv);
 
-    comm = MPI_COMM_WORLD;
+    int wrank, wsize;
+    MPI_Comm comm = MPI_COMM_WORLD;
     MPI_Comm_rank(comm, &wrank);
     MPI_Comm_size(comm, &wsize);
 #else
-    comm = 0;
-    wrank = 0;
-    wsize = 1;
+    int comm = 0;
+    int wrank = 0;
+    int wsize = 1;
 #endif
 
     // Initialize printing

--- a/examples/mpi_shared_tree.cpp
+++ b/examples/mpi_shared_tree.cpp
@@ -17,19 +17,12 @@ int main(int argc, char **argv) {
     auto tot_t = mrcpp::Timer();
 
     // Initialize MPI
-
-    auto wcomm = MPI_Comm();
-    auto scomm = MPI_Comm();
-
-    auto wrank = int();
-    auto wsize = int();
-    auto srank = int();
-    auto ssize = int();
-
 #ifdef MRCPP_HAS_MPI
     MPI_Init(&argc, &argv);
 
-    wcomm = MPI_COMM_WORLD;
+    int wrank, wsize, srank, ssize;
+    MPI_Comm scomm;
+    MPI_Comm wcomm = MPI_COMM_WORLD;
     MPI_Comm_rank(wcomm, &wrank);
     MPI_Comm_size(wcomm, &wsize);
 
@@ -37,13 +30,13 @@ int main(int argc, char **argv) {
     MPI_Comm_rank(scomm, &srank);
     MPI_Comm_size(scomm, &ssize);
 #else
-    wcomm = 0;
-    wrank = 0;
-    wsize = 1;
+    int wcomm = 0;
+    int wrank = 0;
+    int wsize = 1;
 
-    scomm = 0;
-    srank = 0;
-    ssize = 1;
+    int scomm = 0;
+    int srank = 0;
+    int ssize = 1;
 #endif
 
     // Initialize printing

--- a/examples/mpi_shared_tree.cpp
+++ b/examples/mpi_shared_tree.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     auto srank = int();
     auto ssize = int();
 
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Init(&argc, &argv);
 
     wcomm = MPI_COMM_WORLD;
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
     delete shared_mem;
 
     // Finalize MPI
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Finalize();
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,14 @@ add_dependencies(mrcpp mrcpp-info)
 target_compile_definitions(mrcpp
   INTERFACE
     $<INSTALL_INTERFACE:USING_MRCPP>
-  PUBLIC
-    $<$<TARGET_EXISTS:MPI::MPI_CXX>:HAVE_MPI>
   )
 
 if (TARGET OpenMP::OpenMP_CXX)
   target_compile_definitions(mrcpp PUBLIC MRCPP_HAS_OMP)
+endif()
+
+if (TARGET MPI::MPI_CXX)
+  target_compile_definitions(mrcpp PUBLIC MRCPP_HAS_MPI)
 endif()
 
 target_include_directories(mrcpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,11 +9,19 @@ target_compile_definitions(mrcpp
 
 if (TARGET OpenMP::OpenMP_CXX)
   target_compile_definitions(mrcpp PUBLIC MRCPP_HAS_OMP)
+  set_target_properties(mrcpp PROPERTIES MRCPP_HAS_OMP TRUE)
+else()
+  set_target_properties(mrcpp PROPERTIES MRCPP_HAS_OMP FALSE)
 endif()
 
 if (TARGET MPI::MPI_CXX)
   target_compile_definitions(mrcpp PUBLIC MRCPP_HAS_MPI)
+  set_target_properties(mrcpp PROPERTIES MRCPP_HAS_MPI TRUE)
+else()
+  set_target_properties(mrcpp PROPERTIES MRCPP_HAS_MPI FALSE)
 endif()
+
+set_target_properties(mrcpp PROPERTIES EXPORT_PROPERTIES "MRCPP_HAS_OMP;MRCPP_HAS_MPI")
 
 target_include_directories(mrcpp
   PRIVATE

--- a/src/trees/SerialTree.cpp
+++ b/src/trees/SerialTree.cpp
@@ -41,7 +41,7 @@ SerialTree<D>::SerialTree(MWTree<D> *tree, SharedMemory *mem)
         , maxNodes(0)
         , tree_p(tree)
         ,
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
         shMem(mem) {
 #else
         shMem(nullptr) {

--- a/src/utils/Printer.cpp
+++ b/src/utils/Printer.cpp
@@ -108,7 +108,7 @@ void print::environment(int level) {
                                                       << EIGEN_MINOR_VERSION);
 #endif
 
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
 #ifdef MRCPP_HAS_OMP
     println(level, " Parallelization       : MPI/OpenMP (" << mrcpp_get_num_threads() << " threads)");
 #else

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -37,7 +37,7 @@ namespace mrcpp {
  *  @param[in] comm: Communicator sharing resources
  *  @param[in] sh_size: Memory size, in MB
  */
-SharedMemory::SharedMemory(MPI_Comm comm, int sh_size)
+SharedMemory::SharedMemory(mrcpp::mpi_comm comm, int sh_size)
         : sh_start_ptr(nullptr)
         , sh_end_ptr(nullptr)
         , sh_max_ptr(nullptr)
@@ -89,7 +89,7 @@ SharedMemory::~SharedMemory() {
  *  to speed up communication, otherwise it will be communicated in a separate
  *  step before the main communication.
  */
-template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, int nChunks) {
+template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks) {
 #ifdef MRCPP_HAS_MPI
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_ABORT("Sending of GenNodes not implemented");
@@ -125,7 +125,7 @@ template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Com
  *  to speed up communication, otherwise it will be communicated in a separate
  *  step before the main communication.
  */
-template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm, int nChunks) {
+template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks) {
 #ifdef MRCPP_HAS_MPI
     MPI_Status status;
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
@@ -179,7 +179,7 @@ template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Com
  *  @details This function should be called every time a shared function is
  *  updated, in order to update the local memory of each MPI process.
  */
-template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm) {
+template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm) {
 #ifdef MRCPP_HAS_MPI
     Timer t1;
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
@@ -234,14 +234,14 @@ template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Co
 #endif
 }
 
-template void send_tree<1>(FunctionTree<1> &tree, int dst, int tag, MPI_Comm comm, int nChunks);
-template void send_tree<2>(FunctionTree<2> &tree, int dst, int tag, MPI_Comm comm, int nChunks);
-template void send_tree<3>(FunctionTree<3> &tree, int dst, int tag, MPI_Comm comm, int nChunks);
-template void recv_tree<1>(FunctionTree<1> &tree, int src, int tag, MPI_Comm comm, int nChunks);
-template void recv_tree<2>(FunctionTree<2> &tree, int src, int tag, MPI_Comm comm, int nChunks);
-template void recv_tree<3>(FunctionTree<3> &tree, int src, int tag, MPI_Comm comm, int nChunks);
-template void share_tree<1>(FunctionTree<1> &tree, int src, int tag, MPI_Comm comm);
-template void share_tree<2>(FunctionTree<2> &tree, int src, int tag, MPI_Comm comm);
-template void share_tree<3>(FunctionTree<3> &tree, int src, int tag, MPI_Comm comm);
+template void send_tree<1>(FunctionTree<1> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks);
+template void send_tree<2>(FunctionTree<2> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks);
+template void send_tree<3>(FunctionTree<3> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks);
+template void recv_tree<1>(FunctionTree<1> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks);
+template void recv_tree<2>(FunctionTree<2> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks);
+template void recv_tree<3>(FunctionTree<3> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks);
+template void share_tree<1>(FunctionTree<1> &tree, int src, int tag, mrcpp::mpi_comm comm);
+template void share_tree<2>(FunctionTree<2> &tree, int src, int tag, mrcpp::mpi_comm comm);
+template void share_tree<3>(FunctionTree<3> &tree, int src, int tag, mrcpp::mpi_comm comm);
 
 } // namespace mrcpp

--- a/src/utils/mpi_utils.cpp
+++ b/src/utils/mpi_utils.cpp
@@ -44,7 +44,7 @@ SharedMemory::SharedMemory(MPI_Comm comm, int sh_size)
         , sh_win(0)
         , rank(0) {
 
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Comm_rank(comm, &this->rank);
     // MPI_Aint types are used for adresses (can be larger than int)
     MPI_Aint size = (rank == 0) ? sh_size : 0; // rank 0 defines length of segment
@@ -64,13 +64,13 @@ SharedMemory::SharedMemory(MPI_Comm comm, int sh_size)
 }
 
 void SharedMemory::clear() {
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     this->sh_end_ptr = this->sh_start_ptr;
 #endif
 }
 
 SharedMemory::~SharedMemory() {
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     // deallocates the memory block
     MPI_Win_free(&this->sh_win);
 #endif
@@ -90,7 +90,7 @@ SharedMemory::~SharedMemory() {
  *  step before the main communication.
  */
 template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, int nChunks) {
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_ABORT("Sending of GenNodes not implemented");
 
@@ -126,7 +126,7 @@ template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Com
  *  step before the main communication.
  */
 template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm, int nChunks) {
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     MPI_Status status;
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
 
@@ -180,7 +180,7 @@ template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Com
  *  updated, in order to update the local memory of each MPI process.
  */
 template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm) {
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
     Timer t1;
     SerialFunctionTree<D> &sTree = *tree.getSerialFunctionTree();
     if (sTree.nGenNodes != 0) MSG_ABORT("Sending of GenNodes not implemented");

--- a/src/utils/mpi_utils.h
+++ b/src/utils/mpi_utils.h
@@ -27,10 +27,17 @@
 
 #ifdef MRCPP_HAS_MPI
 #include <mpi.h>
+namespace mrcpp {
+using mpi_comm = MPI_Comm;
+using mpi_win = MPI_Win;
+using mpi_request = MPI_Request;
+} // namespace mrcpp
 #else
-using MPI_Comm = int;
-using MPI_Win = int;
-using MPI_Request = int;
+namespace mrcpp {
+using mpi_comm = int;
+using mpi_win = int;
+using mpi_request = int;
+} // namespace mrcpp
 #endif
 
 namespace mrcpp {
@@ -45,23 +52,24 @@ namespace mrcpp {
  */
 class SharedMemory {
 public:
-    SharedMemory(MPI_Comm comm, int sh_size);
+    SharedMemory(mrcpp::mpi_comm comm, int sh_size);
     SharedMemory(const SharedMemory &mem) = delete;
     SharedMemory &operator=(const SharedMemory &mem) = delete;
     ~SharedMemory();
 
-    double *sh_start_ptr; // start of shared block
-    double *sh_end_ptr;   // end of used part
-    double *sh_max_ptr;   // end of shared block
-    MPI_Win sh_win;       // MPI window object
-    int rank;             // rank among shared group
-    void clear();         // show shared memory as entirely available
+    void clear(); // show shared memory as entirely available
+
+    double *sh_start_ptr;  // start of shared block
+    double *sh_end_ptr;    // end of used part
+    double *sh_max_ptr;    // end of shared block
+    mrcpp::mpi_win sh_win; // MPI window object
+    int rank;              // rank among shared group
 };
 
 template <int D> class FunctionTree;
 
-template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, MPI_Comm comm, int nChunks = -1);
-template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm, int nChunks = -1);
-template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, MPI_Comm comm);
+template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks = -1);
+template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks = -1);
+template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm);
 
 } // namespace mrcpp

--- a/src/utils/mpi_utils.h
+++ b/src/utils/mpi_utils.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#ifdef HAVE_MPI
+#ifdef MRCPP_HAS_MPI
 #include <mpi.h>
 #else
 using MPI_Comm = int;


### PR DESCRIPTION
Has been tested to work for:

- Serial client -- serial MRCPP (works)
- Serial client -- parallel MRCPP (works as one would expect, client can use MRCPP as serial lib and no MPI parallelization is gained)
- Parallel client -- serial MRCPP (works as long as there's no reference in client to MRCPPs parallel API, the client's parallelization will be completely independent of MRCPP)
- Parallel client -- parallel MRCPP (works, but need to juggle client's `HAVE_MPI` vs `MRCPP_HAS_MPI`)