### PR TITLE
Fix incoming issue with .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.6"
+    python: "3.9"
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.6"
+
 sphinx:
   configuration: docs/conf.py
 
@@ -8,6 +13,5 @@ formats:
   - pdf
 
 python:
-  version: 3.6
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 breathe
-Sphinx>=2.0
+Sphinx<7
 sphinx_rtd_theme


### PR DESCRIPTION
The key `build.os` will start being a requirement soon (see [link](https://blog.readthedocs.com/use-build-os-config/) )
Hopefully this fixes any issues