### PR TITLE
.clang format, longer lines and EndNodes in AppendTree

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,7 +36,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     120
+ColumnLimit:     200
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 8

--- a/src/trees/NodeAllocator.cpp
+++ b/src/trees/NodeAllocator.cpp
@@ -184,7 +184,7 @@ template <int D> void NodeAllocator<D>::appendChunk(bool coefs) {
             // may increase size dynamically in the future
             if (this->shmem_p->sh_max_ptr < this->shmem_p->sh_end_ptr) MSG_ABORT("Shared block too small");
         } else {
-            c_chunk = new double[getCoefChunkSize()];
+            c_chunk = new double[getCoefChunkSize() / sizeof(double)];
         }
         this->coefChunks.push_back(c_chunk);
     }


### PR DESCRIPTION
Small changes: 
.clang_format with ColumnLimit:     200
FunctionTree.appendTreeNoCoeff now also writes EndNodeTable and sets EndNode flags.