### PR TITLE
Tree coeff

### DIFF
--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -339,16 +339,16 @@ template <int D> void ConvolutionCalculator<D>::tensorApplyOperComp(OperatorStat
         if (oData[i] != nullptr) {
             Eigen::Map<MatrixXd> op(oData[i], os.kp1, os.kp1);
             if (i == D - 1) { // Last dir: Add up into g
-                g += f.transpose() * op;
+                g.noalias() += f.transpose() * op;
             } else {
-                g = f.transpose() * op;
+                g.noalias() = f.transpose() * op;
             }
         } else {
             // Identity operator in direction i
             if (i == D - 1) { // Last dir: Add up into g
-                g += f.transpose();
+                g.noalias() += f.transpose();
             } else {
-                g = f.transpose();
+                g.noalias() = f.transpose();
             }
         }
     }

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -248,16 +248,16 @@ template <int D> void DerivativeCalculator<D>::tensorApplyOperComp(OperatorState
         if (oData[i] != nullptr) {
             Eigen::Map<MatrixXd> op(oData[i], os.kp1, os.kp1);
             if (i == D - 1) { // Last dir: Add up into g
-                g += f.transpose() * op;
+                g.noalias() += f.transpose() * op;
             } else {
-                g = f.transpose() * op;
+                g.noalias() = f.transpose() * op;
             }
         } else {
             // Identity operator in direction i
             if (i == D - 1) { // Last dir: Add up into g
-                g += f.transpose();
+                g.noalias() += f.transpose();
             } else {
-                g = f.transpose();
+                g.noalias() = f.transpose();
             }
         }
     }

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -549,14 +549,20 @@ template <int D> int FunctionTree<D>::crop(double prec, double splitFac, bool ab
  * Returns an array with the address of the coefs, an array with the
  * corresponding values of serialIx in refTree, and an array with the sizes of the nodes.
  * Set index -1 for nodes that are not present in refTree */
-  template <int D> void FunctionTree<D>::makeCoeffVector(std::vector<double *> &coefs, std::vector<int> &indices, std::vector<int> &parent_indices, std::vector<double> &scalefac, int &max_index, MWTree<D> &refTree)  {
+template <int D>
+void FunctionTree<D>::makeCoeffVector(std::vector<double *> &coefs,
+                                      std::vector<int> &indices,
+                                      std::vector<int> &parent_indices,
+                                      std::vector<double> &scalefac,
+                                      int &max_index,
+                                      MWTree<D> &refTree) {
     coefs.clear();
     indices.clear();
     parent_indices.clear();
     max_index = 0;
     int sizecoeff = (1 << refTree.getDim()) * refTree.getKp1_d();
     int sizecoeffW = ((1 << refTree.getDim()) - 1) * refTree.getKp1_d();
-    std::vector<MWNode<D> *> refstack; // nodes from refTree
+    std::vector<MWNode<D> *> refstack;  // nodes from refTree
     std::vector<MWNode<D> *> thisstack; // nodes from this Tree
     for (int rIdx = 0; rIdx < this->getRootBox().size(); rIdx++) {
         refstack.push_back(refTree.getRootBox().getNodes()[rIdx]);
@@ -566,22 +572,25 @@ template <int D> int FunctionTree<D>::crop(double prec, double splitFac, bool ab
     while (thisstack.size() > stack_p) {
         // refNode and thisNode are the same node in space, but on different trees
         MWNode<D> *thisNode = thisstack[stack_p];
-	MWNode<D> *refNode = refstack[stack_p++];
+        MWNode<D> *refNode = refstack[stack_p++];
         coefs.push_back(thisNode->getCoefs());
         if (refNode != nullptr) {
             indices.push_back(refNode->getSerialIx());
             max_index = std::max(max_index, refNode->getSerialIx());
             parent_indices.push_back(refNode->parentSerialIx); // is -1 for root nodes
-            scalefac.push_back(refNode->getScaleFactor(1.0, true)); // could be faster: essentially inverse of powers of 2
-	} else {
+            scalefac.push_back(
+                refNode->getScaleFactor(1.0, true)); // could be faster: essentially inverse of powers of 2
+        } else {
             indices.push_back(-1); // indicates that the node is not in the refTree
             parent_indices.push_back(-2);
             scalefac.push_back(1.0);
         }
         if (thisNode->getNChildren() > 0) {
             for (int i = 0; i < thisNode->getNChildren(); i++) {
-	        if (refNode!=nullptr and refNode->getNChildren() > 0) refstack.push_back(refNode->children[i]);
-		else refstack.push_back(nullptr);
+                if (refNode != nullptr and refNode->getNChildren() > 0)
+                    refstack.push_back(refNode->children[i]);
+                else
+                    refstack.push_back(nullptr);
                 thisstack.push_back(thisNode->children[i]);
             }
         }
@@ -592,11 +601,15 @@ template <int D> int FunctionTree<D>::crop(double prec, double splitFac, bool ab
  * reference tree and a list of coefficients.
  * It is the reference tree (refTree) which is traversed, but one does not descend
  * into children if the norm of this tree is smaller than absPrec. */
-template <int D> void FunctionTree<D>::makeTreefromCoeff(MWTree<D> &refTree, std::vector<double*> coefpVec, std::map<int,int> &ix2coef, double absPrec) {
+template <int D>
+void FunctionTree<D>::makeTreefromCoeff(MWTree<D> &refTree,
+                                        std::vector<double *> coefpVec,
+                                        std::map<int, int> &ix2coef,
+                                        double absPrec) {
     std::vector<MWNode<D> *> stack;
-    std::map<int,MWNode<D> *> ix2node; // gives the nodes in this tree for a given ix
+    std::map<int, MWNode<D> *> ix2node; // gives the nodes in this tree for a given ix
     int sizecoef = (1 << this->getDim()) * this->getKp1_d();
-    int sizecoefW = ((1 <<  this->getDim()) - 1) * this->getKp1_d();
+    int sizecoefW = ((1 << this->getDim()) - 1) * this->getKp1_d();
     this->squareNorm = 0.0;
     for (int rIdx = 0; rIdx < refTree.getRootBox().size(); rIdx++) {
         MWNode<D> *refNode = refTree.getRootBox().getNodes()[rIdx];
@@ -610,15 +623,15 @@ template <int D> void FunctionTree<D>::makeTreefromCoeff(MWTree<D> &refTree, std
         int ix = -1;
         if (ix2coef.count(refNode->getSerialIx()) > 0) ix = ix2coef[refNode->getSerialIx()];
         MWNode<D> *node = ix2node[ix]; // corresponding node in this tree
-        //copy coefficients into this tree
+        // copy coefficients into this tree
         int size = sizecoefW;
         if (refNode->isRootNode()) {
-            size =  sizecoef;
-	    for (int k = 0; k < size; k++) node->getCoefs()[k] = coefpVec[ix][k];
+            size = sizecoef;
+            for (int k = 0; k < size; k++) node->getCoefs()[k] = coefpVec[ix][k];
         } else {
             // only wavelets are defined in coefVec. Scaling part set below, when creating children
             if (ix < coefpVec.size() and ix >= 0) {
-	        for (int k = 0; k < size; k++) node->getCoefs()[k + this->getKp1_d()] = coefpVec[ix][k];
+                for (int k = 0; k < size; k++) node->getCoefs()[k + this->getKp1_d()] = coefpVec[ix][k];
             } else {
                 // we do not have W coefficients. Set them to zero
                 for (int k = 0; k < size; k++) node->getCoefs()[k + this->getKp1_d()] = 0.0;
@@ -629,26 +642,25 @@ template <int D> void FunctionTree<D>::makeTreefromCoeff(MWTree<D> &refTree, std
         if (node->splitCheck(absPrec, 1.0, true) and refNode->getNChildren() > 0) {
             // include children in tree
             node->createChildren();
-	    double *inp = node->getCoefs();
-	    double *out = node->getMWChild(0).getCoefs();
-	    this->getSerialTree()->S_mwTransform(inp, out, false, sizecoef, true); // make the scaling part
-            for (int i = 0; i < refNode->getNChildren(); i++){
+            double *inp = node->getCoefs();
+            double *out = node->getMWChild(0).getCoefs();
+            this->getSerialTree()->S_mwTransform(inp, out, false, sizecoef, true); // make the scaling part
+            for (int i = 0; i < refNode->getNChildren(); i++) {
                 stack.push_back(refNode->children[i]); // means we continue to traverse the reference tree
                 int ixc = ix2coef[refNode->children[i]->getSerialIx()];
                 ix2node[ixc] = node->children[i]; // corresponding child node in this tree
                 node->children[i]->setHasCoefs();
             }
         } else {
-	    this->squareNorm += node->getSquareNorm();
-	}
+            this->squareNorm += node->getSquareNorm();
+        }
     }
     SerialFunctionTree<D> &sTree = *this->getSerialFunctionTree();
 }
 
-
 /** Traverse tree using DFS and append same nodes as another tree, without coefficients */
 template <int D> void FunctionTree<D>::appendTreeNoCoeff(MWTree<D> &inTree) {
-    std::vector<MWNode<D> *> instack; // node from inTree
+    std::vector<MWNode<D> *> instack;   // node from inTree
     std::vector<MWNode<D> *> thisstack; // node from this Tree
     for (int rIdx = 0; rIdx < inTree.getRootBox().size(); rIdx++) {
         instack.push_back(inTree.getRootBox().getNodes()[rIdx]);
@@ -658,14 +670,14 @@ template <int D> void FunctionTree<D>::appendTreeNoCoeff(MWTree<D> &inTree) {
         // inNode and thisNode are the same node in space, but on different trees
         MWNode<D> *thisNode = thisstack.back();
         thisstack.pop_back();
-	MWNode<D> *inNode = instack.back();
+        MWNode<D> *inNode = instack.back();
         instack.pop_back();
         if (inNode->getNChildren() > 0) {
             if (thisNode->getNChildren() < inNode->getNChildren()) thisNode->createChildrenNoCoeff();
             for (int i = 0; i < inNode->getNChildren(); i++) {
                 instack.push_back(inNode->children[i]);
                 thisstack.push_back(thisNode->children[i]);
-           }
+            }
         }
     }
 }

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -545,6 +545,131 @@ template <int D> int FunctionTree<D>::crop(double prec, double splitFac, bool ab
     return nChunks;
 }
 
+/** Traverse tree using BFS and find nodes of any rankId.
+ * Returns an array with the address of the coefs, an array with the
+ * corresponding values of serialIx in refTree, and an array with the sizes of the nodes.
+ * Set index -1 for nodes that are not present in refTree */
+  template <int D> void FunctionTree<D>::makeCoeffVector(std::vector<double *> &coefs, std::vector<int> &indices, std::vector<int> &parent_indices, std::vector<double> &scalefac, int &max_index, MWTree<D> &refTree)  {
+    coefs.clear();
+    indices.clear();
+    parent_indices.clear();
+    max_index = 0;
+    int sizecoeff = (1 << refTree.getDim()) * refTree.getKp1_d();
+    int sizecoeffW = ((1 << refTree.getDim()) - 1) * refTree.getKp1_d();
+    std::vector<MWNode<D> *> refstack; // nodes from refTree
+    std::vector<MWNode<D> *> thisstack; // nodes from this Tree
+    for (int rIdx = 0; rIdx < this->getRootBox().size(); rIdx++) {
+        refstack.push_back(refTree.getRootBox().getNodes()[rIdx]);
+        thisstack.push_back(this->getRootBox().getNodes()[rIdx]);
+    }
+    int stack_p = 0;
+    while (thisstack.size() > stack_p) {
+        // refNode and thisNode are the same node in space, but on different trees
+        MWNode<D> *thisNode = thisstack[stack_p];
+	MWNode<D> *refNode = refstack[stack_p++];
+        coefs.push_back(thisNode->getCoefs());
+        if (refNode != nullptr) {
+            indices.push_back(refNode->getSerialIx());
+            max_index = std::max(max_index, refNode->getSerialIx());
+            parent_indices.push_back(refNode->parentSerialIx); // is -1 for root nodes
+            scalefac.push_back(refNode->getScaleFactor(1.0, true)); // could be faster: essentially inverse of powers of 2
+	} else {
+            indices.push_back(-1); // indicates that the node is not in the refTree
+            parent_indices.push_back(-2);
+            scalefac.push_back(1.0);
+        }
+        if (thisNode->getNChildren() > 0) {
+            for (int i = 0; i < thisNode->getNChildren(); i++) {
+	        if (refNode!=nullptr and refNode->getNChildren() > 0) refstack.push_back(refNode->children[i]);
+		else refstack.push_back(nullptr);
+                thisstack.push_back(thisNode->children[i]);
+            }
+        }
+    }
+}
+
+/** Traverse tree using DFS and reconstruct it using node info from the
+ * reference tree and a list of coefficients.
+ * It is the reference tree (refTree) which is traversed, but one does not descend
+ * into children if the norm of this tree is smaller than absPrec. */
+template <int D> void FunctionTree<D>::makeTreefromCoeff(MWTree<D> &refTree, std::vector<double*> coefpVec, std::map<int,int> &ix2coef, double absPrec) {
+    std::vector<MWNode<D> *> stack;
+    std::map<int,MWNode<D> *> ix2node; // gives the nodes in this tree for a given ix
+    int sizecoef = (1 << this->getDim()) * this->getKp1_d();
+    int sizecoefW = ((1 <<  this->getDim()) - 1) * this->getKp1_d();
+    this->squareNorm = 0.0;
+    for (int rIdx = 0; rIdx < refTree.getRootBox().size(); rIdx++) {
+        MWNode<D> *refNode = refTree.getRootBox().getNodes()[rIdx];
+        stack.push_back(refNode);
+        int ix = ix2coef[refNode->getSerialIx()];
+        ix2node[ix] = this->getRootBox().getNodes()[rIdx];
+    }
+    while (stack.size() > 0) {
+        MWNode<D> *refNode = stack.back(); // node in the reference tree refTree
+        stack.pop_back();
+        int ix = -1;
+        if (ix2coef.count(refNode->getSerialIx()) > 0) ix = ix2coef[refNode->getSerialIx()];
+        MWNode<D> *node = ix2node[ix]; // corresponding node in this tree
+        //copy coefficients into this tree
+        int size = sizecoefW;
+        if (refNode->isRootNode()) {
+            size =  sizecoef;
+	    for (int k = 0; k < size; k++) node->getCoefs()[k] = coefpVec[ix][k];
+        } else {
+            // only wavelets are defined in coefVec. Scaling part set below, when creating children
+            if (ix < coefpVec.size() and ix >= 0) {
+	        for (int k = 0; k < size; k++) node->getCoefs()[k + this->getKp1_d()] = coefpVec[ix][k];
+            } else {
+                // we do not have W coefficients. Set them to zero
+                for (int k = 0; k < size; k++) node->getCoefs()[k + this->getKp1_d()] = 0.0;
+            }
+        }
+        node->setHasCoefs();
+        node->calcNorms();
+        if (node->splitCheck(absPrec, 1.0, true) and refNode->getNChildren() > 0) {
+            // include children in tree
+            node->createChildren();
+	    double *inp = node->getCoefs();
+	    double *out = node->getMWChild(0).getCoefs();
+	    this->getSerialTree()->S_mwTransform(inp, out, false, sizecoef, true); // make the scaling part
+            for (int i = 0; i < refNode->getNChildren(); i++){
+                stack.push_back(refNode->children[i]); // means we continue to traverse the reference tree
+                int ixc = ix2coef[refNode->children[i]->getSerialIx()];
+                ix2node[ixc] = node->children[i]; // corresponding child node in this tree
+                node->children[i]->setHasCoefs();
+            }
+        } else {
+	    this->squareNorm += node->getSquareNorm();
+	}
+    }
+    SerialFunctionTree<D> &sTree = *this->getSerialFunctionTree();
+}
+
+
+/** Traverse tree using DFS and append same nodes as another tree, without coefficients */
+template <int D> void FunctionTree<D>::appendTreeNoCoeff(MWTree<D> &inTree) {
+    std::vector<MWNode<D> *> instack; // node from inTree
+    std::vector<MWNode<D> *> thisstack; // node from this Tree
+    for (int rIdx = 0; rIdx < inTree.getRootBox().size(); rIdx++) {
+        instack.push_back(inTree.getRootBox().getNodes()[rIdx]);
+        thisstack.push_back(this->getRootBox().getNodes()[rIdx]);
+    }
+    while (thisstack.size() > 0) {
+        // inNode and thisNode are the same node in space, but on different trees
+        MWNode<D> *thisNode = thisstack.back();
+        thisstack.pop_back();
+	MWNode<D> *inNode = instack.back();
+        instack.pop_back();
+        if (inNode->getNChildren() > 0) {
+            if (thisNode->getNChildren() < inNode->getNChildren()) thisNode->createChildrenNoCoeff();
+            for (int i = 0; i < inNode->getNChildren(); i++) {
+                instack.push_back(inNode->children[i]);
+                thisstack.push_back(thisNode->children[i]);
+           }
+        }
+    }
+}
+
 template class FunctionTree<1>;
 template class FunctionTree<2>;
 template class FunctionTree<3>;

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <map>
 #include "MWTree.h"
+#include <map>
 
 namespace mrcpp {
 
@@ -95,9 +95,18 @@ public:
         return static_cast<const FunctionNode<D> &>(this->rootBox.getNode(i));
     }
 
-    void makeCoeffVector(std::vector<double *> &coefs, std::vector<int> &indices, std::vector<int> &parent_indices, std::vector<double> &scalefac, int &max_index, MWTree<D> &refTree);
-    void makeTreefromCoeff(MWTree<D> &refTree, std::vector<double *> coefpVec, std::map<int,int> &ix2coef, double absPrec);
+    void makeCoeffVector(std::vector<double *> &coefs,
+                         std::vector<int> &indices,
+                         std::vector<int> &parent_indices,
+                         std::vector<double> &scalefac,
+                         int &max_index,
+                         MWTree<D> &refTree);
+    void makeTreefromCoeff(MWTree<D> &refTree,
+                           std::vector<double *> coefpVec,
+                           std::map<int, int> &ix2coef,
+                           double absPrec);
     void appendTreeNoCoeff(MWTree<D> &inTree);
+
 protected:
     std::ostream &print(std::ostream &o) override;
 };

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <map>
 #include "MWTree.h"
 
 namespace mrcpp {
@@ -94,6 +95,9 @@ public:
         return static_cast<const FunctionNode<D> &>(this->rootBox.getNode(i));
     }
 
+    void makeCoeffVector(std::vector<double *> &coefs, std::vector<int> &indices, std::vector<int> &parent_indices, std::vector<double> &scalefac, int &max_index, MWTree<D> &refTree);
+    void makeTreefromCoeff(MWTree<D> &refTree, std::vector<double *> coefpVec, std::map<int,int> &ix2coef, double absPrec);
+    void appendTreeNoCoeff(MWTree<D> &inTree);
 protected:
     std::ostream &print(std::ostream &o) override;
 };

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -630,6 +630,12 @@ template <int D> void MWNode<D>::createChildren() {
     this->setIsBranchNode();
 }
 
+template <int D> void MWNode<D>::createChildrenNoCoeff() {
+    if (this->isBranchNode()) MSG_ABORT("Node already has children");
+    this->getMWTree().getSerialTree()->allocChildrenNoCoeff(*this);
+    this->setIsBranchNode();
+}
+
 template <int D> void MWNode<D>::genChildren() {
     NOT_REACHED_ABORT;
 }

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -123,6 +123,7 @@ public:
     void clearNorms();
 
     virtual void createChildren();
+    virtual void createChildrenNoCoeff();
     virtual void genChildren();
     virtual void deleteChildren();
 

--- a/src/trees/SerialFunctionTree.h
+++ b/src/trees/SerialFunctionTree.h
@@ -50,6 +50,7 @@ public:
 
     void allocRoots(MWTree<D> &tree) override;
     void allocChildren(MWNode<D> &parent) override;
+    void allocChildrenNoCoeff(MWNode<D> &parent) override;
     void allocGenChildren(MWNode<D> &parent) override;
 
     void deallocNodes(int serialIx) override;
@@ -77,7 +78,7 @@ public:
     //    int *genNodeStackStatus;
     std::vector<int> genNodeStackStatus;
 
-    void rewritePointers();
+    void rewritePointers(bool Coeff = true);
 
     void clear(int n);
 
@@ -92,6 +93,7 @@ protected:
     GenNode<D> *lastGenNode;    // pointer just after the last active Gen node, i.e. where to put next node
 
     ProjectedNode<D> *allocNodes(int nAlloc, int *serialIx, double **coefs_p);
+    ProjectedNode<D> *allocNodes(int nAlloc, int *serialIx); // Does not allocate coefficents
     GenNode<D> *allocGenNodes(int nAlloc, int *serialIx, double **coefs_p);
 
 private:

--- a/src/trees/SerialOperatorTree.cpp
+++ b/src/trees/SerialOperatorTree.cpp
@@ -175,6 +175,10 @@ void SerialOperatorTree::allocChildren(MWNode<2> &parent) {
     }
 }
 
+void SerialOperatorTree::allocChildrenNoCoeff(MWNode<2> &parent) {
+    NOT_IMPLEMENTED_ABORT;
+}
+
 void SerialOperatorTree::allocGenChildren(MWNode<2> &parent) {
     NOT_REACHED_ABORT;
 }

--- a/src/trees/SerialOperatorTree.h
+++ b/src/trees/SerialOperatorTree.h
@@ -50,6 +50,7 @@ public:
 
     void allocRoots(MWTree<2> &tree) override;
     void allocChildren(MWNode<2> &parent) override;
+    void allocChildrenNoCoeff(MWNode<2> &parent) override;
     void allocGenChildren(MWNode<2> &parent) override;
 
     void deallocNodes(int serialIx) override;

--- a/src/trees/SerialTree.h
+++ b/src/trees/SerialTree.h
@@ -57,6 +57,7 @@ public:
 
     virtual void allocRoots(MWTree<D> &tree) = 0;
     virtual void allocChildren(MWNode<D> &parent) = 0;
+    virtual void allocChildrenNoCoeff(MWNode<D> &parent) = 0;
     virtual void allocGenChildren(MWNode<D> &parent) = 0;
 
     virtual void deallocNodes(int serialIx) = 0;

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -191,9 +191,9 @@ void math_utils::apply_filter(double *out, double *in, const MatrixXd &filter, i
     Map<MatrixXd> f(in, kp1, kp1_dm1);
     Map<MatrixXd> g(out, kp1_dm1, kp1);
     if (fac < MachineZero) {
-        g = f.transpose() * filter;
+        g.noalias() = f.transpose() * filter;
     } else {
-        g += f.transpose() * filter;
+        g.noalias() += f.transpose() * filter;
     }
 #endif
 }

--- a/src/utils/mpi_utils.h
+++ b/src/utils/mpi_utils.h
@@ -68,8 +68,8 @@ public:
 
 template <int D> class FunctionTree;
 
-template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks = -1);
-template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks = -1);
+template <int D> void send_tree(FunctionTree<D> &tree, int dst, int tag, mrcpp::mpi_comm comm, int nChunks = -1, bool Coeff = true);
+template <int D> void recv_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm, int nChunks = -1, bool Coeff = true);
 template <int D> void share_tree(FunctionTree<D> &tree, int src, int tag, mrcpp::mpi_comm comm);
 
 } // namespace mrcpp


### PR DESCRIPTION
Additional functionalities to be used by the "fast_rotate" of MRChem. Should not change behaviour of other parts.
(also added "noalias" to the Eigen matrix multiplication: it is faster (does not buffer output))