### PR TITLE
Add getChildPts and getQuadPts methods to MWNode for VAMPyR

### DIFF
--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -672,6 +672,21 @@ template <int D> void MWNode<D>::getPrimitiveQuadPts(MatrixXd &pts) const {
     for (int d = 0; d < D; d++) pts.row(d) = sFac * (roots.array() + static_cast<double>(l[d]));
 }
 
+template <int D> std::vector<std::vector<double>> MWNode<D>::getQuadPts() const {
+    MatrixXd pts;
+    getPrimitiveQuadPts(pts);
+
+    std::vector<std::vector<double>> ptsVec;
+
+    for (int d = 0; d < D; d++) {
+        std::vector<double> ptsVecD;
+        for (int i = 0; i < pts.cols(); i++) ptsVecD.push_back(pts(d, i));
+        ptsVec.push_back(ptsVecD);
+    }
+
+    return ptsVec;
+}
+
 template <int D> void MWNode<D>::getPrimitiveChildPts(MatrixXd &pts) const {
     int kp1 = this->getKp1();
     pts = MatrixXd::Zero(D, 2 * kp1);
@@ -685,6 +700,22 @@ template <int D> void MWNode<D>::getPrimitiveChildPts(MatrixXd &pts) const {
         pts.row(d).segment(0, kp1) = sFac * (roots.array() + 2.0 * static_cast<double>(l[d]));
         pts.row(d).segment(kp1, kp1) = sFac * (roots.array() + 2.0 * static_cast<double>(l[d]) + 1.0);
     }
+}
+
+template <int D>
+std::vector<std::vector<double>> MWNode<D>::getChildPts() const {
+    MatrixXd pts;
+    getPrimitiveChildPts(pts);
+
+    std::vector<std::vector<double>> ptsVec;
+
+    for (int d = 0; d < D; d++) {
+        std::vector<double> ptsVecD;
+        for (int i = 0; i < pts.cols(); i++) ptsVecD.push_back(pts(d, i));
+        ptsVec.push_back(ptsVecD);
+    }
+
+    return ptsVec;
 }
 
 template <int D> void MWNode<D>::getExpandedQuadPts(Eigen::MatrixXd &pts) const {

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -669,7 +669,7 @@ template <int D> void MWNode<D>::getPrimitiveQuadPts(MatrixXd &pts) const {
 
     double sFac = std::pow(2.0, -getScale());
     const NodeIndex<D> &l = getNodeIndex();
-    for (int d = 0; d < D; d++) pts.col(d) = sFac * (roots.array() + static_cast<double>(l[d]));
+    for (int d = 0; d < D; d++) pts.row(d) = sFac * (roots.array() + static_cast<double>(l[d]));
 }
 
 template <int D> void MWNode<D>::getPrimitiveChildPts(MatrixXd &pts) const {

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -89,6 +89,9 @@ public:
     void getExpandedQuadPts(Eigen::MatrixXd &pts) const;
     void getExpandedChildPts(Eigen::MatrixXd &pts) const;
 
+    std::vector<std::vector<double>> getQuadPts() const;
+    std::vector<std::vector<double>> getChildPts() const;
+
     MWTree<D> &getMWTree() { return static_cast<MWTree<D> &>(*this->tree); }
     MWNode<D> &getMWParent() { return static_cast<MWNode<D> &>(*this->parent); }
     MWNode<D> &getMWChild(int i) { return static_cast<MWNode<D> &>(*this->children[i]); }


### PR DESCRIPTION
- Implement `getChildPts()` and `getQuadPts()` methods in MWNode class.
- These methods return child and quadrature points as a vector of vectors of doubles.
- Both methods call the corresponding `getPrimitive*Pts()` methods to obtain the points in `Eigen::MatrixXd` format and then convert the points to `std::vector<std::vector<double>>`.

Also bugfix on col/row mixup in getPrimitiveQuadPts