### PR TITLE
Remove macos-12 test (temporarily)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         # setup-miniconda not compatible with macos-latest presently.
         # https://github.com/conda-incubator/setup-miniconda/issues/344
-        os: [ubuntu-latest, macos-12]
+        # macos-12 temporarily removed since it keeps failing
+        os: [ubuntu-latest]  #, macos-12]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We still need mac build tests