### PR TITLE
Refactor copy to complex

### DIFF
--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -430,7 +430,7 @@ template <int D> void apply(CompFunction<D> &out, DerivativeOperator<D> &oper, C
                 } else {
                     if (inp.isreal()) {
                         apply(*out.CompD[ocomp], oper, *inp.CompD[icomp], dir);
-                        out.CompD[icomp]->CopyTreeToComplex(out.CompC[ocomp]);
+                        out.CompC[ocomp] = out.CompD[ocomp]->CopyTreeToComplex();
                         out.func_ptr->isreal = 0;
                         out.func_ptr->iscomplex = 1;
                     } else {

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -1206,9 +1206,8 @@ template <int D, typename T> FunctionTree<D, double> *FunctionTree<D, T>::Imag()
  */
 template <int D, typename T>
 template <typename U, typename>
-void FunctionTree<D, T>::CopyTreeToComplex(FunctionTree<D, ComplexDouble> *&outTree) {
-    delete outTree;
-    outTree = new FunctionTree<3, ComplexDouble>(this->getMRA());
+FunctionTree<D, ComplexDouble>* FunctionTree<D, T>::CopyTreeToComplex() {
+    auto* outTree = new FunctionTree<D, ComplexDouble>(this->getMRA());
     std::vector<MWNode<3, double> *> instack;         // node from this
     std::vector<MWNode<3, ComplexDouble> *> outstack; // node from outTree
     outTree->clearEndNodeTable();
@@ -1242,15 +1241,15 @@ void FunctionTree<D, T>::CopyTreeToComplex(FunctionTree<D, ComplexDouble> *&outT
     }
     outTree->calcSquareNorm();
     outTree->calcSquareNorm(true);
+    return outTree;
 }
 
 // for testing
 template <int D, typename T>
 template <typename U, typename>
-void FunctionTree<D, T>::CopyTreeToReal(FunctionTree<D, double> *&outTree) {
-    delete outTree;
+FunctionTree<D, double>* FunctionTree<D, T>::CopyTreeToReal() {
     // FunctionTree<3, double>* inTree = this;
-    outTree = new FunctionTree<3, double>(this->getMRA());
+    auto* outTree = new FunctionTree<D, double>(this->getMRA());
     std::vector<MWNode<3, double> *> instack;  // node from this
     std::vector<MWNode<3, double> *> outstack; // node from outTree
     outTree->clearEndNodeTable();
@@ -1283,6 +1282,7 @@ void FunctionTree<D, T>::CopyTreeToReal(FunctionTree<D, double> *&outTree) {
             outTree->endNodeTable.push_back(outNode);
         }
     }
+    return outTree;
 }
 
 template class FunctionTree<1, double>;

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -1204,8 +1204,9 @@ template <int D, typename T> FunctionTree<D, double> *FunctionTree<D, T>::Imag()
  * From real to complex tree. Copy everything, and convert double to ComplexDouble for the coefficents.
  * Should use a deep_copy if generalized in the future.
  */
-
-template <> void FunctionTree<3, double>::CopyTreeToComplex(FunctionTree<3, ComplexDouble> *&outTree) {
+template <int D, typename T>
+template <typename U, typename>
+void FunctionTree<D, T>::CopyTreeToComplex(FunctionTree<D, ComplexDouble> *&outTree) {
     delete outTree;
     outTree = new FunctionTree<3, ComplexDouble>(this->getMRA());
     std::vector<MWNode<3, double> *> instack;         // node from this
@@ -1243,84 +1244,10 @@ template <> void FunctionTree<3, double>::CopyTreeToComplex(FunctionTree<3, Comp
     outTree->calcSquareNorm(true);
 }
 
-template <> void FunctionTree<2, double>::CopyTreeToComplex(FunctionTree<2, ComplexDouble> *&outTree) {
-    delete outTree;
-    outTree = new FunctionTree<2, ComplexDouble>(this->getMRA());
-    std::vector<MWNode<2, double> *> instack;         // node from this
-    std::vector<MWNode<2, ComplexDouble> *> outstack; // node from outTree
-    outTree->clearEndNodeTable();
-    for (int rIdx = 0; rIdx < this->getRootBox().size(); rIdx++) {
-        instack.push_back(this->getRootBox().getNodes()[rIdx]);
-        outstack.push_back(outTree->getRootBox().getNodes()[rIdx]);
-    }
-    int ncoefs = this->getNodeAllocator().getNCoefs();
-    while (instack.size() > 0) {
-        // inNode and outNode are the same node in space, but on different trees
-        MWNode<2, ComplexDouble> *outNode = outstack.back();
-        outstack.pop_back();
-        MWNode<2, double> *inNode = instack.back();
-        instack.pop_back();
-        // copy coefficients:
-        double *incoefs = inNode->getCoefs();
-        ComplexDouble *outcoefs = outNode->getCoefs();
-        for (int i = 0; i < ncoefs; i++) outcoefs[i] = incoefs[i];
-        outNode->setHasCoefs();
-        outNode->calcNorms();
-
-        if (inNode->getNChildren() > 0) {
-            if (outNode->getNChildren() < inNode->getNChildren()) outNode->createChildren(true);
-            for (int i = 0; i < inNode->getNChildren(); i++) {
-                instack.push_back(inNode->children[i]);
-                outstack.push_back(outNode->children[i]);
-            }
-        } else {
-            outTree->endNodeTable.push_back(outNode);
-        }
-    }
-    outTree->calcSquareNorm();
-    outTree->calcSquareNorm(true);
-}
-
-template <> void FunctionTree<1, double>::CopyTreeToComplex(FunctionTree<1, ComplexDouble> *&outTree) {
-    delete outTree;
-    outTree = new FunctionTree<1, ComplexDouble>(this->getMRA());
-    std::vector<MWNode<1, double> *> instack;         // node from this
-    std::vector<MWNode<1, ComplexDouble> *> outstack; // node from outTree
-    outTree->clearEndNodeTable();
-    for (int rIdx = 0; rIdx < this->getRootBox().size(); rIdx++) {
-        instack.push_back(this->getRootBox().getNodes()[rIdx]);
-        outstack.push_back(outTree->getRootBox().getNodes()[rIdx]);
-    }
-    int ncoefs = this->getNodeAllocator().getNCoefs();
-    while (instack.size() > 0) {
-        // inNode and outNode are the same node in space, but on different trees
-        MWNode<1, ComplexDouble> *outNode = outstack.back();
-        outstack.pop_back();
-        MWNode<1, double> *inNode = instack.back();
-        instack.pop_back();
-        // copy coefficients:
-        double *incoefs = inNode->getCoefs();
-        ComplexDouble *outcoefs = outNode->getCoefs();
-        for (int i = 0; i < ncoefs; i++) outcoefs[i] = incoefs[i];
-        outNode->setHasCoefs();
-        outNode->calcNorms();
-
-        if (inNode->getNChildren() > 0) {
-            if (outNode->getNChildren() < inNode->getNChildren()) outNode->createChildren(true);
-            for (int i = 0; i < inNode->getNChildren(); i++) {
-                instack.push_back(inNode->children[i]);
-                outstack.push_back(outNode->children[i]);
-            }
-        } else {
-            outTree->endNodeTable.push_back(outNode);
-        }
-    }
-    outTree->calcSquareNorm();
-    outTree->calcSquareNorm(true);
-}
-
 // for testing
-template <> void FunctionTree<3, double>::CopyTreeToReal(FunctionTree<3, double> *&outTree) {
+template <int D, typename T>
+template <typename U, typename>
+void FunctionTree<D, T>::CopyTreeToReal(FunctionTree<D, double> *&outTree) {
     delete outTree;
     // FunctionTree<3, double>* inTree = this;
     outTree = new FunctionTree<3, double>(this->getMRA());

--- a/src/trees/FunctionTree.cpp
+++ b/src/trees/FunctionTree.cpp
@@ -1208,8 +1208,8 @@ template <int D, typename T>
 template <typename U, typename>
 FunctionTree<D, ComplexDouble>* FunctionTree<D, T>::CopyTreeToComplex() {
     auto* outTree = new FunctionTree<D, ComplexDouble>(this->getMRA());
-    std::vector<MWNode<3, double> *> instack;         // node from this
-    std::vector<MWNode<3, ComplexDouble> *> outstack; // node from outTree
+    std::vector<MWNode<D, double> *> instack;         // node from this
+    std::vector<MWNode<D, ComplexDouble> *> outstack; // node from outTree
     outTree->clearEndNodeTable();
     for (int rIdx = 0; rIdx < this->getRootBox().size(); rIdx++) {
         instack.push_back(this->getRootBox().getNodes()[rIdx]);
@@ -1218,9 +1218,9 @@ FunctionTree<D, ComplexDouble>* FunctionTree<D, T>::CopyTreeToComplex() {
     int ncoefs = this->getNodeAllocator().getNCoefs();
     while (instack.size() > 0) {
         // inNode and outNode are the same node in space, but on different trees
-        MWNode<3, ComplexDouble> *outNode = outstack.back();
+        MWNode<D, ComplexDouble> *outNode = outstack.back();
         outstack.pop_back();
-        MWNode<3, double> *inNode = instack.back();
+        MWNode<D, double> *inNode = instack.back();
         instack.pop_back();
         // copy coefficients:
         double *incoefs = inNode->getCoefs();
@@ -1248,10 +1248,10 @@ FunctionTree<D, ComplexDouble>* FunctionTree<D, T>::CopyTreeToComplex() {
 template <int D, typename T>
 template <typename U, typename>
 FunctionTree<D, double>* FunctionTree<D, T>::CopyTreeToReal() {
-    // FunctionTree<3, double>* inTree = this;
+    // FunctionTree<D, double>* inTree = this;
     auto* outTree = new FunctionTree<D, double>(this->getMRA());
-    std::vector<MWNode<3, double> *> instack;  // node from this
-    std::vector<MWNode<3, double> *> outstack; // node from outTree
+    std::vector<MWNode<D, double> *> instack;  // node from this
+    std::vector<MWNode<D, double> *> outstack; // node from outTree
     outTree->clearEndNodeTable();
     for (int rIdx = 0; rIdx < this->getRootBox().size(); rIdx++) {
         instack.push_back(this->getRootBox().getNodes()[rIdx]);
@@ -1260,9 +1260,9 @@ FunctionTree<D, double>* FunctionTree<D, T>::CopyTreeToReal() {
     int ncoefs = this->getNodeAllocator().getNCoefs();
     while (instack.size() > 0) {
         // inNode and outNode are the same node in space, but on different trees
-        MWNode<3, double> *outNode = outstack.back();
+        MWNode<D, double> *outNode = outstack.back();
         outstack.pop_back();
-        MWNode<3, double> *inNode = instack.back();
+        MWNode<D, double> *inNode = instack.back();
         instack.pop_back();
         // copy coefficients:
         double *incoefs = inNode->getCoefs();
@@ -1292,5 +1292,12 @@ template class FunctionTree<3, double>;
 template class FunctionTree<1, ComplexDouble>;
 template class FunctionTree<2, ComplexDouble>;
 template class FunctionTree<3, ComplexDouble>;
+
+template FunctionTree<1, ComplexDouble>* FunctionTree<1, double>::CopyTreeToComplex<double, void>();
+template FunctionTree<2, ComplexDouble>* FunctionTree<2, double>::CopyTreeToComplex<double, void>();
+template FunctionTree<3, ComplexDouble>* FunctionTree<3, double>::CopyTreeToComplex<double, void>();
+template FunctionTree<1, double>* FunctionTree<1, double>::CopyTreeToReal<double, void>();
+template FunctionTree<2, double>* FunctionTree<2, double>::CopyTreeToReal<double, void>();
+template FunctionTree<3, double>* FunctionTree<3, double>::CopyTreeToReal<double, void>();
 
 } // namespace mrcpp

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -129,10 +129,12 @@ public:
     void deep_copy(FunctionTree<D, T> *out);
     FunctionTree<D, double> *Real();
     FunctionTree<D, double> *Imag();
-    void CopyTreeToComplex(FunctionTree<3, ComplexDouble> *&out);
-    void CopyTreeToComplex(FunctionTree<2, ComplexDouble> *&out);
-    void CopyTreeToComplex(FunctionTree<1, ComplexDouble> *&out);
-    void CopyTreeToReal(FunctionTree<3, double> *&out); // for testing
+    template <typename U = T,
+              typename = std::enable_if_t<std::is_same_v<U, double>>>
+        void CopyTreeToComplex(FunctionTree<D, ComplexDouble> *&out);
+     template <typename U = T,
+              typename = std::enable_if_t<std::is_same_v<U, double>>>
+       void CopyTreeToReal(FunctionTree<D, double> *&out); // for testing
 
 protected:
     std::unique_ptr<NodeAllocator<D, T>> genNodeAllocator_p{nullptr};

--- a/src/trees/FunctionTree.h
+++ b/src/trees/FunctionTree.h
@@ -131,10 +131,10 @@ public:
     FunctionTree<D, double> *Imag();
     template <typename U = T,
               typename = std::enable_if_t<std::is_same_v<U, double>>>
-        void CopyTreeToComplex(FunctionTree<D, ComplexDouble> *&out);
+        FunctionTree<D, ComplexDouble>* CopyTreeToComplex();
      template <typename U = T,
               typename = std::enable_if_t<std::is_same_v<U, double>>>
-       void CopyTreeToReal(FunctionTree<D, double> *&out); // for testing
+       FunctionTree<D, double>* CopyTreeToReal(); // for testing
 
 protected:
     std::unique_ptr<NodeAllocator<D, T>> genNodeAllocator_p{nullptr};

--- a/src/utils/CompFunction.cpp
+++ b/src/utils/CompFunction.cpp
@@ -425,8 +425,6 @@ template <int D> void CompFunction<D>::add(ComplexDouble c, CompFunction<D> inp)
                 CompC[i] = CompD[i]->CopyTreeToComplex();
                 delete CompD[i];
                 CompD[i] = nullptr;
-                inp.func_ptr->isreal = 0;
-                inp.func_ptr->iscomplex = 1;
             }
             func_ptr->iscomplex = 1;
             func_ptr->isreal = 0;
@@ -491,29 +489,6 @@ template class MultiResolutionAnalysis<3>;
 template class CompFunction<1>;
 template class CompFunction<2>;
 template class CompFunction<3>;
-
-/** @brief Deep copy that changes type from real to complex
- *
- * Deep copy: makes an exact copy with type complex from a real input
- */
-template <int D> void CopyToComplex(CompFunction<D> &out, const CompFunction<D> &inp) {
-    out.func_ptr->data = inp.func_ptr->data;
-    out.defcomplex();
-    out.func_ptr->data.isreal = 0;
-    out.alloc(inp.Ncomp());
-    if (inp.getNNodes() == 0) return;
-    for (int i = 0; i < inp.Ncomp(); i++) {
-        if (inp.isreal()) {
-            out.CompC[i] = inp.CompD[i]->CopyTreeToComplex();
-            delete inp.CompD[i];
-            inp.CompD[i] = nullptr;
-            inp.func_ptr->iscomplex = true;
-            inp.func_ptr->isreal = false;
-        } else {
-            inp.CompC[i]->deep_copy(out.CompC[i]);
-        }
-    }
-}
 
 
 /** @brief Deep copy
@@ -2749,7 +2724,6 @@ template void multiply(CompFunction<3> &out, FunctionTree<3, double> &inp_a, Rep
 template void multiply(CompFunction<3> &out, FunctionTree<3, ComplexDouble> &inp_a, RepresentableFunction<3, ComplexDouble> &f, double prec, int nrefine = 0, bool conjugate);
 template void multiply(CompFunction<3> &out, CompFunction<3> &inp_a, RepresentableFunction<3, double> &f, double prec, int nrefine = 0, bool conjugate);
 template void multiply(CompFunction<3> &out, CompFunction<3> &inp_a, RepresentableFunction<3, ComplexDouble> &f, double prec, int nrefine = 0, bool conjugate);
-template void CopyToComplex(CompFunction<3> &out, const CompFunction<3> &inp);
 template void deep_copy(CompFunction<3> *out, const CompFunction<3> &inp);
 template void deep_copy(CompFunction<3> &out, const CompFunction<3> &inp);
 template void add(CompFunction<3> &out, ComplexDouble a, CompFunction<3> inp_a, ComplexDouble b, CompFunction<3> inp_b, double prec, bool conjugate);

--- a/src/utils/CompFunction.cpp
+++ b/src/utils/CompFunction.cpp
@@ -422,7 +422,7 @@ template <int D> void CompFunction<D>::add(ComplexDouble c, CompFunction<D> inp)
         } else if( this->isreal()) {
             // we set as complex
             for (int i = 0; i < Ncomp(); i++) {
-                CompD[i]->CopyTreeToComplex(CompC[i]);
+                CompC[i] = CompD[i]->CopyTreeToComplex();
                 delete CompD[i];
                 CompD[i] = nullptr;
             }
@@ -468,7 +468,7 @@ template <int D> void CompFunction<D>::rescale(ComplexDouble c) {
                 CompC[i]->rescale(c);
             } else {
                 if (abs(c.imag()) > MachineZero) { // works only only for NComp==1)
-                    CompD[i]->CopyTreeToComplex(CompC[i]);
+                    CompC[i] = CompD[i]->CopyTreeToComplex();
                     delete CompD[i];
                     CompD[i] = nullptr;
                     func_ptr->iscomplex = true;
@@ -502,7 +502,7 @@ template <int D> void CopyToComplex(CompFunction<D> &out, const CompFunction<D> 
     if (inp.getNNodes() == 0) return;
     for (int i = 0; i < inp.Ncomp(); i++) {
         if (inp.isreal()) {
-            inp.CompD[i]->CopyTreeToComplex(out.CompC[i]);
+            out.CompC[i] = inp.CompD[i]->CopyTreeToComplex();
         } else {
             inp.CompC[i]->deep_copy(out.CompC[i]);
         }
@@ -603,7 +603,7 @@ template <int D> void linear_combination(CompFunction<D> &out, const std::vector
             FunctionTreeVector<D, ComplexDouble> fvec; // one component vector
             for (int i = 0; i < inp.size(); i++) {
                 if (inp[i].isreal()) {
-                    inp[i].CompD[comp]->CopyTreeToComplex(inp[i].CompC[comp]);
+                    inp[i].CompC[comp] = inp[i].CompD[comp]->CopyTreeToComplex();
                     delete inp[i].CompD[comp];
                     inp[i].CompD[comp] = nullptr;
                     inp[i].func_ptr->iscomplex = true;
@@ -695,12 +695,12 @@ template <int D> void multiply(double prec, CompFunction<D> &out, double coef, C
             bool inp_aisReal = inp_a.isreal();
             bool inp_bisReal = inp_b.isreal();
             if (inp_aisReal) {
-                inp_a.CompD[comp]->CopyTreeToComplex(inp_a.CompC[comp]);
+                inp_a.CompC[comp] = inp_a.CompD[comp]->CopyTreeToComplex();
                 inp_a.func_ptr->iscomplex = true;
                 inp_a.func_ptr->isreal = false;
             }
             if (inp_bisReal) {
-                inp_b.CompD[comp]->CopyTreeToComplex(inp_b.CompC[comp]);
+                inp_b.CompC[comp] = inp_b.CompD[comp]->CopyTreeToComplex();
                 inp_b.func_ptr->iscomplex = true;
                 inp_b.func_ptr->isreal = false;
             }
@@ -722,7 +722,7 @@ template <int D> void multiply(double prec, CompFunction<D> &out, double coef, C
                     // Adaptive grid
                     if (out.CompD[comp] != nullptr) { // NB: func_ptr has alreadybeen overwritten!
                         if (out.CompD[comp]->getNNodes() > 0) {
-                            out.CompD[comp]->CopyTreeToComplex(out.CompC[comp]);
+                            out.CompC[comp] = out.CompD[comp]->CopyTreeToComplex();
                             out.func_ptr->iscomplex = 1;
                             out.func_ptr->isreal = 0;
                             delete out.CompD[comp];
@@ -2246,13 +2246,13 @@ ComplexMatrix calc_overlap_matrix_cplx(CompFunctionVector &Bra, CompFunctionVect
         // temporary solution: copy as complex trees
         if (braisreal) {
             for (int i = 0; i < Bra.size(); i++) {
-                Bra[i].CompD[0]->CopyTreeToComplex(Bra[i].CompC[0]);
+                Bra[i].CompC[0] = Bra[i].CompD[0]->CopyTreeToComplex();
                 Bra[i].func_ptr->iscomplex = 1;
             }
         }
         if (ketisreal) {
             for (int i = 0; i < Ket.size(); i++) {
-                Ket[i].CompD[0]->CopyTreeToComplex(Ket[i].CompC[0]);
+                Ket[i].CompC[0] = Ket[i].CompD[0]->CopyTreeToComplex();
                 Ket[i].func_ptr->iscomplex = 1;
             }
         }

--- a/src/utils/CompFunction.cpp
+++ b/src/utils/CompFunction.cpp
@@ -13,7 +13,7 @@
  * NComp is the number of components. If Ncomp>0, the corresponding trees must exist (can be only empty roots).
  * The other trees should be set to nullptr.
  * The trees and data can be shared among several CompFunction; this is managed automatically by "std::make_shared"
- * Normally the CompFunction must be eiher real or complex (or none if noe is defined anyway).
+ * Normally the CompFunction must be eiher real or complex (or none if none is defined anyway).
  * Though it is allowed in some cases to have both and the code should preferably allow this. (It is used temporary
  * when we need a Complex type, but the trees are real: the tree is then copied as a complex tree in the same CompFunction).
  * TreePtr (aka func_ptr) is the part potentially shared with others with "std::make_shared". It contains the pointers to the trees.
@@ -425,6 +425,8 @@ template <int D> void CompFunction<D>::add(ComplexDouble c, CompFunction<D> inp)
                 CompC[i] = CompD[i]->CopyTreeToComplex();
                 delete CompD[i];
                 CompD[i] = nullptr;
+                inp.func_ptr->isreal = 0;
+                inp.func_ptr->iscomplex = 1;
             }
             func_ptr->iscomplex = 1;
             func_ptr->isreal = 0;
@@ -503,6 +505,10 @@ template <int D> void CopyToComplex(CompFunction<D> &out, const CompFunction<D> 
     for (int i = 0; i < inp.Ncomp(); i++) {
         if (inp.isreal()) {
             out.CompC[i] = inp.CompD[i]->CopyTreeToComplex();
+            delete inp.CompD[i];
+            inp.CompD[i] = nullptr;
+            inp.func_ptr->iscomplex = true;
+            inp.func_ptr->isreal = false;
         } else {
             inp.CompC[i]->deep_copy(out.CompC[i]);
         }
@@ -696,11 +702,15 @@ template <int D> void multiply(double prec, CompFunction<D> &out, double coef, C
             bool inp_bisReal = inp_b.isreal();
             if (inp_aisReal) {
                 inp_a.CompC[comp] = inp_a.CompD[comp]->CopyTreeToComplex();
+                delete inp_a.CompD[comp];
+                inp_a.CompD[comp] = nullptr;
                 inp_a.func_ptr->iscomplex = true;
                 inp_a.func_ptr->isreal = false;
             }
             if (inp_bisReal) {
                 inp_b.CompC[comp] = inp_b.CompD[comp]->CopyTreeToComplex();
+                delete inp_b.CompD[comp];
+                inp_b.CompD[comp] = nullptr;
                 inp_b.func_ptr->iscomplex = true;
                 inp_b.func_ptr->isreal = false;
             }
@@ -2247,13 +2257,19 @@ ComplexMatrix calc_overlap_matrix_cplx(CompFunctionVector &Bra, CompFunctionVect
         if (braisreal) {
             for (int i = 0; i < Bra.size(); i++) {
                 Bra[i].CompC[0] = Bra[i].CompD[0]->CopyTreeToComplex();
+                delete Bra[i].CompD[0];
+                Bra[i].CompD[0] = nullptr;
                 Bra[i].func_ptr->iscomplex = 1;
+                Bra[i].func_ptr->isreal = 0;
             }
         }
         if (ketisreal) {
             for (int i = 0; i < Ket.size(); i++) {
                 Ket[i].CompC[0] = Ket[i].CompD[0]->CopyTreeToComplex();
+                delete Ket[i].CompD[0];
+                Ket[i].CompD[0] = nullptr;
                 Ket[i].func_ptr->iscomplex = 1;
+                Ket[i].func_ptr->isreal = 0;
             }
         }
     }

--- a/src/utils/CompFunction.h
+++ b/src/utils/CompFunction.h
@@ -170,7 +170,6 @@ public:
     std::shared_ptr<mrcpp::TreePtr<D>> func_ptr;
 };
 
-template <int D> void CopyToComplex(CompFunction<D> &out, const CompFunction<D> &inp);
 template <int D> void deep_copy(CompFunction<D> *out, const CompFunction<D> &inp);
 template <int D> void deep_copy(CompFunction<D> &out, const CompFunction<D> &inp);
 template <int D> void add(CompFunction<D> &out, ComplexDouble a, 

--- a/src/utils/CompFunction.h
+++ b/src/utils/CompFunction.h
@@ -133,8 +133,7 @@ public:
      * @param positiveSide If true, integrate over the positive side (x>0 if dim=0)
      * @return Resulting integral
      */
-    ComplexDouble integrateSide(int dim, bool positiveSide) const;
-    
+    ComplexDouble integrateSide(int dim, bool positiveSide) const;  //LUCA: This should rather become a utility function instead of being a member function, as it is not required for the "exsistence" of the CompFunction, but only a specific operation on it. 
     double norm() const;
     double getSquareNorm() const;
     void alloc(int nalloc = 1, bool zero = true);
@@ -174,20 +173,35 @@ public:
 template <int D> void CopyToComplex(CompFunction<D> &out, const CompFunction<D> &inp);
 template <int D> void deep_copy(CompFunction<D> *out, const CompFunction<D> &inp);
 template <int D> void deep_copy(CompFunction<D> &out, const CompFunction<D> &inp);
-template <int D> void add(CompFunction<D> &out, ComplexDouble a, CompFunction<D> inp_a, ComplexDouble b, CompFunction<D> inp_b, double prec, bool conjugate = false);
-template <int D> void linear_combination(CompFunction<D> &out, const std::vector<ComplexDouble> &c, std::vector<CompFunction<D>> &inp, double prec, bool conjugate = false);
-template <int D> void multiply(CompFunction<D> &out, CompFunction<D> inp_a, CompFunction<D> inp_b, double prec, bool absPrec = false, bool useMaxNorms = false, bool conjugate = false);
-template <int D>
-void multiply(double prec, CompFunction<D> &out, double coef, CompFunction<D> inp_a, CompFunction<D> inp_b, int maxIter = -1, bool absPrec = false, bool useMaxNorms = false, bool conjugate = false);
+template <int D> void add(CompFunction<D> &out, ComplexDouble a, 
+                          CompFunction<D> inp_a, ComplexDouble b, 
+                          CompFunction<D> inp_b, double prec, bool conjugate = false);
+template <int D> void linear_combination(CompFunction<D> &out, const std::vector<ComplexDouble> &c, 
+                                         std::vector<CompFunction<D>> &inp, double prec, bool conjugate = false);
+template <int D> void multiply(CompFunction<D> &out, CompFunction<D> inp_a, CompFunction<D> inp_b, 
+                               double prec, bool absPrec = false, bool useMaxNorms = false, bool conjugate = false);
+template <int D> void multiply(double prec, CompFunction<D> &out, double coef, CompFunction<D> inp_a, 
+                               CompFunction<D> inp_b, int maxIter = -1, bool absPrec = false, bool useMaxNorms = false, 
+                               bool conjugate = false);
+template <int D> void multiply(CompFunction<D> &out, CompFunction<D> inp_a,
+                               CompFunction<D> inp_b, bool absPrec = false, 
+                               bool useMaxNorms = false, bool conjugate = false);
+template <int D> void multiply(CompFunction<D> &out, CompFunction<D> &inp_a, 
+                               RepresentableFunction<D, double> &f, double prec, 
+                               int nrefine = 0, bool conjugate = false);
+template <int D> void multiply(CompFunction<D> &out, CompFunction<D> &inp_a, 
+                               RepresentableFunction<D, ComplexDouble> &f, 
+                               double prec, int nrefine = 0, bool conjugate = false);
+template <int D> void multiply(CompFunction<D> &out, FunctionTree<D, double> &inp_a, 
+                               RepresentableFunction<D, double> &f, double prec, int nrefine = 0, 
+                               bool conjugate = false);
+template <int D> void multiply(CompFunction<D> &out, FunctionTree<D, ComplexDouble> &inp_a, 
+                               RepresentableFunction<D, ComplexDouble> &f, double prec, int nrefine = 0, 
+                               bool conjugate = false);
 template <int D> void make_density(CompFunction<D> &out, CompFunction<D> inp, double prec);
-template <int D> void multiply(CompFunction<D> &out, CompFunction<D> inp_a, CompFunction<D> inp_b, bool absPrec = false, bool useMaxNorms = false, bool conjugate = false);
-template <int D> void multiply(CompFunction<D> &out, CompFunction<D> &inp_a, RepresentableFunction<D, double> &f, double prec, int nrefine = 0, bool conjugate = false);
-template <int D> void multiply(CompFunction<D> &out, CompFunction<D> &inp_a, RepresentableFunction<D, ComplexDouble> &f, double prec, int nrefine = 0, bool conjugate = false);
-template <int D> void multiply(CompFunction<D> &out, FunctionTree<D, double> &inp_a, RepresentableFunction<D, double> &f, double prec, int nrefine = 0, bool conjugate = false);
-template <int D> void multiply(CompFunction<D> &out, FunctionTree<D, ComplexDouble> &inp_a, RepresentableFunction<D, ComplexDouble> &f, double prec, int nrefine = 0, bool conjugate = false);
 template <int D> ComplexDouble dot(CompFunction<D> bra, CompFunction<D> ket);
 template <int D> double node_norm_dot(CompFunction<D> bra, CompFunction<D> ket);
-void project(CompFunction<3> &out, std::function<double(const Coord<3> &r)> f, double prec);
+void project(CompFunction<3> &out, std::function<double(const Coord<3> &r)> f, double prec); //LUCA Why is this only defined for D=3? It should be defined for any D.
 void project_real(CompFunction<3> &out, std::function<double(const Coord<3> &r)> f, double prec); //overload of project is not always recognized by the compiler
 void project(CompFunction<3> &out, std::function<ComplexDouble(const Coord<3> &r)> f, double prec);
 void project_cplx(CompFunction<3> &out, std::function<ComplexDouble(const Coord<3> &r)> f, double prec); //overload of project is not always recognized by the compiler
@@ -195,7 +209,7 @@ template <int D> void project(CompFunction<D> &out, RepresentableFunction<D, dou
 template <int D> void project(CompFunction<D> &out, RepresentableFunction<D, ComplexDouble> &f, double prec);
 template <int D> void orthogonalize(double prec, CompFunction<D> &Bra, CompFunction<D> &Ket);
 
-class CompFunctionVector : public std::vector<CompFunction<3>> {
+class CompFunctionVector : public std::vector<CompFunction<3>> {//LUCA: Why is this only defined for D=3? It should be defined for any D.
 public:
     CompFunctionVector(int N = 0);
     MultiResolutionAnalysis<3> *vecMRA;


### PR DESCRIPTION
Small refactoring of the `CopyTreeToComplex` and `CopyTreeToReal` methods. 

- Generalized for D=1,2,3
- Changed the signature

To be done:
switch from raw pointers to `unique_pointer`s but this requires a refactoring of `CompFunction`