### PR TITLE
Local html documentation with graphs made by Doxygen

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
           auto-update-conda: true
           auto-activate-base: false

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -154,8 +154,8 @@ IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
 #---------------------------------------------------------------------------
-GENERATE_HTML          = NO
-HTML_OUTPUT            = html
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html_local
 HTML_FILE_EXTENSION    = .html
 HTML_HEADER            =
 HTML_FOOTER            =
@@ -296,16 +296,16 @@ PERL_PATH              = @PERL_EXECUTABLE@
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = NO
+CLASS_DIAGRAMS         = YES
 MSCGEN_PATH            =
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 DOT_NUM_THREADS        = 0
 DOT_FONTNAME           = Helvetica
 DOT_FONTSIZE           = 10
 DOT_FONTPATH           =
-CLASS_GRAPH            = YES
+CLASS_GRAPH            = BUILTIN
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 UML_LOOK               = NO

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ html_logo = 'gfx/logo.jpg'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-breathe_projects = {'MRCPP': '_build/xml'}
+breathe_projects = {'MRCPP': '_build/xml', 'dot_graphs': '_build/xml'}
 breathe_default_project = 'MRCPP'
 
 


### PR DESCRIPTION
I was not able to make *sphinx* produce "clickable" diagrams for class inheritance. This PR provides a local workaround: when the documentation is built by *doxygen* it produces both the `xml` stuff required for further processing by *sphinx* and the `html` output. To avoid issues with the `html` produced by *sphinx* later, the native *doxygen* `html` is in the folder `docs/html_local`. It can be inspected by pointing your browser at `docs/html_local/index.html`