### PR TITLE
bug fix and remove MPI_CXX type

### DIFF
--- a/src/utils/ComplexFunction.cpp
+++ b/src/utils/ComplexFunction.cpp
@@ -1999,7 +1999,7 @@ DoubleMatrix calc_norm_overlap_matrix(MPI_FuncVector &BraKet) {
  *
  */
 void orthogonalize(double prec, MPI_FuncVector &Bra, MPI_FuncVector &Ket) {
-    // TODO: generalize for cases where Bra functions are not orthogonal to each other?
+    // TODO: generalize for cases where Ket functions are not orthogonal to each other?
     ComplexMatrix S = mpifuncvec::calc_overlap_matrix(Bra, Ket);
     int N = Bra.size();
     int M = Ket.size();
@@ -2011,7 +2011,7 @@ void orthogonalize(double prec, MPI_FuncVector &Bra, MPI_FuncVector &Ket) {
     ComplexMatrix rmat =  ComplexMatrix::Zero(M, N);
     for (int j = 0; j < N; j++) {
         for (int i = 0; i < M; i++) {
-            rmat(i,j) = 0.0 - S(j,i)/Ketnorms(i);
+            rmat(i,j) = 0.0 - S.conjugate()(j,i)/Ketnorms(i);
         }
     }
     MPI_FuncVector rotatedKet(N);

--- a/src/utils/parallel.cpp
+++ b/src/utils/parallel.cpp
@@ -292,7 +292,7 @@ void mpi::allreduce_vector(DoubleVector &vec, MPI_Comm comm) {
 void mpi::allreduce_vector(ComplexVector &vec, MPI_Comm comm) {
 #ifdef MRCPP_HAS_MPI
     int N = vec.size();
-    MPI_Allreduce(MPI_IN_PLACE, vec.data(), N, MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, vec.data(), N, MPI_C_DOUBLE_COMPLEX, MPI_SUM, comm);
 #endif
 }
 
@@ -316,7 +316,7 @@ void mpi::allreduce_matrix(DoubleMatrix &mat, MPI_Comm comm) {
 void mpi::allreduce_matrix(ComplexMatrix &mat, MPI_Comm comm) {
 #ifdef MRCPP_HAS_MPI
     int N = mat.size();
-    MPI_Allreduce(MPI_IN_PLACE, mat.data(), N, MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, mat.data(), N, MPI_C_DOUBLE_COMPLEX, MPI_SUM, comm);
 #endif
 }
 


### PR DESCRIPTION
The MPI_CXX types are not supported by MPICH. (It matters only for the size of the types so any type with correct (16 bytes) size would do)
Also bugfix in orthogonalization of orbital set wrt another set for general complex orbitals. 