### PR TITLE
Fix compile failure on Fedora rawhide arising from missing includes

### DIFF
--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 
 #include "MWTree.h"
 #include "NodeAllocator.h"

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <memory>
 
 #include "MRCPP/mrcpp_declarations.h"
 #include "utils/omp_utils.h"


### PR DESCRIPTION
`std::unique_ptr` is defined in `<memory>` which needs to be `#include`d to avoid compile failures.