### PR TITLE
CartesianConvolution operator

### DIFF
--- a/api/MWOperators
+++ b/api/MWOperators
@@ -23,8 +23,14 @@
  * <https://mrcpp.readthedocs.io/>
  */
 
+#include "operators/PoissonKernel.h"
+#include "operators/IdentityKernel.h"
+#include "operators/HelmholtzKernel.h"
+
 #include "operators/PoissonOperator.h"
 #include "operators/HelmholtzOperator.h"
+#include "operators/ConvolutionOperator.h"
+#include "operators/CartesianConvolution.h"
 #include "operators/DerivativeConvolution.h"
 #include "operators/IdentityConvolution.h"
 #include "operators/ABGVOperator.h"

--- a/api/mrcpp_declarations.h
+++ b/api/mrcpp_declarations.h
@@ -67,6 +67,7 @@ class OperatorNode;
 template <int D> class IdentityConvolution;
 template <int D> class DerivativeConvolution;
 template <int D> class ConvolutionOperator;
+class CartesianConvolution;
 class PoissonOperator;
 class HelmholtzOperator;
 template <int D> class DerivativeOperator;

--- a/src/operators/ABGVOperator.cpp
+++ b/src/operators/ABGVOperator.cpp
@@ -70,7 +70,10 @@ void ABGVOperator<D>::initialize(double a, double b) {
     print::time(10, "Time transform", trans_t);
     print::separator(10, ' ');
 
-    this->oper_exp.push_back(std::move(o_tree));
+    this->raw_exp.push_back(std::move(o_tree));
+
+    this->init(1);
+    for (int d = 0; d < D; d++) this->assign(0, d, this->raw_exp[0].get());
 }
 
 template class ABGVOperator<1>;

--- a/src/operators/ABGVOperator.cpp
+++ b/src/operators/ABGVOperator.cpp
@@ -71,9 +71,7 @@ void ABGVOperator<D>::initialize(double a, double b) {
     print::separator(10, ' ');
 
     this->raw_exp.push_back(std::move(o_tree));
-
-    this->init(1);
-    for (int d = 0; d < D; d++) this->assign(0, d, this->raw_exp[0].get());
+    this->initOperExp(1);
 }
 
 template class ABGVOperator<1>;

--- a/src/operators/BSOperator.cpp
+++ b/src/operators/BSOperator.cpp
@@ -60,7 +60,10 @@ template <int D> void BSOperator<D>::initialize() {
     print::time(10, "Time transform", trans_t);
     print::separator(10, ' ');
 
-    this->oper_exp.push_back(std::move(o_tree));
+    this->raw_exp.push_back(std::move(o_tree));
+
+    this->init(1);
+    for (int d = 0; d < D; d++) this->assign(0, d, this->raw_exp[0].get());
 }
 
 template class BSOperator<1>;

--- a/src/operators/BSOperator.cpp
+++ b/src/operators/BSOperator.cpp
@@ -61,9 +61,7 @@ template <int D> void BSOperator<D>::initialize() {
     print::separator(10, ' ');
 
     this->raw_exp.push_back(std::move(o_tree));
-
-    this->init(1);
-    for (int d = 0; d < D; d++) this->assign(0, d, this->raw_exp[0].get());
+    this->initOperExp(1);
 }
 
 template class BSOperator<1>;

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(mrcpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ABGVOperator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BSOperator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ConvolutionOperator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CartesianConvolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DerivativeConvolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/HelmholtzKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/HelmholtzOperator.cpp
@@ -18,6 +19,7 @@ get_filename_component(_dirname ${CMAKE_CURRENT_LIST_DIR} NAME)
 
 list(APPEND ${_dirname}_h
   ${CMAKE_CURRENT_SOURCE_DIR}/ABGVOperator.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/CartesianConvolution.h
   ${CMAKE_CURRENT_SOURCE_DIR}/ConvolutionOperator.h
   ${CMAKE_CURRENT_SOURCE_DIR}/BSOperator.h
   ${CMAKE_CURRENT_SOURCE_DIR}/DerivativeConvolution.h

--- a/src/operators/CartesianConvolution.cpp
+++ b/src/operators/CartesianConvolution.cpp
@@ -1,0 +1,80 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2021 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#include "CartesianConvolution.h"
+
+#include "core/InterpolatingBasis.h"
+#include "core/LegendreBasis.h"
+
+#include "functions/Gaussian.h"
+#include "functions/GaussExp.h"
+
+#include "treebuilders/CrossCorrelationCalculator.h"
+#include "treebuilders/OperatorAdaptor.h"
+#include "treebuilders/TreeBuilder.h"
+#include "treebuilders/grid.h"
+#include "treebuilders/project.h"
+
+#include "trees/BandWidth.h"
+#include "trees/FunctionTreeVector.h"
+#include "trees/OperatorTree.h"
+
+#include "utils/Printer.h"
+#include "utils/Timer.h"
+#include "utils/math_utils.h"
+
+namespace mrcpp {
+
+CartesianConvolution::CartesianConvolution(const MultiResolutionAnalysis<3> &mra, GaussExp<1> &kernel, double prec)
+        : ConvolutionOperator<3>(mra)
+        , sep_rank(kernel.size()) {
+    int oldlevel = Printer::setPrintLevel(0);
+
+    this->setBuildPrec(prec);
+    auto o_prec = prec;
+    auto k_prec = prec / 10.0;
+
+    for (auto &k : kernel) k->setPow({0});
+    this->initialize(kernel, k_prec, o_prec);
+    for (auto &k : kernel) k->setPow({1});
+    this->initialize(kernel, k_prec, o_prec);
+    for (auto &k : kernel) k->setPow({2});
+    this->initialize(kernel, k_prec, o_prec);
+
+    this->initOperExp(this->sep_rank);
+    Printer::setPrintLevel(oldlevel);
+}
+
+void CartesianConvolution::setCartesianComponents(int x, int y, int z) {
+    int x_shift = x*this->sep_rank;
+    int y_shift = y*this->sep_rank;
+    int z_shift = z*this->sep_rank;
+
+    for (int i = 0; i < this->sep_rank; i++) this->assign(i, 0, this->raw_exp[x_shift + i].get());
+    for (int i = 0; i < this->sep_rank; i++) this->assign(i, 1, this->raw_exp[y_shift + i].get());
+    for (int i = 0; i < this->sep_rank; i++) this->assign(i, 2, this->raw_exp[z_shift + i].get());
+}
+
+} // namespace mrcpp

--- a/src/operators/CartesianConvolution.h
+++ b/src/operators/CartesianConvolution.h
@@ -25,23 +25,21 @@
 
 #pragma once
 
-#include "MWOperator.h"
+#include "ConvolutionOperator.h"
 
 namespace mrcpp {
 
-template <int D> class DerivativeOperator : public MWOperator<D> {
+class CartesianConvolution : public ConvolutionOperator<3> {
 public:
-    DerivativeOperator(const MultiResolutionAnalysis<D> &mra, int root, int reach = 1)
-            : MWOperator<D>(mra, root, reach) {}
+    CartesianConvolution(const MultiResolutionAnalysis<3> &mra, GaussExp<1> &kernel, double prec);
+    CartesianConvolution(const CartesianConvolution &oper) = delete;
+    CartesianConvolution &operator=(const CartesianConvolution &oper) = delete;
+    virtual ~CartesianConvolution() = default;
 
-    DerivativeOperator(const DerivativeOperator &oper) = delete;
-    DerivativeOperator &operator=(const DerivativeOperator &oper) = delete;
-    ~DerivativeOperator() override = default;
-
-    int getOrder() const { return order; }
+    void setCartesianComponents(int x, int y, int z);
 
 protected:
-    int order{1};
+    int sep_rank;
 };
 
 } // namespace mrcpp

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -81,6 +81,7 @@ void ConvolutionOperator<D>::initialize(GaussExp<1> &kernel, double k_prec, doub
     TreeBuilder<2> builder;
     OperatorAdaptor adaptor(o_prec, o_mra.getMaxScale());
 
+    this->init(kernel.size());
     for (int i = 0; i < kernel.size(); i++) {
         // Rescale Gaussian for D-dim application
         auto *k_func = kernel.getFunc(i).copy();
@@ -102,7 +103,8 @@ void ConvolutionOperator<D>::initialize(GaussExp<1> &kernel, double k_prec, doub
         print::time(10, "Time transform", trans_t);
         print::separator(10, ' ');
 
-        this->oper_exp.push_back(std::move(o_tree));
+        this->raw_exp.push_back(std::move(o_tree));
+        for (int d = 0; d < D; d++) this->assign(i, d, this->raw_exp[i].get());
     }
 }
 

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -56,6 +56,7 @@ ConvolutionOperator<D>::ConvolutionOperator(const MultiResolutionAnalysis<D> &mr
     auto o_prec = prec;
     auto k_prec = prec / 10.0;
     initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }
@@ -69,6 +70,7 @@ ConvolutionOperator<D>::ConvolutionOperator(const MultiResolutionAnalysis<D> &mr
     auto o_prec = prec;
     auto k_prec = prec / 100.0;
     initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }
@@ -81,7 +83,6 @@ void ConvolutionOperator<D>::initialize(GaussExp<1> &kernel, double k_prec, doub
     TreeBuilder<2> builder;
     OperatorAdaptor adaptor(o_prec, o_mra.getMaxScale());
 
-    this->init(kernel.size());
     for (int i = 0; i < kernel.size(); i++) {
         // Rescale Gaussian for D-dim application
         auto *k_func = kernel.getFunc(i).copy();
@@ -104,7 +105,6 @@ void ConvolutionOperator<D>::initialize(GaussExp<1> &kernel, double k_prec, doub
         print::separator(10, ' ');
 
         this->raw_exp.push_back(std::move(o_tree));
-        for (int d = 0; d < D; d++) this->assign(i, d, this->raw_exp[i].get());
     }
 }
 

--- a/src/operators/ConvolutionOperator.h
+++ b/src/operators/ConvolutionOperator.h
@@ -41,6 +41,8 @@ public:
     double getBuildPrec() const { return this->build_prec; }
 
 protected:
+    std::vector<std::unique_ptr<OperatorTree>> raw_exp;
+
     ConvolutionOperator(const MultiResolutionAnalysis<D> &mra)
         : MWOperator<D>(mra, mra.getRootScale(), -10) {}
     ConvolutionOperator(const MultiResolutionAnalysis<D> &mra, int root, int reach)

--- a/src/operators/ConvolutionOperator.h
+++ b/src/operators/ConvolutionOperator.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "MWOperator.h"
-#include "trees/FunctionTreeVector.h"
 
 namespace mrcpp {
 
@@ -41,8 +40,6 @@ public:
     double getBuildPrec() const { return this->build_prec; }
 
 protected:
-    std::vector<std::unique_ptr<OperatorTree>> raw_exp;
-
     ConvolutionOperator(const MultiResolutionAnalysis<D> &mra)
         : MWOperator<D>(mra, mra.getRootScale(), -10) {}
     ConvolutionOperator(const MultiResolutionAnalysis<D> &mra, int root, int reach)

--- a/src/operators/DerivativeOperator.h
+++ b/src/operators/DerivativeOperator.h
@@ -42,6 +42,7 @@ public:
 
 protected:
     int order{1};
+    std::vector<std::unique_ptr<OperatorTree>> raw_exp;
 };
 
 } // namespace mrcpp

--- a/src/operators/HelmholtzOperator.cpp
+++ b/src/operators/HelmholtzOperator.cpp
@@ -50,6 +50,7 @@ HelmholtzOperator::HelmholtzOperator(const MultiResolutionAnalysis<3> &mra, doub
 
     HelmholtzKernel kernel(mu, k_prec, r_min, r_max);
     initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }
@@ -71,6 +72,7 @@ HelmholtzOperator::HelmholtzOperator(const MultiResolutionAnalysis<3> &mra, doub
 
     HelmholtzKernel kernel(mu, k_prec, r_min, r_max);
     initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }

--- a/src/operators/IdentityConvolution.cpp
+++ b/src/operators/IdentityConvolution.cpp
@@ -46,6 +46,7 @@ IdentityConvolution<D>::IdentityConvolution(const MultiResolutionAnalysis<D> &mr
 
     IdentityKernel<D> kernel(k_prec);
     this->initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }
@@ -61,6 +62,7 @@ IdentityConvolution<D>::IdentityConvolution(const MultiResolutionAnalysis<D> &mr
 
     IdentityKernel<D> kernel(k_prec);
     this->initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -32,6 +32,21 @@ using namespace Eigen;
 
 namespace mrcpp {
 
+template<int D>
+void MWOperator<D>::initOperExp(int M) {
+    if (this->raw_exp.size() < M) MSG_ABORT("Incompatible raw expansion");
+    this->oper_exp.clear();
+    for (int m = 0; m < M; m++) {
+        std::array<OperatorTree *, D> otrees;
+        otrees.fill(nullptr);
+        this->oper_exp.push_back(otrees);
+    }
+
+    // Sets up an isotropic operator with the first M raw terms in all direction
+    for (int i = 0; i < M; i++)
+        for (int d = 0; d < D; d++) assign(i, d, this->raw_exp[i].get());
+}
+
 template <int D>
 OperatorTree &MWOperator<D>::getComponent(int i, int d) {
     if (i < 0 or i >= this->oper_exp.size()) MSG_ERROR("Index out of bounds");

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -44,8 +44,6 @@ public:
     virtual ~MWOperator() = default;
 
     int size() const { return this->oper_exp.size(); }
-    void push_back(std::unique_ptr<OperatorTree> oper) { this->oper_exp.push_back(std::move(oper)); }
-
     int getMaxBandWidth(int depth = -1) const;
     const std::vector<int> &getMaxBandWidths() const { return this->band_max; }
 
@@ -55,20 +53,32 @@ public:
     int getOperatorRoot() const { return this->oper_root; }
     int getOperatorReach() const { return this->oper_reach; }
 
-    OperatorTree &getComponent(int i);
-    const OperatorTree &getComponent(int i) const;
+    OperatorTree &getComponent(int i, int d);
+    const OperatorTree &getComponent(int i, int d) const;
 
-    OperatorTree &operator[](int i) { return *this->oper_exp[i]; }
-    const OperatorTree &operator[](int i) const { return *this->oper_exp[i]; }
+    std::array<OperatorTree*, D> &operator[](int i) { return this->oper_exp[i]; }
+    const std::array<OperatorTree*, D> &operator[](int i) const { return this->oper_exp[i]; }
 
 protected:
     int oper_root;
     int oper_reach;
     MultiResolutionAnalysis<D> MRA;
-    std::vector<std::unique_ptr<OperatorTree>> oper_exp;
+    std::vector<std::array<OperatorTree *, D>> oper_exp;
     std::vector<int> band_max;
 
     MultiResolutionAnalysis<2> getOperatorMRA() const;
+
+    void init(int M) {
+        for (int m = 0; m < M; m++) {
+            std::array<OperatorTree *, D> otrees;
+            otrees.fill(nullptr);
+            this->oper_exp.push_back(otrees);
+        }
+    }
+    void assign(int i, int d, OperatorTree *oper) {
+        this->oper_exp[i][d] = oper;
+    }
+
 };
 
 } // namespace mrcpp

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -64,20 +64,13 @@ protected:
     int oper_reach;
     MultiResolutionAnalysis<D> MRA;
     std::vector<std::array<OperatorTree *, D>> oper_exp;
+    std::vector<std::unique_ptr<OperatorTree>> raw_exp;
     std::vector<int> band_max;
 
     MultiResolutionAnalysis<2> getOperatorMRA() const;
 
-    void init(int M) {
-        for (int m = 0; m < M; m++) {
-            std::array<OperatorTree *, D> otrees;
-            otrees.fill(nullptr);
-            this->oper_exp.push_back(otrees);
-        }
-    }
-    void assign(int i, int d, OperatorTree *oper) {
-        this->oper_exp[i][d] = oper;
-    }
+    void initOperExp(int M);
+    void assign(int i, int d, OperatorTree *oper) { this->oper_exp[i][d] = oper; }
 
 };
 

--- a/src/operators/OperatorState.h
+++ b/src/operators/OperatorState.h
@@ -104,7 +104,6 @@ private:
     int kp1_d;
     int kp1_dm1;
 
-    const OperatorTree *oTree;
     MWNode<D> *gNode;
     MWNode<D> *fNode;
     NodeIndex<D> *fIdx;

--- a/src/operators/PHOperator.cpp
+++ b/src/operators/PHOperator.cpp
@@ -65,9 +65,7 @@ template <int D> void PHOperator<D>::initialize() {
     print::separator(10, ' ');
 
     this->raw_exp.push_back(std::move(o_tree));
-
-    this->init(1);
-    for (int d = 0; d < D; d++) this->assign(0, d, this->raw_exp[0].get());
+    this->initOperExp(1);
 }
 
 template class PHOperator<1>;

--- a/src/operators/PHOperator.cpp
+++ b/src/operators/PHOperator.cpp
@@ -64,7 +64,10 @@ template <int D> void PHOperator<D>::initialize() {
     print::time(10, "Time transform", trans_t);
     print::separator(10, ' ');
 
-    this->oper_exp.push_back(std::move(o_tree));
+    this->raw_exp.push_back(std::move(o_tree));
+
+    this->init(1);
+    for (int d = 0; d < D; d++) this->assign(0, d, this->raw_exp[0].get());
 }
 
 template class PHOperator<1>;

--- a/src/operators/PoissonOperator.cpp
+++ b/src/operators/PoissonOperator.cpp
@@ -49,6 +49,7 @@ PoissonOperator::PoissonOperator(const MultiResolutionAnalysis<3> &mra, double p
 
     PoissonKernel kernel(k_prec, r_min, r_max);
     initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }
@@ -70,6 +71,7 @@ PoissonOperator::PoissonOperator(const MultiResolutionAnalysis<3> &mra, double p
 
     PoissonKernel kernel(k_prec, r_min, r_max);
     initialize(kernel, k_prec, o_prec);
+    this->initOperExp(kernel.size());
 
     Printer::setPrintLevel(oldlevel);
 }

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -87,7 +87,7 @@ private:
     }
 
     void applyOperComp(OperatorState<D> &os);
-    void applyOperator(OperatorState<D> &os);
+    void applyOperator(int i, OperatorState<D> &os);
     void tensorApplyOperComp(OperatorState<D> &os);
 
     void touchParentNodes(MWTree<D> &tree) const;

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -100,10 +100,6 @@ template <int D> void DerivativeCalculator<D>::calcNode(MWNode<D> &gNode) {
     MWNodeVector<D> fBand = makeOperBand(gNode, idx_band);
     this->band_t[mrcpp_get_thread_num()].stop();
 
-    assert(this->oper->size() == 1);
-    const OperatorTree &oTree = this->oper->getComponent(0);
-    os.oTree = &oTree;
-
     this->calc_t[mrcpp_get_thread_num()].resume();
     for (int n = 0; n < fBand.size(); n++) {
         MWNode<D> &fNode = *fBand[n];
@@ -159,7 +155,6 @@ MWNodeVector<D> DerivativeCalculator<D>::makeOperBand(const MWNode<D> &gNode, st
 /** Apply a single operator component (term) to a single f-node. Whether the
 operator actualy is applied is determined by a screening threshold. */
 template <int D> void DerivativeCalculator<D>::applyOperator(OperatorState<D> &os) {
-    const OperatorTree &oTree = *os.oTree;
     MWNode<D> &gNode = *os.gNode;
     MWNode<D> &fNode = *os.fNode;
     const NodeIndex<D> &fIdx = *os.fIdx;
@@ -170,6 +165,8 @@ template <int D> void DerivativeCalculator<D>::applyOperator(OperatorState<D> &o
     double **oData = os.getOperData();
 
     for (int d = 0; d < D; d++) {
+        const OperatorTree &oTree = this->oper->getComponent(0, d);
+
         int oTransl = fIdx[d] - gIdx[d];
 
         //  The following will check the actual band width in each direction.

--- a/src/trees/OperatorTree.cpp
+++ b/src/trees/OperatorTree.cpp
@@ -99,7 +99,7 @@ void OperatorTree::clearBandWidth() {
 }
 
 void OperatorTree::calcBandWidth(double prec) {
-    if (this->bandWidth != nullptr) MSG_ERROR("Band width not properly cleared");
+    if (this->bandWidth == nullptr) clearBandWidth();
     this->bandWidth = new BandWidth(getDepth());
 
     VectorXi max_transl;

--- a/tests/operators/helmholtz_operator.cpp
+++ b/tests/operators/helmholtz_operator.cpp
@@ -98,7 +98,6 @@ TEST_CASE("Helmholtz' kernel", "[init_helmholtz], [helmholtz_operator], [mw_oper
                 TreeBuilder<2> builder;
                 OperatorAdaptor adaptor(ccc_prec, oper_mra.getMaxScale());
 
-                MWOperator<3> O(func_mra, func_mra.getRootScale(), -10);
                 for (int i = 0; i < K.size(); i++) {
                     FunctionTree<1> &kern_tree = get_func(K, i);
                     CrossCorrelationCalculator calculator(kern_tree);
@@ -123,13 +122,7 @@ TEST_CASE("Helmholtz' kernel", "[init_helmholtz], [helmholtz_operator], [mw_oper
                         REQUIRE(bw_1.getMaxWidth(i) <= bw_2.getMaxWidth(i));
                         REQUIRE(bw_2.getMaxWidth(i) <= bw_3.getMaxWidth(i));
                     }
-                    O.push_back(std::move(oper_tree));
                 }
-                O.calcBandWidths(band_prec);
-                REQUIRE(O.getMaxBandWidth(3) == 3);
-                REQUIRE(O.getMaxBandWidth(7) == 5);
-                REQUIRE(O.getMaxBandWidth(13) == 9);
-                REQUIRE(O.getMaxBandWidth(20) == -1);
             }
             clear(K, true);
         }

--- a/tests/operators/poisson_operator.cpp
+++ b/tests/operators/poisson_operator.cpp
@@ -96,7 +96,6 @@ TEST_CASE("Initialize Poisson operator", "[init_poisson], [poisson_operator], [m
                 TreeBuilder<2> builder;
                 OperatorAdaptor adaptor(ccc_prec, oper_mra.getMaxScale());
 
-                MWOperator<3> O(func_mra, func_mra.getRootScale(), -10);
                 for (int i = 0; i < kern_vec.size(); i++) {
                     FunctionTree<1> &kern_tree = get_func(kern_vec, i);
                     CrossCorrelationCalculator calculator(kern_tree);
@@ -121,13 +120,7 @@ TEST_CASE("Initialize Poisson operator", "[init_poisson], [poisson_operator], [m
                         REQUIRE(bw_1.getMaxWidth(i) <= bw_2.getMaxWidth(i));
                         REQUIRE(bw_2.getMaxWidth(i) <= bw_3.getMaxWidth(i));
                     }
-                    O.push_back(std::move(oper_tree));
                 }
-                O.calcBandWidths(band_prec);
-                REQUIRE(O.getMaxBandWidth(3) == 3);
-                REQUIRE(O.getMaxBandWidth(7) == 5);
-                REQUIRE(O.getMaxBandWidth(13) == 9);
-                REQUIRE(O.getMaxBandWidth(19) == -1);
             }
             clear(kern_vec, true);
         }


### PR DESCRIPTION
- Allow for anisotropic `MWOperator` expansion
- Add `CartesianConvolution` operator which is takes a regular Gaussian kernel $$K(x) \approx \sum_p \alpha_p e^{-\beta_p x^2}$$ and projects three versions of it $$K(x),  x K(x),  x^2 K(x)$$ We can then assemble an arbitrary combination in three dimensions, e.g.  for a component of the Gauge operator with kernel $$O = \frac{xy}{r^3} \approx \sum_p \left[xK_p(x)\right] \left[yK_p(y)\right] \left[K_p(z)\right]$$