### PR TITLE
Prebuild

### DIFF
--- a/src/trees/NodeAllocator.cpp
+++ b/src/trees/NodeAllocator.cpp
@@ -130,7 +130,7 @@ template <int D, typename T> int NodeAllocator<D, T>::alloc(int nNodes, bool coe
 
     // we require that the index for first child is a multiple of 2**D
     // so that we can find the sibling rank using rank=sIdx%(2**D)
-    if (sIdx % nNodes != 0) MSG_ERROR(" node allocate error");
+    if (sIdx % nNodes != 0) std::cout << "Warning: recommended number of siblings is 2**D" << std::endl;
 
     // fill stack status
     auto &status = this->stackStatus;

--- a/src/utils/CompFunction.cpp
+++ b/src/utils/CompFunction.cpp
@@ -782,6 +782,7 @@ template <int D> void project(CompFunction<D> &out, RepresentableFunction<D, dou
     out.func_ptr->isreal = 1;
     out.func_ptr->iscomplex = 0;
     if (out.Ncomp() < 1) out.alloc(1);
+    if (need_to_project) build_grid(*out.CompD[0], f);
     if (need_to_project) mrcpp::project<D, double>(prec, *out.CompD[0], f);
     mpi::share_function(out, 0, 132231, mpi::comm_share);
 }
@@ -790,6 +791,7 @@ template <int D> void project(CompFunction<D> &out, RepresentableFunction<D, Com
     out.func_ptr->isreal = 0;
     out.func_ptr->iscomplex = 1;
     if (out.Ncomp() < 1) out.alloc(1);
+    if (need_to_project) build_grid(*out.CompC[0], f);
     if (need_to_project) mrcpp::project<D, ComplexDouble>(prec, *out.CompC[0], f);
     mpi::share_function(out, 0, 132231, mpi::comm_share);
 }

--- a/src/utils/CompFunction.cpp
+++ b/src/utils/CompFunction.cpp
@@ -432,6 +432,7 @@ template class CompFunction<3>;
 template <int D> void deep_copy(CompFunction<D> *out, const CompFunction<D> &inp) {
     out->func_ptr->data = inp.func_ptr->data;
     out->alloc(inp.Ncomp());
+    if (inp.getNNodes() == 0) return;
     for (int i = 0; i < inp.Ncomp(); i++) {
         if (inp.isreal()) {
             inp.CompD[i]->deep_copy(out->CompD[i]);
@@ -448,6 +449,7 @@ template <int D> void deep_copy(CompFunction<D> *out, const CompFunction<D> &inp
 template <int D> void deep_copy(CompFunction<D> &out, const CompFunction<D> &inp) {
     out.func_ptr->data = inp.func_ptr->data;
     out.alloc(inp.Ncomp());
+    if (inp.getNNodes() == 0) return;
     for (int i = 0; i < inp.Ncomp(); i++) {
         if (inp.isreal()) {
             inp.CompD[i]->deep_copy(out.CompD[i]);
@@ -564,6 +566,10 @@ template <int D> void multiply(double prec, CompFunction<D> &out, double coef, C
     out.func_ptr->data = inp_a.func_ptr->data;
     out.func_ptr->data.shared = share; // we don't inherit the shareness
     out.func_ptr->conj = false;        // we don't inherit conjugaison
+    if (inp_a.getNNodes() == 0 or inp_b.getNNodes() == 0) {
+        if (!out_allocated) out.alloc(out.Ncomp());
+        return;
+    }
     for (int comp = 0; comp < inp_a.Ncomp(); comp++) {
         out.func_ptr->data.c1[comp] = inp_a.func_ptr->data.c1[comp] * inp_b.func_ptr->data.c1[comp]; // we could put this is coef if everything is real?
         if (inp_a.isreal() and inp_b.isreal()) {


### PR DESCRIPTION
Compared to older versions, there was a difference when projecting a representable function (not a function) that created differences in MRChem results in some cases.
"Prebuild" adds a build when a representable is projected.