### PR TITLE
Rename scaling factor

### DIFF
--- a/src/treebuilders/CrossCorrelationCalculator.cpp
+++ b/src/treebuilders/CrossCorrelationCalculator.cpp
@@ -89,10 +89,10 @@ template <int T> void CrossCorrelationCalculator::applyCcc(MWNode<2> &node, Cros
     double *coefs = node.getCoefs();
     double two_n = std::pow(2.0, -scale / 2.0);
     for (int i = 0; i < t_dim * kp1_d; i++) {
-        auto sf = node.getMWTree().getMRA().getWorldBox().getScalingFactor(0);
+        auto scaling_factor = node.getMWTree().getMRA().getWorldBox().getScalingFactor(0);
         // This is only implemented for unifrom scaling factors
         // hence the zero TODO: make it work for non-unifrom scaling
-        coefs[i] = std::sqrt(sf) * two_n * vec_o(i);
+        coefs[i] = std::sqrt(scaling_factor) * two_n * vec_o(i);
     }
 }
 

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -121,9 +121,9 @@ template <int D> void DerivativeCalculator<D>::calcNode(MWNode<D> &gNode) {
         }
     }
     // Multiply appropriate scaling factor
-    const double sf =
+    const double scaling_factor =
         std::pow(gNode.getMWTree().getMRA().getWorldBox().getScalingFactor(this->applyDir), oper->getOrder());
-    for (int i = 0; i < gNode.getNCoefs(); i++) gNode.getCoefs()[i] /= sf;
+    for (int i = 0; i < gNode.getNCoefs(); i++) gNode.getCoefs()[i] /= scaling_factor;
     this->calc_t[mrcpp_get_thread_num()].stop();
 
     this->norm_t[mrcpp_get_thread_num()].resume();

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -176,9 +176,9 @@ template <int D> double FunctionTree<D>::integrate() const {
     }
 
     // Handle potential scaling
-    auto sf = this->getMRA().getWorldBox().getScalingFactors();
+    auto scaling_factor = this->getMRA().getWorldBox().getScalingFactors();
     auto jacobian = 1.0;
-    for (const auto &sf_i : sf) jacobian *= std::sqrt(sf_i);
+    for (const auto &sf_i : scaling_factor) jacobian *= std::sqrt(sf_i);
     // Square root of scaling factor in each diection. The seemingly missing
     // multiplication by the square root of sf_i is included in the basis
 
@@ -201,9 +201,9 @@ template <int D> double FunctionTree<D>::integrate() const {
 template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 
     // Handle potential scaling
-    const auto sf = this->getMRA().getWorldBox().getScalingFactors();
+    const auto scaling_factor = this->getMRA().getWorldBox().getScalingFactors();
     auto arg = r;
-    for (auto i = 0; i < D; i++) arg[i] = arg[i] / sf[i];
+    for (auto i = 0; i < D; i++) arg[i] = arg[i] / scaling_factor[i];
 
     // The 1.0 appearing in the if tests comes from the period is
     // always 1.0 from the point of view of this function.
@@ -218,7 +218,7 @@ template <int D> double FunctionTree<D>::evalf(const Coord<D> &r) const {
 
     // Adjust for scaling factor included in basis
     auto coef = 1.0;
-    for (const auto &fac : sf) coef /= std::sqrt(fac);
+    for (const auto &fac : scaling_factor) coef /= std::sqrt(fac);
 
     return coef * result;
 }

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -317,9 +317,9 @@ template <int D> void MWNode<D>::cvTransform(int operation) {
         out_vec = tmp;
     }
 
-    const auto sf = this->getMWTree().getMRA().getWorldBox().getScalingFactors();
+    const auto scaling_factor = this->getMWTree().getMRA().getWorldBox().getScalingFactors();
     double sf_prod = 1.0;
-    for (const auto &s : sf) sf_prod *= s;
+    for (const auto &s : scaling_factor) sf_prod *= s;
     if (sf_prod <= MachineZero) sf_prod = 1.0; // When there is no scaling factor
 
     int np1 = getScale() + 1; // we're working on scaling coefs on next scale

--- a/tests/operators/derivative_operator.cpp
+++ b/tests/operators/derivative_operator.cpp
@@ -165,9 +165,6 @@ template <int D> void testDifferentiationPH(int order) {
 
 template <int D> void testDifferentiationPeriodicABGV(double a, double b) {
     MultiResolutionAnalysis<D> *mra = initializePeriodicMRA<D>();
-    Printer::init(0);
-    (*mra).print();
-
     double prec = 1.0e-6;
     ABGVOperator<D> diff(*mra, a, b);
 
@@ -181,8 +178,6 @@ template <int D> void testDifferentiationPeriodicABGV(double a, double b) {
 
     apply(dg_tree, diff, g_tree, 0);
     refine_grid(dg_tree, 1); // for accurate evalf
-    std::cout << "dg_tree " << dg_tree.evalf({12.0, 0.0, 0.0}) << "\n";
-    std::cout << "dg_func " << dg_func({12.0, 0.0, 0.0}) << "\n";
 
     REQUIRE(dg_tree.evalf({0.0, 0.0, 0.0}) == Approx(dg_func({0.0, 0.0, 0.0})).margin(prec));
     REQUIRE(dg_tree.evalf({12.0, 0.0, 0.0}) == Approx(dg_func({12.0, 0.0, 0.0})).margin(prec));


### PR DESCRIPTION
I renamed `sf` -> `scaling_factor`. This makes it easier to grep.

Note on `scaling_factor` in `derivatives`: 

Generally in the code the `scaling_factor`, are placed together with `two_n` factor. For derivatives the `two_n` factor is placed in the construction of the Operators. For the `scaling_factor` it is instead
placed in the apply, since we need access to the `apply_direction`.