### PR TITLE
Native complex TimeEvolution operator and templates for it

### DIFF
--- a/api/mrcpp_declarations.h
+++ b/api/mrcpp_declarations.h
@@ -56,7 +56,7 @@ template <int D> class MultiResolutionAnalysis;
 
 template <int D, typename T = double> class MWTree;
 template <int D, typename T = double> class FunctionTree;
-class OperatorTree;
+template <typename T> class OperatorTree;
 
 template <int D, typename T = double> class NodeAllocator;
 
@@ -64,7 +64,7 @@ template <int D, typename T = double> class MWNode;
 template <int D, typename T = double> class FunctionNode;
 template <int D = 3> class CompFunction;
 class ComplexFunction;
-class OperatorNode;
+template <typename T> class OperatorNode;
 
 template <int D> class IdentityConvolution;
 template <int D> class DerivativeConvolution;

--- a/examples/schrodinger_semigroup1d.cpp
+++ b/examples/schrodinger_semigroup1d.cpp
@@ -2,7 +2,7 @@
 #include "MRCPP/Plotter"
 #include "functions/special_functions.h"
 #include "operators/TimeEvolutionOperator.h"
-#include "treebuilders/complex_apply.h"
+#include "treebuilders/apply.h"
 #include <MRCPP/MWOperators>
 #include <MRCPP/Printer>
 #include <MRCPP/Timer>
@@ -56,11 +56,9 @@ int main(int argc, char **argv) {
     mrcpp::print::header(0, "Building operator");
     mrcpp::print::footer(0, timer, 2);
 
-    // Time evolution operatror Exp(delta_t)
-    mrcpp::TimeEvolutionOperator<1> ReExp(MRA, prec, delta_t, finest_scale, false);
-    println(0, ReExp.getComponent(0, 0));
-    mrcpp::TimeEvolutionOperator<1> ImExp(MRA, prec, delta_t, finest_scale, true);
-    println(0, ImExp.getComponent(0, 0));
+    // Time evolution operator Exp(delta_t): one complex operator tree
+    mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t, finest_scale);
+    println(0, Exp.getComponentCplx(0, 0));
 
     mrcpp::print::header(0, "Preparing analytical solution");
     mrcpp::print::footer(0, timer, 2);
@@ -70,56 +68,31 @@ int main(int argc, char **argv) {
     double x0 = 0.5;
 
     // Functions f(x) = psi(x, t1) and g(x) = psi(x, t2)
-    auto Re_f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).real(); };
-    auto Im_f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).imag(); };
-    auto Re_g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).real(); };
-    auto Im_g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).imag(); };
+    auto f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> ComplexDouble { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma); };
+    auto g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> ComplexDouble { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma); };
 
     // Projecting functions
-    mrcpp::FunctionTree<1> Re_f_tree(MRA);
-    mrcpp::project<1, double>(prec, Re_f_tree, Re_f);
-    mrcpp::FunctionTree<1> Im_f_tree(MRA);
-    mrcpp::project<1, double>(prec, Im_f_tree, Im_f);
-    mrcpp::FunctionTree<1> Re_g_tree(MRA);
-    mrcpp::project<1, double>(prec, Re_g_tree, Re_g);
-    mrcpp::FunctionTree<1> Im_g_tree(MRA);
-    mrcpp::project<1, double>(prec, Im_g_tree, Im_g);
+    mrcpp::FunctionTree<1, ComplexDouble> f_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, f_tree, f);
+    mrcpp::FunctionTree<1, ComplexDouble> g_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, g_tree, g);
 
-    // Output function trees
-    mrcpp::FunctionTree<1> Re_fout_tree(MRA);
-    mrcpp::FunctionTree<1> Im_fout_tree(MRA);
-
-    // Complex objects for use in apply()
-    mrcpp::ComplexObject<mrcpp::ConvolutionOperator<1>> E(ReExp, ImExp);
-    mrcpp::ComplexObject<mrcpp::FunctionTree<1>> input(Re_f_tree, Im_f_tree);
-    mrcpp::ComplexObject<mrcpp::FunctionTree<1>> output(Re_fout_tree, Im_fout_tree);
+    // Output function tree
+    mrcpp::FunctionTree<1, ComplexDouble> fout_tree(MRA);
 
     mrcpp::print::header(0, "Applying operator");
     mrcpp::print::footer(0, timer, 2);
 
     // Apply operator Exp(delta_t) f(x)
-    mrcpp::apply(prec, output, E, input);
+    mrcpp::apply<1, ComplexDouble>(prec, fout_tree, Exp, f_tree, -1, false);
 
     mrcpp::print::header(0, "Checking the result on analytical solution");
     mrcpp::print::footer(0, timer, 2);
 
     // Check g(x) = Exp(delta_t) f(x)
-    mrcpp::FunctionTree<1> Re_error(MRA); // = Re_fout_tree - Re_g_tree
-    mrcpp::FunctionTree<1> Im_error(MRA); // = Im_fout_tree - Im_g_tree
-
-    // Re_error = Re_fout_tree - Re_g_tree
-    add(prec, Re_error, 1.0, Re_fout_tree, -1.0, Re_g_tree);
-    auto Re_integral = Re_error.integrate();
-    auto Re_sq_norm = Re_error.getSquareNorm();
-    mrcpp::print::value(0, "Integral of    Re(Exp(delta_t) f(x) - g(x)) =", Re_integral);
-    mrcpp::print::value(0, "Square norm of Re(Exp(delta_t) f(x) - g(x)) =", Re_sq_norm);
-
-    // Im_error = Im_fout_tree - Im_g_tree
-    add(prec, Im_error, 1.0, Im_fout_tree, -1.0, Im_g_tree);
-    auto Im_integral = Im_error.integrate();
-    auto Im_sq_norm = Im_error.getSquareNorm();
-    mrcpp::print::value(0, "Integral of    Im(Exp(delta_t) f(x) - g(x)) =", Im_integral);
-    mrcpp::print::value(0, "Square norm of Im(Exp(delta_t) f(x) - g(x)) =", Im_sq_norm);
+    mrcpp::FunctionTree<1, ComplexDouble> error(MRA);
+    mrcpp::add<1, ComplexDouble>(prec, error, {1.0, 0.0}, fout_tree, {-1.0, 0.0}, g_tree, -1, false, false);
+    mrcpp::print::value(0, "Square norm of Exp(delta_t) f(x) - g(x) =", error.getSquareNorm());
 
     mrcpp::print::header(0, "Saving plots to files");
     mrcpp::print::footer(0, timer, 2);
@@ -131,12 +104,14 @@ int main(int argc, char **argv) {
     mrcpp::Plotter<1> plot(o);
     plot.setRange(a);
 
-    plot.linePlot({nPts}, Re_error, "Re_error");   // Write to file Re_error.line
-    plot.linePlot({nPts}, Im_error, "Im_error");   // Write to file Im_error.line
-    plot.linePlot({nPts}, Re_f_tree, "Re_f_tree"); // Write to file Re_f_tree.line
-    plot.linePlot({nPts}, Im_f_tree, "Im_f_tree"); // Write to file Im_f_tree.line
-    plot.linePlot({nPts}, Re_g_tree, "Re_g_tree"); // Write to file Re_g_tree.line
-    plot.linePlot({nPts}, Im_g_tree, "Im_g_tree"); // Write to file Im_g_tree.line
+    auto Re_error = error.Real();
+    auto Im_error = error.Imag();
+    auto Re_f_tree = f_tree.Real();
+    auto Im_f_tree = f_tree.Imag();
+    plot.linePlot({nPts}, *Re_error, "Re_error");   // Write to file Re_error.line
+    plot.linePlot({nPts}, *Im_error, "Im_error");   // Write to file Im_error.line
+    plot.linePlot({nPts}, *Re_f_tree, "Re_f_tree"); // Write to file Re_f_tree.line
+    plot.linePlot({nPts}, *Im_f_tree, "Im_f_tree"); // Write to file Im_f_tree.line
 
     mrcpp::print::footer(0, timer, 2);
     return 0;

--- a/examples/schrodinger_semigroup1d.cpp
+++ b/examples/schrodinger_semigroup1d.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     mrcpp::print::header(0, "Building operator");
     mrcpp::print::footer(0, timer, 2);
 
-    // Time evolution operator Exp(delta_t): one complex operator tree
+    // Time evolution operator Exp(delta_t)
     mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t, finest_scale);
     println(0, Exp.getComponentCplx(0, 0));
 
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
     mrcpp::Plotter<1> plot(o);
     plot.setRange(a);
 
-    // Real() and Imag() allocate a new tree each; take ownership
+    // The caller owns the trees returned by Real() and Imag()
     std::unique_ptr<mrcpp::FunctionTree<1, double>> Re_error(error.Real());
     std::unique_ptr<mrcpp::FunctionTree<1, double>> Im_error(error.Imag());
     std::unique_ptr<mrcpp::FunctionTree<1, double>> Re_f_tree(f_tree.Real());

--- a/examples/schrodinger_semigroup1d.cpp
+++ b/examples/schrodinger_semigroup1d.cpp
@@ -7,6 +7,8 @@
 #include <MRCPP/Printer>
 #include <MRCPP/Timer>
 
+#include <memory>
+
 const auto min_scale = 0;
 const auto max_depth = 25;
 
@@ -104,10 +106,11 @@ int main(int argc, char **argv) {
     mrcpp::Plotter<1> plot(o);
     plot.setRange(a);
 
-    auto Re_error = error.Real();
-    auto Im_error = error.Imag();
-    auto Re_f_tree = f_tree.Real();
-    auto Im_f_tree = f_tree.Imag();
+    // Real() and Imag() allocate a new tree each; take ownership
+    std::unique_ptr<mrcpp::FunctionTree<1, double>> Re_error(error.Real());
+    std::unique_ptr<mrcpp::FunctionTree<1, double>> Im_error(error.Imag());
+    std::unique_ptr<mrcpp::FunctionTree<1, double>> Re_f_tree(f_tree.Real());
+    std::unique_ptr<mrcpp::FunctionTree<1, double>> Im_f_tree(f_tree.Imag());
     plot.linePlot({nPts}, *Re_error, "Re_error");   // Write to file Re_error.line
     plot.linePlot({nPts}, *Im_error, "Im_error");   // Write to file Im_error.line
     plot.linePlot({nPts}, *Re_f_tree, "Re_f_tree"); // Write to file Re_f_tree.line

--- a/src/operators/ABGVOperator.cpp
+++ b/src/operators/ABGVOperator.cpp
@@ -60,7 +60,7 @@ template <int D> void ABGVOperator<D>::initialize(double a, double b) {
     ABGVCalculator calculator(oper_mra.getScalingBasis(), a, b);
     BandWidthAdaptor adaptor(bw, oper_mra.getMaxScale());
 
-    auto o_tree = std::make_unique<OperatorTree>(oper_mra, MachineZero);
+    auto o_tree = std::make_unique<OperatorTree<double>>(oper_mra, MachineZero);
     builder.build(*o_tree, calculator, adaptor, -1);
 
     Timer trans_t;

--- a/src/operators/BSOperator.cpp
+++ b/src/operators/BSOperator.cpp
@@ -51,7 +51,7 @@ template <int D> void BSOperator<D>::initialize() {
     BSCalculator calculator(oper_mra.getScalingBasis(), this->order);
     BandWidthAdaptor adaptor(bw, oper_mra.getMaxScale());
 
-    auto o_tree = std::make_unique<OperatorTree>(oper_mra, MachineZero);
+    auto o_tree = std::make_unique<OperatorTree<double>>(oper_mra, MachineZero);
     builder.build(*o_tree, calculator, adaptor, -1);
 
     Timer trans_t;

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -93,7 +93,7 @@ template <int D> void ConvolutionOperator<D>::initialize(GaussExp<1> &kernel, do
         delete k_func;
 
         CrossCorrelationCalculator calculator(k_tree);
-        auto o_tree = std::make_unique<OperatorTree>(o_mra, o_prec);
+        auto o_tree = std::make_unique<OperatorTree<double>>(o_mra, o_prec);
         builder.build(*o_tree, calculator, adaptor, -1); // Expand 1D kernel into 2D operator
 
         Timer trans_t;

--- a/src/operators/ConvolutionOperator.cpp
+++ b/src/operators/ConvolutionOperator.cpp
@@ -80,7 +80,7 @@ template <int D> void ConvolutionOperator<D>::initialize(GaussExp<1> &kernel, do
     auto o_mra = this->getOperatorMRA();
 
     TreeBuilder<2> builder;
-    OperatorAdaptor adaptor(o_prec, o_mra.getMaxScale());
+    OperatorAdaptor<double> adaptor(o_prec, o_mra.getMaxScale());
 
     for (size_t i = 0; i < kernel.size(); i++) {
         // Rescale Gaussian for D-dim application

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -60,6 +60,11 @@ template <int D> void MWOperator<D>::initOperExp(int M) {
         for (int d = 0; d < D; d++) assign(i, d, this->raw_exp[i].get());
 }
 
+template <int D> const BandWidth &MWOperator<D>::getBandWidth(int i, int d) const {
+    if (iscomplex()) return getComponentCplx(i, d).getBandWidth();
+    return getComponent(i, d).getBandWidth();
+}
+
 template <int D> OperatorTree<ComplexDouble> &MWOperator<D>::getComponentCplx(int i, int d) {
     if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ERROR("Index out of bounds");
     if (d < 0 or d >= D) MSG_ERROR("Index out of bounds");

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -34,6 +34,7 @@ namespace mrcpp {
 
 template <int D> void MWOperator<D>::initOperExp(int M) {
     // The expansion is held in one scalar or the other, never both.
+    if (not this->raw_exp.empty() and not this->raw_exp_cplx.empty()) MSG_ABORT("Both a real and a complex raw expansion");
     if (iscomplex()) {
         if (this->raw_exp_cplx.size() < static_cast<size_t>(M)) MSG_ABORT("Incompatible raw expansion");
         this->oper_exp_cplx.clear();
@@ -42,6 +43,7 @@ template <int D> void MWOperator<D>::initOperExp(int M) {
             otrees.fill(nullptr);
             this->oper_exp_cplx.push_back(otrees);
         }
+        this->oper_exp.clear();
         for (int i = 0; i < M; i++)
             for (int d = 0; d < D; d++) assign(i, d, this->raw_exp_cplx[i].get());
         return;

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -36,7 +36,7 @@ template <int D> void MWOperator<D>::initOperExp(int M) {
     if (this->raw_exp.size() < static_cast<size_t>(M)) MSG_ABORT("Incompatible raw expansion");
     this->oper_exp.clear();
     for (int m = 0; m < M; m++) {
-        std::array<OperatorTree *, D> otrees;
+        std::array<OperatorTree<double> *, D> otrees;
         otrees.fill(nullptr);
         this->oper_exp.push_back(otrees);
     }
@@ -46,14 +46,14 @@ template <int D> void MWOperator<D>::initOperExp(int M) {
         for (int d = 0; d < D; d++) assign(i, d, this->raw_exp[i].get());
 }
 
-template <int D> OperatorTree &MWOperator<D>::getComponent(int i, int d) {
+template <int D> OperatorTree<double> &MWOperator<D>::getComponent(int i, int d) {
     if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ERROR("Index out of bounds");
     if (d < 0 or d >= D) MSG_ERROR("Dimension out of bounds");
     if (this->oper_exp[i][d] == nullptr) MSG_ERROR("Invalid component");
     return *this->oper_exp[i][d];
 }
 
-template <int D> const OperatorTree &MWOperator<D>::getComponent(int i, int d) const {
+template <int D> const OperatorTree<double> &MWOperator<D>::getComponent(int i, int d) const {
     if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ERROR("Index out of bounds");
     if (d < 0 or d >= D) MSG_ERROR("Dimension out of bounds");
     if (this->oper_exp[i][d] == nullptr) MSG_ERROR("Invalid component");
@@ -80,7 +80,7 @@ template <int D> void MWOperator<D>::calcBandWidths(double prec) {
     // First compute BandWidths and find depth of the deepest component
     for (auto &i : this->oper_exp) {
         for (int d = 0; d < D; d++) {
-            OperatorTree &oTree = *i[d];
+            OperatorTree<double> &oTree = *i[d];
             oTree.calcBandWidth(prec);
             const BandWidth &bw = oTree.getBandWidth();
             int depth = bw.getDepth();
@@ -92,7 +92,7 @@ template <int D> void MWOperator<D>::calcBandWidths(double prec) {
     // Find the largest effective bandwidth at each scale
     for (auto &i : this->oper_exp) {
         for (int d = 0; d < D; d++) {
-            const OperatorTree &oTree = *i[d];
+            const OperatorTree<double> &oTree = *i[d];
             const BandWidth &bw = oTree.getBandWidth();
             for (int n = 0; n <= bw.getDepth(); n++) { // scale loop
                 for (int j = 0; j < 4; j++) {          // component loop

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -33,6 +33,20 @@ using namespace Eigen;
 namespace mrcpp {
 
 template <int D> void MWOperator<D>::initOperExp(int M) {
+    // The expansion is held in one scalar or the other, never both.
+    if (iscomplex()) {
+        if (this->raw_exp_cplx.size() < static_cast<size_t>(M)) MSG_ABORT("Incompatible raw expansion");
+        this->oper_exp_cplx.clear();
+        for (int m = 0; m < M; m++) {
+            std::array<OperatorTree<ComplexDouble> *, D> otrees;
+            otrees.fill(nullptr);
+            this->oper_exp_cplx.push_back(otrees);
+        }
+        for (int i = 0; i < M; i++)
+            for (int d = 0; d < D; d++) assign(i, d, this->raw_exp_cplx[i].get());
+        return;
+    }
+
     if (this->raw_exp.size() < static_cast<size_t>(M)) MSG_ABORT("Incompatible raw expansion");
     this->oper_exp.clear();
     for (int m = 0; m < M; m++) {
@@ -44,6 +58,20 @@ template <int D> void MWOperator<D>::initOperExp(int M) {
     // Sets up an isotropic operator with the first M raw terms in all direction
     for (int i = 0; i < M; i++)
         for (int d = 0; d < D; d++) assign(i, d, this->raw_exp[i].get());
+}
+
+template <int D> OperatorTree<ComplexDouble> &MWOperator<D>::getComponentCplx(int i, int d) {
+    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ERROR("Index out of bounds");
+    if (d < 0 or d >= D) MSG_ERROR("Index out of bounds");
+    if (this->oper_exp_cplx[i][d] == nullptr) MSG_ERROR("Invalid component");
+    return *this->oper_exp_cplx[i][d];
+}
+
+template <int D> const OperatorTree<ComplexDouble> &MWOperator<D>::getComponentCplx(int i, int d) const {
+    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ERROR("Index out of bounds");
+    if (d < 0 or d >= D) MSG_ERROR("Index out of bounds");
+    if (this->oper_exp_cplx[i][d] == nullptr) MSG_ERROR("Invalid component");
+    return *this->oper_exp_cplx[i][d];
 }
 
 template <int D> OperatorTree<double> &MWOperator<D>::getComponent(int i, int d) {
@@ -73,35 +101,46 @@ template <int D> int MWOperator<D>::getMaxBandWidth(int depth) const {
 template <int D> void MWOperator<D>::clearBandWidths() {
     for (auto &i : this->oper_exp)
         for (int d = 0; d < D; d++) i[d]->clearBandWidth();
+    for (auto &i : this->oper_exp_cplx)
+        for (int d = 0; d < D; d++) i[d]->clearBandWidth();
 }
 
 template <int D> void MWOperator<D>::calcBandWidths(double prec) {
     int maxDepth = 0;
     // First compute BandWidths and find depth of the deepest component
-    for (auto &i : this->oper_exp) {
-        for (int d = 0; d < D; d++) {
-            OperatorTree<double> &oTree = *i[d];
-            oTree.calcBandWidth(prec);
-            const BandWidth &bw = oTree.getBandWidth();
-            int depth = bw.getDepth();
-            if (depth > maxDepth) maxDepth = depth;
+    auto calc_depth = [&](auto &exp) {
+        for (auto &i : exp) {
+            for (int d = 0; d < D; d++) {
+                auto &oTree = *i[d];
+                oTree.calcBandWidth(prec);
+                const BandWidth &bw = oTree.getBandWidth();
+                int depth = bw.getDepth();
+                if (depth > maxDepth) maxDepth = depth;
+            }
         }
-    }
+    };
+    calc_depth(this->oper_exp);
+    calc_depth(this->oper_exp_cplx);
+
     this->band_max = std::vector<int>(maxDepth + 1, -1);
 
     // Find the largest effective bandwidth at each scale
-    for (auto &i : this->oper_exp) {
-        for (int d = 0; d < D; d++) {
-            const OperatorTree<double> &oTree = *i[d];
-            const BandWidth &bw = oTree.getBandWidth();
-            for (int n = 0; n <= bw.getDepth(); n++) { // scale loop
-                for (int j = 0; j < 4; j++) {          // component loop
-                    int w = bw.getWidth(n, j);
-                    if (w > this->band_max[n]) this->band_max[n] = w;
+    auto fold_widths = [&](const auto &exp) {
+        for (const auto &i : exp) {
+            for (int d = 0; d < D; d++) {
+                const auto &oTree = *i[d];
+                const BandWidth &bw = oTree.getBandWidth();
+                for (int n = 0; n <= bw.getDepth(); n++) { // scale loop
+                    for (int j = 0; j < 4; j++) {          // component loop
+                        int w = bw.getWidth(n, j);
+                        if (w > this->band_max[n]) this->band_max[n] = w;
+                    }
                 }
             }
         }
-    }
+    };
+    fold_widths(this->oper_exp);
+    fold_widths(this->oper_exp_cplx);
     println(20, "  Maximum bandwidths:");
     for (auto bw : this->band_max) println(20, bw);
     println(20, std::endl);

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -51,6 +51,7 @@ template <int D> void MWOperator<D>::initOperExp(int M) {
 
     if (this->raw_exp.size() < static_cast<size_t>(M)) MSG_ABORT("Incompatible raw expansion");
     this->oper_exp.clear();
+    this->oper_exp_cplx.clear();
     for (int m = 0; m < M; m++) {
         std::array<OperatorTree<double> *, D> otrees;
         otrees.fill(nullptr);

--- a/src/operators/MWOperator.cpp
+++ b/src/operators/MWOperator.cpp
@@ -69,30 +69,30 @@ template <int D> const BandWidth &MWOperator<D>::getBandWidth(int i, int d) cons
 }
 
 template <int D> OperatorTree<ComplexDouble> &MWOperator<D>::getComponentCplx(int i, int d) {
-    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ERROR("Index out of bounds");
-    if (d < 0 or d >= D) MSG_ERROR("Index out of bounds");
-    if (this->oper_exp_cplx[i][d] == nullptr) MSG_ERROR("Invalid component");
+    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ABORT("Index out of bounds");
+    if (d < 0 or d >= D) MSG_ABORT("Index out of bounds");
+    if (this->oper_exp_cplx[i][d] == nullptr) MSG_ABORT("Invalid component");
     return *this->oper_exp_cplx[i][d];
 }
 
 template <int D> const OperatorTree<ComplexDouble> &MWOperator<D>::getComponentCplx(int i, int d) const {
-    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ERROR("Index out of bounds");
-    if (d < 0 or d >= D) MSG_ERROR("Index out of bounds");
-    if (this->oper_exp_cplx[i][d] == nullptr) MSG_ERROR("Invalid component");
+    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp_cplx.size()) MSG_ABORT("Index out of bounds");
+    if (d < 0 or d >= D) MSG_ABORT("Index out of bounds");
+    if (this->oper_exp_cplx[i][d] == nullptr) MSG_ABORT("Invalid component");
     return *this->oper_exp_cplx[i][d];
 }
 
 template <int D> OperatorTree<double> &MWOperator<D>::getComponent(int i, int d) {
-    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ERROR("Index out of bounds");
-    if (d < 0 or d >= D) MSG_ERROR("Dimension out of bounds");
-    if (this->oper_exp[i][d] == nullptr) MSG_ERROR("Invalid component");
+    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ABORT("Index out of bounds");
+    if (d < 0 or d >= D) MSG_ABORT("Dimension out of bounds");
+    if (this->oper_exp[i][d] == nullptr) MSG_ABORT("Invalid component");
     return *this->oper_exp[i][d];
 }
 
 template <int D> const OperatorTree<double> &MWOperator<D>::getComponent(int i, int d) const {
-    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ERROR("Index out of bounds");
-    if (d < 0 or d >= D) MSG_ERROR("Dimension out of bounds");
-    if (this->oper_exp[i][d] == nullptr) MSG_ERROR("Invalid component");
+    if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ABORT("Index out of bounds");
+    if (d < 0 or d >= D) MSG_ABORT("Dimension out of bounds");
+    if (this->oper_exp[i][d] == nullptr) MSG_ABORT("Invalid component");
     return *this->oper_exp[i][d];
 }
 

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -100,10 +100,12 @@ public:
     /** @note Real expansions only; aborts on a complex operator. */
     std::array<OperatorTree<double> *, D> &operator[](int i) {
         if (iscomplex()) MSG_ABORT("operator[] is not available for a complex expansion");
+        if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ABORT("Index out of bounds");
         return this->oper_exp[i];
     }
     const std::array<OperatorTree<double> *, D> &operator[](int i) const {
         if (iscomplex()) MSG_ABORT("operator[] is not available for a complex expansion");
+        if (i < 0 or static_cast<size_t>(i) >= this->oper_exp.size()) MSG_ABORT("Index out of bounds");
         return this->oper_exp[i];
     }
 

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -49,7 +49,7 @@ public:
     MWOperator &operator=(const MWOperator &oper) = delete;
     virtual ~MWOperator() = default;
 
-    size_t size() const { return this->oper_exp.size(); }
+    size_t size() const { return isreal() ? this->oper_exp.size() : this->oper_exp_cplx.size(); }
     int getMaxBandWidth(int depth = -1) const;
     const std::vector<int> &getMaxBandWidths() const { return this->band_max; }
 
@@ -59,8 +59,30 @@ public:
     int getOperatorRoot() const { return this->oper_root; }
     int getOperatorReach() const { return this->oper_reach; }
 
+    /** @brief Whether the kernel is real.
+     *
+     * @details The expansion is held in one scalar or the other, never both:
+     * - `isreal()` means the terms live in `oper_exp` as `OperatorTree<double>`
+     * - `iscomplex()` means they live in `oper_exp_cplx` as `OperatorTree<ComplexDouble>`
+     * - only `TimeEvolutionOperator` builds a complex expansion
+     *
+     * @note Follows the `isreal`/`iscomplex` convention of `CompFunctionData`,
+     * which likewise holds a function in one scalar or the other.
+     */
+    int isreal() const { return this->raw_exp_cplx.empty(); }
+
+    /** @brief Whether the kernel has a non-zero imaginary part. */
+    int iscomplex() const { return not isreal(); }
+
     OperatorTree<double> &getComponent(int i, int d);
     const OperatorTree<double> &getComponent(int i, int d) const;
+
+    /** @brief Separable term `i` in direction `d` of a complex kernel.
+     *
+     * @note Aborts for a real operator; guard with `iscomplex()`.
+     */
+    OperatorTree<ComplexDouble> &getComponentCplx(int i, int d);
+    const OperatorTree<ComplexDouble> &getComponentCplx(int i, int d) const;
 
     std::array<OperatorTree<double> *, D> &operator[](int i) { return this->oper_exp[i]; }
     const std::array<OperatorTree<double> *, D> &operator[](int i) const { return this->oper_exp[i]; }
@@ -71,12 +93,15 @@ protected:
     MultiResolutionAnalysis<D> MRA;
     std::vector<std::array<OperatorTree<double> *, D>> oper_exp;
     std::vector<std::unique_ptr<OperatorTree<double>>> raw_exp;
+    std::vector<std::array<OperatorTree<ComplexDouble> *, D>> oper_exp_cplx;
+    std::vector<std::unique_ptr<OperatorTree<ComplexDouble>>> raw_exp_cplx;
     std::vector<int> band_max;
 
     MultiResolutionAnalysis<2> getOperatorMRA() const;
 
     void initOperExp(int M);
     void assign(int i, int d, OperatorTree<double> *oper) { this->oper_exp[i][d] = oper; }
+    void assign(int i, int d, OperatorTree<ComplexDouble> *oper) { this->oper_exp_cplx[i][d] = oper; }
 };
 
 } // namespace mrcpp

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -62,21 +62,13 @@ public:
 
     /** @brief Whether the operator stores real coefficients.
      *
-     * @details The expansion is held in one scalar or the other, never both:
-     * - `isreal()` means the terms live in `oper_exp` as `OperatorTree<double>`
-     * - `iscomplex()` means they live in `oper_exp_cplx` as `OperatorTree<ComplexDouble>`
-     * - only `TimeEvolutionOperator` builds a complex expansion
-     *
-     * @note Follows the `isreal`/`iscomplex` convention of `CompFunctionData`,
-     * which likewise holds a function in one scalar or the other.
+     * @note Reports the storage type, not whether the imaginary part vanishes.
      */
     int isreal() const { return this->raw_exp_cplx.empty(); }
 
     /** @brief Whether the operator stores complex coefficients.
      *
-     * @note This is the storage type, not a statement about the coefficients:
-     * a complex expansion whose imaginary part happens to vanish still reports
-     * `iscomplex()`.
+     * @note Reports the storage type, not whether any imaginary part is set.
      */
     int iscomplex() const { return not isreal(); }
 

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -29,6 +29,7 @@
 
 #include "trees/MultiResolutionAnalysis.h"
 #include "trees/OperatorTree.h"
+#include "utils/Printer.h"
 
 namespace mrcpp {
 
@@ -59,7 +60,7 @@ public:
     int getOperatorRoot() const { return this->oper_root; }
     int getOperatorReach() const { return this->oper_reach; }
 
-    /** @brief Whether the kernel is real.
+    /** @brief Whether the operator stores real coefficients.
      *
      * @details The expansion is held in one scalar or the other, never both:
      * - `isreal()` means the terms live in `oper_exp` as `OperatorTree<double>`
@@ -71,7 +72,12 @@ public:
      */
     int isreal() const { return this->raw_exp_cplx.empty(); }
 
-    /** @brief Whether the kernel has a non-zero imaginary part. */
+    /** @brief Whether the operator stores complex coefficients.
+     *
+     * @note This is the storage type, not a statement about the coefficients:
+     * a complex expansion whose imaginary part happens to vanish still reports
+     * `iscomplex()`.
+     */
     int iscomplex() const { return not isreal(); }
 
     OperatorTree<double> &getComponent(int i, int d);
@@ -91,8 +97,15 @@ public:
      */
     const BandWidth &getBandWidth(int i, int d) const;
 
-    std::array<OperatorTree<double> *, D> &operator[](int i) { return this->oper_exp[i]; }
-    const std::array<OperatorTree<double> *, D> &operator[](int i) const { return this->oper_exp[i]; }
+    /** @note Real expansions only; aborts on a complex operator. */
+    std::array<OperatorTree<double> *, D> &operator[](int i) {
+        if (iscomplex()) MSG_ABORT("operator[] is not available for a complex expansion");
+        return this->oper_exp[i];
+    }
+    const std::array<OperatorTree<double> *, D> &operator[](int i) const {
+        if (iscomplex()) MSG_ABORT("operator[] is not available for a complex expansion");
+        return this->oper_exp[i];
+    }
 
 protected:
     int oper_root;

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -59,24 +59,24 @@ public:
     int getOperatorRoot() const { return this->oper_root; }
     int getOperatorReach() const { return this->oper_reach; }
 
-    OperatorTree &getComponent(int i, int d);
-    const OperatorTree &getComponent(int i, int d) const;
+    OperatorTree<double> &getComponent(int i, int d);
+    const OperatorTree<double> &getComponent(int i, int d) const;
 
-    std::array<OperatorTree *, D> &operator[](int i) { return this->oper_exp[i]; }
-    const std::array<OperatorTree *, D> &operator[](int i) const { return this->oper_exp[i]; }
+    std::array<OperatorTree<double> *, D> &operator[](int i) { return this->oper_exp[i]; }
+    const std::array<OperatorTree<double> *, D> &operator[](int i) const { return this->oper_exp[i]; }
 
 protected:
     int oper_root;
     int oper_reach;
     MultiResolutionAnalysis<D> MRA;
-    std::vector<std::array<OperatorTree *, D>> oper_exp;
-    std::vector<std::unique_ptr<OperatorTree>> raw_exp;
+    std::vector<std::array<OperatorTree<double> *, D>> oper_exp;
+    std::vector<std::unique_ptr<OperatorTree<double>>> raw_exp;
     std::vector<int> band_max;
 
     MultiResolutionAnalysis<2> getOperatorMRA() const;
 
     void initOperExp(int M);
-    void assign(int i, int d, OperatorTree *oper) { this->oper_exp[i][d] = oper; }
+    void assign(int i, int d, OperatorTree<double> *oper) { this->oper_exp[i][d] = oper; }
 };
 
 } // namespace mrcpp

--- a/src/operators/MWOperator.h
+++ b/src/operators/MWOperator.h
@@ -84,6 +84,13 @@ public:
     OperatorTree<ComplexDouble> &getComponentCplx(int i, int d);
     const OperatorTree<ComplexDouble> &getComponentCplx(int i, int d) const;
 
+    /** @brief Band width of separable term `i` in direction `d`.
+     *
+     * @details Reads from whichever expansion is populated, so callers that
+     * only need the band do not have to know the scalar.
+     */
+    const BandWidth &getBandWidth(int i, int d) const;
+
     std::array<OperatorTree<double> *, D> &operator[](int i) { return this->oper_exp[i]; }
     const std::array<OperatorTree<double> *, D> &operator[](int i) const { return this->oper_exp[i]; }
 

--- a/src/operators/OperatorState.h
+++ b/src/operators/OperatorState.h
@@ -115,7 +115,7 @@ private:
     T *aux[D + 1];
     T *gData;
     T *fData;
-    double *oData[D];
+    double *oData[D]{};
     ComplexDouble *oData_cplx[D]{};
 
     void calcMaxDeltaL() {

--- a/src/operators/OperatorState.h
+++ b/src/operators/OperatorState.h
@@ -89,6 +89,9 @@ public:
     T **getAuxData() { return this->aux; }
     double **getOperData() { return this->oData; }
 
+    /** @brief Band of a complex kernel; entries are null for a real one. */
+    ComplexDouble **getOperDataCplx() { return this->oData_cplx; }
+
     friend class ConvolutionCalculator<D, T>;
     friend class DerivativeCalculator<D, T>;
 
@@ -113,6 +116,7 @@ private:
     T *gData;
     T *fData;
     double *oData[D];
+    ComplexDouble *oData_cplx[D]{};
 
     void calcMaxDeltaL() {
         const auto &gl = this->gNode->getNodeIndex();

--- a/src/operators/PHOperator.cpp
+++ b/src/operators/PHOperator.cpp
@@ -55,7 +55,7 @@ template <int D> void PHOperator<D>::initialize() {
     int max_scale = this->MRA.getMaxScale();
     BandWidthAdaptor adaptor(bw, max_scale);
 
-    auto o_tree = std::make_unique<OperatorTree>(o_mra, MachineZero);
+    auto o_tree = std::make_unique<OperatorTree<double>>(o_mra, MachineZero);
     builder.build(*o_tree, calculator, adaptor, -1);
 
     Timer trans_t;

--- a/src/operators/TimeEvolutionOperator.cpp
+++ b/src/operators/TimeEvolutionOperator.cpp
@@ -56,16 +56,15 @@
 
 namespace mrcpp {
 
-/** @brief A uniform constructor for TimeEvolutionOperator class.
+/** @brief An adaptive constructor for TimeEvolutionOperator class.
  *
  * @param[in] mra: MRA.
  * @param[in] prec: precision.
  * @param[in] time: the time moment (step).
- * @param[in] finest_scale: the operator tree is constructed uniformly down to this scale.
- * @param[in] max_Jpower: maximum amount of power integrals used.
  *
- * @details Constructs either real or imaginary part of the Schrodinger semigroup at a given time moment.
+ * @details Constructs the complete complex Schrodinger semigroup at a given time moment.
  *
+ * @note For technical reasons the operator tree is constructed no deeper than to scale \f$ n = 18 \f$.
  */
 template <int D>
 TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time)
@@ -77,13 +76,24 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
     SchrodingerEvolution_CrossCorrelation cross_correlation(30, mra.getOrder(), mra.getScalingBasis().getScalingType());
     this->cross_correlation = &cross_correlation;
 
-    initialize(time, 30); // will go outside of the constructor in future
+    initialize(time, 30);
     this->cross_correlation = nullptr; // the object above dies with this scope
 
-    this->initOperExp(1); // this turns out to be important
+    this->initOperExp(1); // one separable term
     Printer::setPrintLevel(oldlevel);
 }
 
+/** @brief A uniform constructor for TimeEvolutionOperator class.
+ *
+ * @param[in] mra: MRA.
+ * @param[in] prec: precision.
+ * @param[in] time: the time moment (step).
+ * @param[in] finest_scale: the operator tree is constructed uniformly down to this scale.
+ * @param[in] max_Jpower: maximum amount of power integrals used.
+ *
+ * @details Constructs the complete complex Schrodinger semigroup on a uniform grid.
+ *
+ */
 template <int D>
 TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, int max_Jpower)
         : ConvolutionOperator<D>(mra, mra.getRootScale(), -10) {
@@ -99,21 +109,6 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
     this->initOperExp(1);
     Printer::setPrintLevel(oldlevel);
 }
-
-/** @brief An adaptive constructor for TimeEvolutionOperator class.
- *
- * @param[in] mra: MRA.
- * @param[in] prec: precision.
- * @param[in] time: the time moment (step).
- * @param[in] max_Jpower: maximum amount of power integrals used.
- *
- * @details Adaptively constructs either real or imaginary part of the Schrodinger semigroup at a given time moment.
- * It is recommended for use in case of high polynomial order in use of the scaling basis.
- *
- * @note For technical reasons the operator tree is constructed no deeper than to scale \f$ n = 18 \f$.
- * This should be weakened in future.
- *
- */
 
 /** @brief Creates the complex operator
  *
@@ -200,7 +195,7 @@ template <int D> void TimeEvolutionOperator<D>::initialize(double time, int fine
  *
  */
 template <int D> void TimeEvolutionOperator<D>::initializeSemiUniformly(double time, int max_Jpower) {
-    MSG_ERROR("Not implemented yet method.");
+    MSG_ABORT("Not implemented");
 
     double o_prec = this->build_prec;
     auto o_mra = this->getOperatorMRA();

--- a/src/operators/TimeEvolutionOperator.cpp
+++ b/src/operators/TimeEvolutionOperator.cpp
@@ -129,13 +129,13 @@ template <int D> void TimeEvolutionOperator<D>::initialize(double time, bool ima
 
     double o_prec = this->build_prec;
     auto o_mra = this->getOperatorMRA();
-    auto o_tree = std::make_unique<CornerOperatorTree>(o_mra, o_prec);
+    auto o_tree = std::make_unique<CornerOperatorTree<double>>(o_mra, o_prec);
 
     std::map<int, JpowerIntegrals *> J;
     for (int n = 0; n <= N + 1; n++) J[n] = new JpowerIntegrals(time * std::pow(4, n), n, max_Jpower);
     TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation, imaginary);
 
-    OperatorAdaptor adaptor(o_prec, o_mra.getMaxScale(), true);
+    OperatorAdaptor<double> adaptor(o_prec, o_mra.getMaxScale(), true);
 
     mrcpp::TreeBuilder<2> builder;
     builder.build(*o_tree, calculator, adaptor, N);
@@ -175,7 +175,7 @@ template <int D> void TimeEvolutionOperator<D>::initialize(double time, int fine
     for (int n = 0; n <= N + 1; n++) J[n] = new JpowerIntegrals(time * std::pow(4, n), n, max_Jpower, threshold);
     TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation, imaginary);
 
-    auto o_tree = std::make_unique<CornerOperatorTree>(o_mra, o_prec);
+    auto o_tree = std::make_unique<CornerOperatorTree<double>>(o_mra, o_prec);
     builder.build(*o_tree, calculator, uniform, N); // Expand 1D kernel into 2D operator
 
     // Postprocess to make the operator functional
@@ -210,7 +210,7 @@ template <int D> void TimeEvolutionOperator<D>::initializeSemiUniformly(double t
 
     int N = 18;
 
-    auto o_tree = std::make_unique<CornerOperatorTree>(o_mra, o_prec);
+    auto o_tree = std::make_unique<CornerOperatorTree<double>>(o_mra, o_prec);
     DefaultCalculator<2> intitial_calculator;
     for (auto n = 0; n < 4; n++) builder.build(*o_tree, intitial_calculator, uniform, 1);
 
@@ -219,7 +219,7 @@ template <int D> void TimeEvolutionOperator<D>::initializeSemiUniformly(double t
     for (int n = 0; n <= N + 1; n++) J[n] = new mrcpp::JpowerIntegrals(time * std::pow(4, n), n, max_Jpower, threshold);
     mrcpp::TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation, imaginary);
 
-    OperatorAdaptor adaptor(o_prec, o_mra.getMaxScale());
+    OperatorAdaptor<double> adaptor(o_prec, o_mra.getMaxScale());
     builder.build(*o_tree, calculator, adaptor, 13);
 
     // Postprocess to make the operator functional

--- a/src/operators/TimeEvolutionOperator.cpp
+++ b/src/operators/TimeEvolutionOperator.cpp
@@ -78,6 +78,7 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
     this->cross_correlation = &cross_correlation;
 
     initialize(time, 30); // will go outside of the constructor in future
+    this->cross_correlation = nullptr; // the object above dies with this scope
 
     this->initOperExp(1); // this turns out to be important
     Printer::setPrintLevel(oldlevel);
@@ -93,6 +94,7 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
     this->cross_correlation = &cross_correlation;
 
     initialize(time, finest_scale, max_Jpower);
+    this->cross_correlation = nullptr; // the object above dies with this scope
 
     this->initOperExp(1);
     Printer::setPrintLevel(oldlevel);

--- a/src/operators/TimeEvolutionOperator.cpp
+++ b/src/operators/TimeEvolutionOperator.cpp
@@ -62,14 +62,13 @@ namespace mrcpp {
  * @param[in] prec: precision.
  * @param[in] time: the time moment (step).
  * @param[in] finest_scale: the operator tree is constructed uniformly down to this scale.
- * @param[in] imaginary: defines the real (faulse) or imaginary (true) part of the semigroup.
  * @param[in] max_Jpower: maximum amount of power integrals used.
  *
  * @details Constructs either real or imaginary part of the Schrodinger semigroup at a given time moment.
  *
  */
 template <int D>
-TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, bool imaginary, int max_Jpower)
+TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, int max_Jpower)
         : ConvolutionOperator<D>(mra, mra.getRootScale(), -10) // One can use ConvolutionOperator instead as well
 {
     int oldlevel = Printer::setPrintLevel(0);
@@ -78,7 +77,11 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
     SchrodingerEvolution_CrossCorrelation cross_correlation(30, mra.getOrder(), mra.getScalingBasis().getScalingType());
     this->cross_correlation = &cross_correlation;
 
-    initialize(time, finest_scale, imaginary, max_Jpower); // will go outside of the constructor in future
+    // will go outside of the constructor in future
+    if (finest_scale < 0)
+        initialize(time, max_Jpower);
+    else
+        initialize(time, finest_scale, max_Jpower);
 
     this->initOperExp(1); // this turns out to be important
     Printer::setPrintLevel(oldlevel);
@@ -89,7 +92,6 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
  * @param[in] mra: MRA.
  * @param[in] prec: precision.
  * @param[in] time: the time moment (step).
- * @param[in] imaginary: defines the real (faulse) or imaginary (true) part of the semigroup.
  * @param[in] max_Jpower: maximum amount of power integrals used.
  *
  * @details Adaptively constructs either real or imaginary part of the Schrodinger semigroup at a given time moment.
@@ -99,23 +101,8 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
  * This should be weakened in future.
  *
  */
-template <int D>
-TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, bool imaginary, int max_Jpower)
-        : ConvolutionOperator<D>(mra, mra.getRootScale(), -10) // One can use ConvolutionOperator instead as well
-{
-    int oldlevel = Printer::setPrintLevel(0);
-    this->setBuildPrec(prec);
 
-    SchrodingerEvolution_CrossCorrelation cross_correlation(30, mra.getOrder(), mra.getScalingBasis().getScalingType());
-    this->cross_correlation = &cross_correlation;
-
-    initialize(time, imaginary, max_Jpower); // will go outside of the constructor in future
-
-    this->initOperExp(1); // this turns out to be important
-    Printer::setPrintLevel(oldlevel);
-}
-
-/** @brief Creates Re or Im of operator
+/** @brief Creates the complex operator
  *
  * @details Adaptive down to scale \f$ N = 18 \f$.
  * This scale limit bounds the amount of JpowerIntegrals
@@ -124,20 +111,20 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
  * only needed ones, while building the tree (in progress).
  *
  */
-template <int D> void TimeEvolutionOperator<D>::initialize(double time, bool imaginary, int max_Jpower) {
+template <int D> void TimeEvolutionOperator<D>::initialize(double time, int max_Jpower) {
     int N = 18;
 
     double o_prec = this->build_prec;
     auto o_mra = this->getOperatorMRA();
-    auto o_tree = std::make_unique<CornerOperatorTree<double>>(o_mra, o_prec);
+    auto o_tree = std::make_unique<CornerOperatorTree<ComplexDouble>>(o_mra, o_prec);
 
     std::map<int, JpowerIntegrals *> J;
     for (int n = 0; n <= N + 1; n++) J[n] = new JpowerIntegrals(time * std::pow(4, n), n, max_Jpower);
-    TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation, imaginary);
+    TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation);
 
-    OperatorAdaptor<double> adaptor(o_prec, o_mra.getMaxScale(), true);
+    OperatorAdaptor<ComplexDouble> adaptor(o_prec, o_mra.getMaxScale(), true);
 
-    mrcpp::TreeBuilder<2> builder;
+    mrcpp::TreeBuilder<2, ComplexDouble> builder;
     builder.build(*o_tree, calculator, adaptor, N);
 
     // Postprocess to make the operator functional
@@ -151,31 +138,31 @@ template <int D> void TimeEvolutionOperator<D>::initialize(double time, bool ima
     print::time(10, "Time transform", trans_t);
     print::separator(10, ' ');
 
-    this->raw_exp.push_back(std::move(o_tree));
+    this->raw_exp_cplx.push_back(std::move(o_tree));
 
     for (int n = 0; n <= N + 1; n++) delete J[n];
 }
 
-/** @brief Creates Re or Im of operator
+/** @brief Creates the complex operator
  *
  * @details Uniform down to finest scale.
  *
  */
-template <int D> void TimeEvolutionOperator<D>::initialize(double time, int finest_scale, bool imaginary, int max_Jpower) {
+template <int D> void TimeEvolutionOperator<D>::initialize(double time, int finest_scale, int max_Jpower) {
     double o_prec = this->build_prec;
     auto o_mra = this->getOperatorMRA();
 
     // Setup uniform tree builder
-    TreeBuilder<2> builder;
-    SplitAdaptor<2> uniform(o_mra.getMaxScale(), true);
+    TreeBuilder<2, ComplexDouble> builder;
+    SplitAdaptor<2, ComplexDouble> uniform(o_mra.getMaxScale(), true);
 
     int N = finest_scale;
     double threshold = o_prec / 1000.0;
     std::map<int, JpowerIntegrals *> J;
     for (int n = 0; n <= N + 1; n++) J[n] = new JpowerIntegrals(time * std::pow(4, n), n, max_Jpower, threshold);
-    TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation, imaginary);
+    TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation);
 
-    auto o_tree = std::make_unique<CornerOperatorTree<double>>(o_mra, o_prec);
+    auto o_tree = std::make_unique<CornerOperatorTree<ComplexDouble>>(o_mra, o_prec);
     builder.build(*o_tree, calculator, uniform, N); // Expand 1D kernel into 2D operator
 
     // Postprocess to make the operator functional
@@ -186,12 +173,12 @@ template <int D> void TimeEvolutionOperator<D>::initialize(double time, int fine
     print::time(10, "Time transform", trans_t);
     print::separator(10, ' ');
 
-    this->raw_exp.push_back(std::move(o_tree));
+    this->raw_exp_cplx.push_back(std::move(o_tree));
 
     for (int n = 0; n <= N + 1; n++) delete J[n];
 }
 
-/** @brief Creates Re or Im of operator (in progress)
+/** @brief Creates the operator (in progress)
  *
  * @details Tree construction starts uniformly and then continues adaptively down to scale \f$ N = 18 \f$.
  * This scale limit bounds the amount of JpowerIntegrals
@@ -199,27 +186,27 @@ template <int D> void TimeEvolutionOperator<D>::initialize(double time, int fine
  * @note This method is not ready for use and should not be used (in progress).
  *
  */
-template <int D> void TimeEvolutionOperator<D>::initializeSemiUniformly(double time, bool imaginary, int max_Jpower) {
+template <int D> void TimeEvolutionOperator<D>::initializeSemiUniformly(double time, int max_Jpower) {
     MSG_ERROR("Not implemented yet method.");
 
     double o_prec = this->build_prec;
     auto o_mra = this->getOperatorMRA();
 
-    mrcpp::TreeBuilder<2> builder;
-    mrcpp::SplitAdaptor<2> uniform(o_mra.getMaxScale(), true);
+    mrcpp::TreeBuilder<2, ComplexDouble> builder;
+    mrcpp::SplitAdaptor<2, ComplexDouble> uniform(o_mra.getMaxScale(), true);
 
     int N = 18;
 
-    auto o_tree = std::make_unique<CornerOperatorTree<double>>(o_mra, o_prec);
-    DefaultCalculator<2> intitial_calculator;
+    auto o_tree = std::make_unique<CornerOperatorTree<ComplexDouble>>(o_mra, o_prec);
+    DefaultCalculator<2, ComplexDouble> intitial_calculator;
     for (auto n = 0; n < 4; n++) builder.build(*o_tree, intitial_calculator, uniform, 1);
 
     double threshold = o_prec / 1000.0;
     std::map<int, mrcpp::JpowerIntegrals *> J;
     for (int n = 0; n <= N + 1; n++) J[n] = new mrcpp::JpowerIntegrals(time * std::pow(4, n), n, max_Jpower, threshold);
-    mrcpp::TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation, imaginary);
+    mrcpp::TimeEvolution_CrossCorrelationCalculator calculator(J, this->cross_correlation);
 
-    OperatorAdaptor<double> adaptor(o_prec, o_mra.getMaxScale());
+    OperatorAdaptor<ComplexDouble> adaptor(o_prec, o_mra.getMaxScale());
     builder.build(*o_tree, calculator, adaptor, 13);
 
     // Postprocess to make the operator functional
@@ -231,7 +218,7 @@ template <int D> void TimeEvolutionOperator<D>::initializeSemiUniformly(double t
     print::time(10, "Time transform", trans_t);
     print::separator(10, ' ');
 
-    this->raw_exp.push_back(std::move(o_tree));
+    this->raw_exp_cplx.push_back(std::move(o_tree));
 
     for (int n = 0; n <= N + 1; n++) delete J[n];
 }

--- a/src/operators/TimeEvolutionOperator.cpp
+++ b/src/operators/TimeEvolutionOperator.cpp
@@ -68,7 +68,7 @@ namespace mrcpp {
  *
  */
 template <int D>
-TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, int max_Jpower)
+TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time)
         : ConvolutionOperator<D>(mra, mra.getRootScale(), -10) // One can use ConvolutionOperator instead as well
 {
     int oldlevel = Printer::setPrintLevel(0);
@@ -77,13 +77,24 @@ TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D>
     SchrodingerEvolution_CrossCorrelation cross_correlation(30, mra.getOrder(), mra.getScalingBasis().getScalingType());
     this->cross_correlation = &cross_correlation;
 
-    // will go outside of the constructor in future
-    if (finest_scale < 0)
-        initialize(time, max_Jpower);
-    else
-        initialize(time, finest_scale, max_Jpower);
+    initialize(time, 30); // will go outside of the constructor in future
 
     this->initOperExp(1); // this turns out to be important
+    Printer::setPrintLevel(oldlevel);
+}
+
+template <int D>
+TimeEvolutionOperator<D>::TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, int max_Jpower)
+        : ConvolutionOperator<D>(mra, mra.getRootScale(), -10) {
+    int oldlevel = Printer::setPrintLevel(0);
+    this->setBuildPrec(prec);
+
+    SchrodingerEvolution_CrossCorrelation cross_correlation(30, mra.getOrder(), mra.getScalingBasis().getScalingType());
+    this->cross_correlation = &cross_correlation;
+
+    initialize(time, finest_scale, max_Jpower);
+
+    this->initOperExp(1);
     Printer::setPrintLevel(oldlevel);
 }
 

--- a/src/operators/TimeEvolutionOperator.h
+++ b/src/operators/TimeEvolutionOperator.h
@@ -85,6 +85,15 @@ public:
      * that position would otherwise bind silently to `finest_scale`.
      */
     TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, bool imaginary, int max_Jpower = 30) = delete;
+
+    /** @brief Rejects the old fixed-scale signature at compile time.
+     *
+     * @details `(mra, prec, time, 7, false)` would otherwise bind to the
+     * `finest_scale, max_Jpower` overload with `max_Jpower = 0`, since `int`
+     * is an exact match in the fourth position and `bool` converts to `int`
+     * in the fifth.
+     */
+    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, bool imaginary, int max_Jpower = 30) = delete;
     TimeEvolutionOperator(const TimeEvolutionOperator &oper) = delete;
     TimeEvolutionOperator &operator=(const TimeEvolutionOperator &oper) = delete;
     virtual ~TimeEvolutionOperator() = default;

--- a/src/operators/TimeEvolutionOperator.h
+++ b/src/operators/TimeEvolutionOperator.h
@@ -56,20 +56,28 @@ public:
      * @param[in] mra: which MRA to operate on
      * @param[in] prec: build precision
      * @param[in] time: time step \f$ t \f$
-     * @param[in] finest_scale: uniform refinement down to this scale
-     * @param[in] max_Jpower: number of power integrals retained
      *
-     * @details The kernel is complex, and is held as a single
+     * @details Built adaptively from the precision, as every other convolution
+     * operator is. The kernel is complex and is held as a single
      * `OperatorTree<ComplexDouble>` -- the operator-side counterpart of a
-     * complex `FunctionTree`:
-     * - `finest_scale < 0` means adaptive construction
-     * - otherwise the operator is refined uniformly down to `finest_scale`
-     * - refinement thresholds on the modulus of the coefficients
+     * complex `FunctionTree` -- with refinement thresholding on the modulus of
+     * the coefficients.
      *
      * @note Applying this to a real `FunctionTree` aborts; project the input as
      * `ComplexDouble` first, or let the `CompFunction` overload promote it.
      */
-    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale = -1, int max_Jpower = 30);
+    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time);
+
+    /** @brief As above, refined uniformly down to a given scale.
+     *
+     * @param[in] finest_scale: uniform refinement down to this scale
+     * @param[in] max_Jpower: number of power integrals retained
+     *
+     * @details Bypasses the adaptive build. Kept for callers that need a fixed
+     * grid, in the same spirit as the `root`/`reach` overloads of
+     * `PoissonOperator` and `HelmholtzOperator`.
+     */
+    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, int max_Jpower = 30);
 
     /** @brief Rejects the old `bool imaginary` argument at compile time.
      *

--- a/src/operators/TimeEvolutionOperator.h
+++ b/src/operators/TimeEvolutionOperator.h
@@ -51,48 +51,18 @@ template <int D>
 class TimeEvolutionOperator : public ConvolutionOperator<D> // One can use ConvolutionOperator instead as well
 {
 public:
-    /** @brief Semigroup \f$ \exp(i t \partial_x^2) \f$ at one time moment.
-     *
-     * @param[in] mra: which MRA to operate on
-     * @param[in] prec: build precision
-     * @param[in] time: time step \f$ t \f$
-     *
-     * @details Built adaptively from the precision, as every other convolution
-     * operator is. The kernel is complex and is held as a single
-     * `OperatorTree<ComplexDouble>` -- the operator-side counterpart of a
-     * complex `FunctionTree` -- with refinement thresholding on the modulus of
-     * the coefficients.
+    /** @brief Semigroup \f$ \exp(i t \partial_x^2) \f$, refined adaptively.
      *
      * @note Applying this to a real `FunctionTree` aborts; project the input as
      * `ComplexDouble` first, or let the `CompFunction` overload promote it.
      */
     TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time);
 
-    /** @brief As above, refined uniformly down to a given scale.
-     *
-     * @param[in] finest_scale: uniform refinement down to this scale
-     * @param[in] max_Jpower: number of power integrals retained
-     *
-     * @details Bypasses the adaptive build. Kept for callers that need a fixed
-     * grid, in the same spirit as the `root`/`reach` overloads of
-     * `PoissonOperator` and `HelmholtzOperator`.
-     */
+    /// @brief As above, on a uniformly refined operator tree.
     TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, int max_Jpower = 30);
 
-    /** @brief Rejects the old `bool imaginary` argument at compile time.
-     *
-     * @details The semigroup is no longer built one part at a time. A `bool` in
-     * that position would otherwise bind silently to `finest_scale`.
-     */
+    /// @brief Rejects the legacy signatures carrying the removed `imaginary` argument.
     TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, bool imaginary, int max_Jpower = 30) = delete;
-
-    /** @brief Rejects the old fixed-scale signature at compile time.
-     *
-     * @details `(mra, prec, time, 7, false)` would otherwise bind to the
-     * `finest_scale, max_Jpower` overload with `max_Jpower = 0`, since `int`
-     * is an exact match in the fourth position and `bool` converts to `int`
-     * in the fifth.
-     */
     TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, bool imaginary, int max_Jpower = 30) = delete;
     TimeEvolutionOperator(const TimeEvolutionOperator &oper) = delete;
     TimeEvolutionOperator &operator=(const TimeEvolutionOperator &oper) = delete;

--- a/src/operators/TimeEvolutionOperator.h
+++ b/src/operators/TimeEvolutionOperator.h
@@ -51,8 +51,32 @@ template <int D>
 class TimeEvolutionOperator : public ConvolutionOperator<D> // One can use ConvolutionOperator instead as well
 {
 public:
-    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale, bool imaginary, int max_Jpower = 30);
-    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, bool imaginary, int max_Jpower = 30);
+    /** @brief Semigroup \f$ \exp(i t \partial_x^2) \f$ at one time moment.
+     *
+     * @param[in] mra: which MRA to operate on
+     * @param[in] prec: build precision
+     * @param[in] time: time step \f$ t \f$
+     * @param[in] finest_scale: uniform refinement down to this scale
+     * @param[in] max_Jpower: number of power integrals retained
+     *
+     * @details The kernel is complex, and is held as a single
+     * `OperatorTree<ComplexDouble>` -- the operator-side counterpart of a
+     * complex `FunctionTree`:
+     * - `finest_scale < 0` means adaptive construction
+     * - otherwise the operator is refined uniformly down to `finest_scale`
+     * - refinement thresholds on the modulus of the coefficients
+     *
+     * @note Applying this to a real `FunctionTree` aborts; project the input as
+     * `ComplexDouble` first, or let the `CompFunction` overload promote it.
+     */
+    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, int finest_scale = -1, int max_Jpower = 30);
+
+    /** @brief Rejects the old `bool imaginary` argument at compile time.
+     *
+     * @details The semigroup is no longer built one part at a time. A `bool` in
+     * that position would otherwise bind silently to `finest_scale`.
+     */
+    TimeEvolutionOperator(const MultiResolutionAnalysis<D> &mra, double prec, double time, bool imaginary, int max_Jpower = 30) = delete;
     TimeEvolutionOperator(const TimeEvolutionOperator &oper) = delete;
     TimeEvolutionOperator &operator=(const TimeEvolutionOperator &oper) = delete;
     virtual ~TimeEvolutionOperator() = default;
@@ -60,9 +84,9 @@ public:
     double getBuildPrec() const { return this->build_prec; }
 
 protected:
-    void initialize(double time, int finest_scale, bool imaginary, int max_Jpower);
-    void initialize(double time, bool imaginary, int max_Jpower);
-    void initializeSemiUniformly(double time, bool imaginary, int max_Jpower);
+    void initialize(double time, int finest_scale, int max_Jpower);
+    void initialize(double time, int max_Jpower);
+    void initializeSemiUniformly(double time, int max_Jpower);
 
     void setBuildPrec(double prec) { this->build_prec = prec; }
 

--- a/src/treebuilders/BandWidthAdaptor.h
+++ b/src/treebuilders/BandWidthAdaptor.h
@@ -28,7 +28,7 @@
 #include "MRCPP/constants.h"
 #include "TreeAdaptor.h"
 
-/** Builds an OperatorTree with known band width (e.g. derivative and identity).
+/** Builds an OperatorTree<double> with known band width (e.g. derivative and identity).
  * Assumes translational invariant and symmetric (in x - y) operator and keeps
  * only lower row of nodes (lx = 0). */
 

--- a/src/treebuilders/BandWidthAdaptor.h
+++ b/src/treebuilders/BandWidthAdaptor.h
@@ -28,7 +28,7 @@
 #include "MRCPP/constants.h"
 #include "TreeAdaptor.h"
 
-/** Builds an OperatorTree<double> with known band width (e.g. derivative and identity).
+/** Builds an OperatorTree with known band width (e.g. derivative and identity).
  * Assumes translational invariant and symmetric (in x - y) operator and keeps
  * only lower row of nodes (lx = 0). */
 

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -24,6 +24,8 @@
  */
 
 #include "ConvolutionCalculator.h"
+
+#include <type_traits>
 #include "operators/ConvolutionOperator.h"
 #include "operators/OperatorState.h"
 #include "trees/BandWidth.h"

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -306,7 +306,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::applyOperator(int
     double **oData = os.getOperData();
     ComplexDouble **oData_cplx = os.getOperDataCplx();
 
-    // The expansion is real or complex, never both; pick the band accordingly.
+    // Select the active coefficient representation.
     const bool oper_cplx = this->oper->iscomplex();
 
     for (int d = 0; d < D; d++) {
@@ -378,7 +378,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::tensorApplyOperCo
         Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>> f(aux[i], os.kp1, os.kp1_dm1);
         Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>> g(aux[i + 1], os.kp1_dm1, os.kp1);
         if (oData[i] != nullptr) {
-            Eigen::Map<MatrixXd> op(oData[i], os.kp1, os.kp1);
+            Eigen::Map<const MatrixXd> op(oData[i], os.kp1, os.kp1);
             if (i == D - 1) { // Last dir: Add up into g
                 g.noalias() += f.transpose() * op;
             } else {
@@ -386,9 +386,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::tensorApplyOperCo
             }
         } else if (oData_cplx[i] != nullptr) {
             if constexpr (std::is_same<T, ComplexDouble>::value) {
-                // A complex kernel: the band multiplies a complex intermediate,
-                // the same mixed-scalar product math_utils::apply_filter uses.
-                Eigen::Map<Eigen::MatrixXcd> op(oData_cplx[i], os.kp1, os.kp1);
+                Eigen::Map<const Eigen::MatrixXcd> op(oData_cplx[i], os.kp1, os.kp1);
                 if (i == D - 1) {
                     g.noalias() += f.transpose() * op;
                 } else {

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -105,7 +105,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::printTimers() con
 template <int D, typename T> void ConvolutionCalculator<D, T>::initBandSizes() {
     for (size_t i = 0; i < this->oper->size(); i++) {
         // IMPORTANT: only 0-th dimension!
-        const OperatorTree &oTree = this->oper->getComponent(i, 0);
+        const OperatorTree<double> &oTree = this->oper->getComponent(i, 0);
         const BandWidth &bw = oTree.getBandWidth();
         auto *bsize = new MatrixXi(this->maxDepth, this->nComp2 + 1);
         bsize->setZero();
@@ -279,7 +279,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::applyOperComp(Ope
     int o_depth = os.fNode->getScale() - this->oper->getOperatorRoot();
     for (size_t i = 0; i < this->oper->size(); i++) {
         // IMPORTANT: only 0-th dimension
-        const OperatorTree &ot = this->oper->getComponent(i, 0);
+        const OperatorTree<double> &ot = this->oper->getComponent(i, 0);
         const BandWidth &bw = ot.getBandWidth();
         if (os.getMaxDeltaL() > bw.getMaxWidth(o_depth)) { continue; }
         os.fThreshold = getBandSizeFactor(i, o_depth, os) * fNorm;
@@ -316,7 +316,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::applyOperator(int
         int idx = (a << 1) + b;
         if (oTree.isOutsideBand(oTransl, o_depth, idx)) { return; }
 
-        const OperatorNode &oNode = oTree.getNode(o_depth, oTransl);
+        const OperatorNode<double> &oNode = oTree.getNode(o_depth, oTransl);
         int oIdx = os.getOperIndex(d);
         oNorm *= oNode.getComponentNorm(oIdx);
         oData[d] = const_cast<double *>(oNode.getCoefs()) + oIdx * os.kp1_2;

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -105,8 +105,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::printTimers() con
 template <int D, typename T> void ConvolutionCalculator<D, T>::initBandSizes() {
     for (size_t i = 0; i < this->oper->size(); i++) {
         // IMPORTANT: only 0-th dimension!
-        const OperatorTree<double> &oTree = this->oper->getComponent(i, 0);
-        const BandWidth &bw = oTree.getBandWidth();
+        const BandWidth &bw = this->oper->getBandWidth(i, 0);
         auto *bsize = new MatrixXi(this->maxDepth, this->nComp2 + 1);
         bsize->setZero();
         for (int j = 0; j < this->maxDepth; j++) { calcBandSizeFactor(*bsize, j, bw); }
@@ -279,8 +278,7 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::applyOperComp(Ope
     int o_depth = os.fNode->getScale() - this->oper->getOperatorRoot();
     for (size_t i = 0; i < this->oper->size(); i++) {
         // IMPORTANT: only 0-th dimension
-        const OperatorTree<double> &ot = this->oper->getComponent(i, 0);
-        const BandWidth &bw = ot.getBandWidth();
+        const BandWidth &bw = this->oper->getBandWidth(i, 0);
         if (os.getMaxDeltaL() > bw.getMaxWidth(o_depth)) { continue; }
         os.fThreshold = getBandSizeFactor(i, o_depth, os) * fNorm;
         applyOperator(i, os);

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -304,9 +304,12 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::applyOperator(int
 
     double oNorm = 1.0;
     double **oData = os.getOperData();
+    ComplexDouble **oData_cplx = os.getOperDataCplx();
+
+    // The expansion is real or complex, never both; pick the band accordingly.
+    const bool oper_cplx = this->oper->iscomplex();
 
     for (int d = 0; d < D; d++) {
-        auto &oTree = this->oper->getComponent(i, d);
         int oTransl = fIdx[d] - gIdx[d];
 
         //  The following will check the actual band width in each direction.
@@ -314,12 +317,23 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::applyOperator(int
         int a = (os.gt & (1 << d)) >> d;
         int b = (os.ft & (1 << d)) >> d;
         int idx = (a << 1) + b;
-        if (oTree.isOutsideBand(oTransl, o_depth, idx)) { return; }
-
-        const OperatorNode<double> &oNode = oTree.getNode(o_depth, oTransl);
         int oIdx = os.getOperIndex(d);
-        oNorm *= oNode.getComponentNorm(oIdx);
-        oData[d] = const_cast<double *>(oNode.getCoefs()) + oIdx * os.kp1_2;
+
+        if (oper_cplx) {
+            auto &oTree = this->oper->getComponentCplx(i, d);
+            if (oTree.isOutsideBand(oTransl, o_depth, idx)) { return; }
+            const OperatorNode<ComplexDouble> &oNode = oTree.getNode(o_depth, oTransl);
+            oNorm *= oNode.getComponentNorm(oIdx);
+            oData[d] = nullptr;
+            oData_cplx[d] = const_cast<ComplexDouble *>(oNode.getCoefs()) + oIdx * os.kp1_2;
+        } else {
+            auto &oTree = this->oper->getComponent(i, d);
+            if (oTree.isOutsideBand(oTransl, o_depth, idx)) { return; }
+            const OperatorNode<double> &oNode = oTree.getNode(o_depth, oTransl);
+            oNorm *= oNode.getComponentNorm(oIdx);
+            oData[d] = const_cast<double *>(oNode.getCoefs()) + oIdx * os.kp1_2;
+            oData_cplx[d] = nullptr;
+        }
     }
     double upperBound = oNorm * os.fThreshold;
     if (upperBound > os.gThreshold) {
@@ -333,6 +347,7 @@ operator component to a f-node in a n-dimensional tesor space. */
 template <int D, typename T> void ConvolutionCalculator<D, T>::tensorApplyOperComp(OperatorState<D, T> &os) {
     T **aux = os.getAuxData();
     double **oData = os.getOperData();
+    ComplexDouble **oData_cplx = os.getOperDataCplx();
     /*
 #ifdef HAVE_BLAS
     double mult = 0.0;
@@ -368,6 +383,19 @@ template <int D, typename T> void ConvolutionCalculator<D, T>::tensorApplyOperCo
                 g.noalias() += f.transpose() * op;
             } else {
                 g.noalias() = f.transpose() * op;
+            }
+        } else if (oData_cplx[i] != nullptr) {
+            if constexpr (std::is_same<T, ComplexDouble>::value) {
+                // A complex kernel: the band multiplies a complex intermediate,
+                // the same mixed-scalar product math_utils::apply_filter uses.
+                Eigen::Map<Eigen::MatrixXcd> op(oData_cplx[i], os.kp1, os.kp1);
+                if (i == D - 1) {
+                    g.noalias() += f.transpose() * op;
+                } else {
+                    g.noalias() = f.transpose() * op;
+                }
+            } else {
+                NOT_REACHED_ABORT; // guarded in apply: real tree, complex operator
             }
         } else {
             // Identity operator in direction i

--- a/src/treebuilders/DerivativeCalculator.cpp
+++ b/src/treebuilders/DerivativeCalculator.cpp
@@ -187,8 +187,8 @@ template <int D, typename T> void DerivativeCalculator<D, T>::applyOperator_bw0(
     double **oData = os.getOperData();
 
     for (int d = 0; d < D; d++) {
-        const OperatorTree &oTree = this->oper->getComponent(0, d);
-        const OperatorNode &oNode = oTree.getNode(depth, 0);
+        const OperatorTree<double> &oTree = this->oper->getComponent(0, d);
+        const OperatorNode<double> &oNode = oTree.getNode(depth, 0);
         int oIdx = os.getOperIndex(d);
         if (this->applyDir == d) {
             oData[d] = const_cast<double *>(oNode.getCoefs()) + oIdx * os.kp1_2;
@@ -218,7 +218,7 @@ template <int D, typename T> void DerivativeCalculator<D, T>::applyOperator(Oper
     double **oData = os.getOperData();
 
     for (int d = 0; d < D; d++) {
-        const OperatorTree &oTree = this->oper->getComponent(0, d);
+        const OperatorTree<double> &oTree = this->oper->getComponent(0, d);
 
         int oTransl = fIdx[d] - gIdx[d];
 
@@ -230,7 +230,7 @@ template <int D, typename T> void DerivativeCalculator<D, T>::applyOperator(Oper
         int w = oTree.getBandWidth().getWidth(depth, idx);
         if (abs(oTransl) > w) { return; }
 
-        const OperatorNode &oNode = oTree.getNode(depth, oTransl);
+        const OperatorNode<double> &oNode = oTree.getNode(depth, oTransl);
         int oIdx = os.getOperIndex(d);
         if (this->applyDir == d) {
             oData[d] = const_cast<double *>(oNode.getCoefs()) + oIdx * os.kp1_2;

--- a/src/treebuilders/OperatorAdaptor.h
+++ b/src/treebuilders/OperatorAdaptor.h
@@ -29,13 +29,13 @@
 
 namespace mrcpp {
 
-class OperatorAdaptor final : public WaveletAdaptor<2> {
+template <typename T = double> class OperatorAdaptor final : public WaveletAdaptor<2, T> {
 public:
     OperatorAdaptor(double pr, int ms, bool ap = false)
-            : WaveletAdaptor<2>(pr, ms, ap) {}
+            : WaveletAdaptor<2, T>(pr, ms, ap) {}
 
 protected:
-    bool splitNode(const MWNode<2> &node) const override {
+    bool splitNode(const MWNode<2, T> &node) const override {
         const auto &idx = node.getNodeIndex();
         bool chkTransl = (idx[0] == 0 or idx[1] == 0);
 

--- a/src/treebuilders/TimeEvolution_CrossCorrelationCalculator.cpp
+++ b/src/treebuilders/TimeEvolution_CrossCorrelationCalculator.cpp
@@ -29,7 +29,7 @@
 #include "utils/Printer.h"
 
 using Eigen::MatrixXd;
-using Eigen::VectorXd;
+using Eigen::VectorXcd;
 
 namespace mrcpp {
 
@@ -40,7 +40,7 @@ namespace mrcpp {
  *
  *
  */
-void TimeEvolution_CrossCorrelationCalculator::calcNode(MWNode<2> &node) {
+void TimeEvolution_CrossCorrelationCalculator::calcNode(MWNode<2, ComplexDouble> &node) {
     node.zeroCoefs();
     int type = node.getMWTree().getMRA().getScalingBasis().getScalingType();
     switch (type) {
@@ -69,7 +69,7 @@ void TimeEvolution_CrossCorrelationCalculator::calcNode(MWNode<2> &node) {
  *
  */
 // template <int T>
-void TimeEvolution_CrossCorrelationCalculator::applyCcc(MWNode<2> &node) {
+void TimeEvolution_CrossCorrelationCalculator::applyCcc(MWNode<2, ComplexDouble> &node) {
     // std::cout << node;
     //  The scale of J power integrals:
     // int scale = node.getScale() + 1;  //scale = n = (n - 1) + 1
@@ -77,7 +77,7 @@ void TimeEvolution_CrossCorrelationCalculator::applyCcc(MWNode<2> &node) {
     int t_dim = node.getTDim();  // t_dim = 4
     int kp1_d = node.getKp1_d(); // kp1_d = (k + 1)^2
 
-    VectorXd vec_o = VectorXd::Zero(t_dim * kp1_d);
+    VectorXcd vec_o = VectorXcd::Zero(t_dim * kp1_d);
     const NodeIndex<2> &idx = node.getNodeIndex();
 
     auto &J_power_inetgarls = *this->J_power_inetgarls[node.getScale() + 1];
@@ -92,18 +92,15 @@ void TimeEvolution_CrossCorrelationCalculator::applyCcc(MWNode<2> &node) {
                 // std::min(M, N)  could be used for breaking the following loop
                 // this->cross_correlation->Matrix.size() should be big enough a priori
                 for (size_t k = 0; 2 * k + p + j < J_power_inetgarls[l_b].size(); k++) {
-                    double J;
-                    if (this->imaginary)
-                        J = J_power_inetgarls[l_b][2 * k + p + j].imag();
-                    else
-                        J = J_power_inetgarls[l_b][2 * k + p + j].real();
+                    // The kernel is complex; the whole power integral is kept.
+                    const ComplexDouble J = J_power_inetgarls[l_b][2 * k + p + j];
                     vec_o.segment(i * kp1_d, kp1_d)(vec_o_segment_index) += J * cross_correlation->Matrix[k](p, j); // by default eigen library reads a transpose matrix from a file
                 }
                 vec_o_segment_index++;
             }
     }
 
-    double *coefs = node.getCoefs();
+    ComplexDouble *coefs = node.getCoefs();
     for (int i = 0; i < t_dim * kp1_d; i++) {
         // auto scaling_factor = node.getMWTree().getMRA().getWorldBox().getScalingFactor(0);
         coefs[i] = vec_o(i);

--- a/src/treebuilders/TimeEvolution_CrossCorrelationCalculator.h
+++ b/src/treebuilders/TimeEvolution_CrossCorrelationCalculator.h
@@ -42,24 +42,20 @@ namespace mrcpp {
  *
  *
  */
-class TimeEvolution_CrossCorrelationCalculator final : public TreeCalculator<2> {
+class TimeEvolution_CrossCorrelationCalculator final : public TreeCalculator<2, ComplexDouble> {
 public:
-    TimeEvolution_CrossCorrelationCalculator(std::map<int, JpowerIntegrals *> &J, SchrodingerEvolution_CrossCorrelation *cross_correlation, bool imaginary)
+    TimeEvolution_CrossCorrelationCalculator(std::map<int, JpowerIntegrals *> &J, SchrodingerEvolution_CrossCorrelation *cross_correlation)
             : J_power_inetgarls(J)
-            , cross_correlation(cross_correlation)
-            , imaginary(imaginary) {}
+            , cross_correlation(cross_correlation) {}
     // private:
     std::map<int, JpowerIntegrals *> J_power_inetgarls;
     SchrodingerEvolution_CrossCorrelation *cross_correlation;
 
-    /// @brief If False then the calculator is using th real part of integrals, otherwise - the imaginary part.
-    bool imaginary;
-
-    void calcNode(MWNode<2> &node) override;
+    void calcNode(MWNode<2, ComplexDouble> &node) override;
 
     // template <int T>
-    void applyCcc(MWNode<2> &node);
-    // template <int T> void applyCcc(MWNode<2> &node, CrossCorrelationCache<T> &ccc);
+    void applyCcc(MWNode<2, ComplexDouble> &node);
+    // template <int T> void applyCcc(MWNode<2, ComplexDouble> &node, CrossCorrelationCache<T> &ccc);
 };
 
 } // namespace mrcpp

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -67,6 +67,9 @@ template <int D, typename T> void apply_on_unit_cell(bool inside, double prec, F
  */
 template <int D, typename T> void apply(double prec, FunctionTree<D, T> &out, ConvolutionOperator<D> &oper, FunctionTree<D, T> &inp, int maxIter, bool absPrec) {
     if (out.getMRA() != inp.getMRA()) MSG_ABORT("Incompatible MRA");
+    if constexpr (std::is_same<T, double>::value) {
+        if (oper.iscomplex()) MSG_ABORT("Complex operator on a real function tree: project the input as ComplexDouble first");
+    }
 
     Timer pre_t;
     oper.calcBandWidths(prec);
@@ -122,10 +125,17 @@ template <int D> void apply(double prec, CompFunction<D> &out, ConvolutionOperat
     for (int icomp = 0; icomp < inp.Ncomp(); icomp++) {
         for (int ocomp = 0; ocomp < 4; ocomp++) {
             if (std::norm(metric[icomp][ocomp]) > MachinePrec) {
-                if (inp.isreal()) {
+                if (inp.isreal() and oper.isreal()) {
                     if (out.CompD[ocomp] == nullptr) out.alloc_comp(ocomp);
                     apply(prec, *out.CompD[ocomp], oper, *inp.CompD[icomp], maxIter, absPrec);
                     if (abs(metric[icomp][ocomp] - 1.0) > MachinePrec) { out.CompD[ocomp]->rescale(metric[icomp][ocomp].real()); }
+                } else if (inp.isreal()) {
+                    // Complex kernel on a real input: promote, as the derivative overload does
+                    out.defcomplex();
+                    if (out.CompC[ocomp] == nullptr) out.alloc_comp(ocomp);
+                    std::unique_ptr<FunctionTree<D, ComplexDouble>> inp_c(inp.CompD[icomp]->CopyTreeToComplex());
+                    apply(prec, *out.CompC[ocomp], oper, *inp_c, maxIter, absPrec);
+                    if (abs(metric[icomp][ocomp] - 1.0) > MachinePrec) { out.CompC[ocomp]->rescale(metric[icomp][ocomp]); }
                 } else {
                     if (out.CompC[ocomp] == nullptr) out.alloc_comp(ocomp);
                     apply(prec, *out.CompC[ocomp], oper, *inp.CompC[icomp], maxIter, absPrec);

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -24,6 +24,8 @@
  */
 
 #include "apply.h"
+
+#include <type_traits>
 #include "ConvolutionCalculator.h"
 #include "CopyAdaptor.h"
 #include "DefaultCalculator.h"

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -132,7 +132,8 @@ template <int D> void apply(double prec, CompFunction<D> &out, ConvolutionOperat
                     apply(prec, *out.CompD[ocomp], oper, *inp.CompD[icomp], maxIter, absPrec);
                     if (abs(metric[icomp][ocomp] - 1.0) > MachinePrec) { out.CompD[ocomp]->rescale(metric[icomp][ocomp].real()); }
                 } else if (inp.isreal()) {
-                    // Complex kernel on a real input: promote, as the derivative overload does
+                    // Promote a real input before applying a complex operator,
+                    // as the DerivativeOperator overload below does
                     out.defcomplex();
                     if (out.CompC[ocomp] == nullptr) out.alloc_comp(ocomp);
                     std::unique_ptr<FunctionTree<D, ComplexDouble>> inp_c(inp.CompD[icomp]->CopyTreeToComplex());

--- a/src/trees/CornerOperatorTree.cpp
+++ b/src/trees/CornerOperatorTree.cpp
@@ -41,12 +41,12 @@ namespace mrcpp {
  * This procedure is repeated for each matrix \f$ A, B \f$ and \f$ C \f$.
  *
  */
-void CornerOperatorTree::calcBandWidth(double prec) {
-    if (this->bandWidth == nullptr) clearBandWidth();
-    this->bandWidth = new BandWidth(getDepth());
+template <typename T> void CornerOperatorTree<T>::calcBandWidth(double prec) {
+    if (this->bandWidth == nullptr) this->clearBandWidth();
+    this->bandWidth = new BandWidth(this->getDepth());
 
     VectorXi max_transl;
-    getMaxTranslations(max_transl);
+    this->getMaxTranslations(max_transl);
 
     if (prec < 0.0) prec = this->normPrec;
     double thrs = std::max(MachinePrec, prec / 10.0); // should be enough due to oscillating behaviour of corner matrix elements (it's affected by polynomial order)
@@ -58,7 +58,7 @@ void CornerOperatorTree::calcBandWidth(double prec) {
 
         while (not done) {
             done = true;
-            MWNode<2> *node = findNode(NodeIndex<2>(depth, {l, 0}));
+            MWNode<2, T> *node = this->findNode(NodeIndex<2>(depth, {l, 0}));
             for (int k = 1; k < 4; k++) {
                 if ((node != nullptr) && (node->getComponentNorm(k) > thrs)) {
                     this->bandWidth->setWidth(depth, k, l);
@@ -80,8 +80,11 @@ void CornerOperatorTree::calcBandWidth(double prec) {
  * @returns True if \b oTransl is outside of the corner band (close to diagonal) and False otherwise.
  *
  */
-bool CornerOperatorTree::isOutsideBand(int oTransl, int o_depth, int idx) {
+template <typename T> bool CornerOperatorTree<T>::isOutsideBand(int oTransl, int o_depth, int idx) {
     return abs(oTransl) < this->bandWidth->getWidth(o_depth, idx);
 }
+
+template class CornerOperatorTree<double>;
+template class CornerOperatorTree<ComplexDouble>;
 
 } // namespace mrcpp

--- a/src/trees/CornerOperatorTree.cpp
+++ b/src/trees/CornerOperatorTree.cpp
@@ -42,7 +42,7 @@ namespace mrcpp {
  *
  */
 template <typename T> void CornerOperatorTree<T>::calcBandWidth(double prec) {
-    if (this->bandWidth == nullptr) this->clearBandWidth();
+    this->clearBandWidth();
     this->bandWidth = new BandWidth(this->getDepth());
 
     VectorXi max_transl;

--- a/src/trees/CornerOperatorTree.h
+++ b/src/trees/CornerOperatorTree.h
@@ -31,15 +31,15 @@ namespace mrcpp {
 
 /** @class CornerOperatorTree
  *
- * @brief Special case of OperatorTree class
+ * @brief Special case of OperatorTree<double> class
  *
  * @details Tree structure of operators having corner matrices
  * \f$ A, B, C \f$ in the non-standard form.
  *
  */
-class CornerOperatorTree final : public OperatorTree {
+class CornerOperatorTree final : public OperatorTree<double> {
 public:
-    using OperatorTree::OperatorTree; // Import the single valid constructor from OperatorTree
+    using OperatorTree<double>::OperatorTree; // Import the single valid constructor from OperatorTree<double>
     CornerOperatorTree(const CornerOperatorTree &tree) = delete;
     CornerOperatorTree &operator=(const CornerOperatorTree &tree) = delete;
     ~CornerOperatorTree() override = default;

--- a/src/trees/CornerOperatorTree.h
+++ b/src/trees/CornerOperatorTree.h
@@ -31,17 +31,17 @@ namespace mrcpp {
 
 /** @class CornerOperatorTree
  *
- * @brief Special case of OperatorTree<double> class
+ * @brief Special case of the OperatorTree class
  *
  * @details Tree structure of operators having corner matrices
  * \f$ A, B, C \f$ in the non-standard form.
  *
  */
-class CornerOperatorTree final : public OperatorTree<double> {
+template <typename T = double> class CornerOperatorTree final : public OperatorTree<T> {
 public:
-    using OperatorTree<double>::OperatorTree; // Import the single valid constructor from OperatorTree<double>
-    CornerOperatorTree(const CornerOperatorTree &tree) = delete;
-    CornerOperatorTree &operator=(const CornerOperatorTree &tree) = delete;
+    using OperatorTree<T>::OperatorTree; // Import the single valid constructor
+    CornerOperatorTree(const CornerOperatorTree<T> &tree) = delete;
+    CornerOperatorTree<T> &operator=(const CornerOperatorTree<T> &tree) = delete;
     ~CornerOperatorTree() override = default;
 
     void calcBandWidth(double prec = -1.0) override;

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -161,9 +161,9 @@ public:
     friend class NodeAllocator<D, T>;
     friend class MWTree<D, T>;
     friend class FunctionTree<D, T>;
-    friend class OperatorTree;
+    friend class OperatorTree<T>;
     friend class FunctionNode<D, T>;
-    friend class OperatorNode;
+    friend class OperatorNode<T>;
     friend class DerivativeCalculator<D, T>;
     bool isComplex = false;               // TODO put as one of the flags
     friend class FunctionTree<D, double>; // required if a ComplexDouble tree access a double node from another tree!

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -42,7 +42,7 @@ class BankAccount;
 
 /** @class MWTree
  *
- * @brief Base class for Multiwavelet tree structures, such as FunctionTree and OperatorTree
+ * @brief Base class for Multiwavelet tree structures, such as FunctionTree and OperatorTree<double>
  *
  * @details The MWTree class is the base class for all tree structures
  * needed for Multiwavelet calculations. The MWTree is a D-dimensional
@@ -150,7 +150,7 @@ public:
 
     friend class MWNode<D, T>;
     friend class FunctionNode<D, T>;
-    friend class OperatorNode;
+    friend class OperatorNode<T>;
     friend class TreeBuilder<D, T>;
     friend class NodeAllocator<D, T>;
 

--- a/src/trees/MWTree.h
+++ b/src/trees/MWTree.h
@@ -42,7 +42,7 @@ class BankAccount;
 
 /** @class MWTree
  *
- * @brief Base class for Multiwavelet tree structures, such as FunctionTree and OperatorTree<double>
+ * @brief Base class for Multiwavelet tree structures, such as FunctionTree and OperatorTree
  *
  * @details The MWTree class is the base class for all tree structures
  * needed for Multiwavelet calculations. The MWTree is a D-dimensional

--- a/src/trees/NodeAllocator.cpp
+++ b/src/trees/NodeAllocator.cpp
@@ -56,7 +56,7 @@ NodeAllocator<D, T>::NodeAllocator(FunctionTree<D, T> *tree, SharedMemory<T> *me
 }
 
 template <>
-NodeAllocator<2>::NodeAllocator(OperatorTree *tree, SharedMemory<double> *mem, int coefsPerNode, int nodesPerChunk)
+NodeAllocator<2, double>::NodeAllocator(OperatorTree<double> *tree, SharedMemory<double> *mem, int coefsPerNode, int nodesPerChunk)
         : coefsPerNode(coefsPerNode)
         , maxNodesPerChunk(nodesPerChunk)
         , tree_p(tree)
@@ -65,19 +65,35 @@ NodeAllocator<2>::NodeAllocator(OperatorTree *tree, SharedMemory<double> *mem, i
     this->nodeChunks.reserve(100);
     this->coefChunks.reserve(100);
 
-    OperatorNode tmp;
+    OperatorNode<double> tmp;
     this->cvptr = *(char **)(&tmp);
-    this->sizeOfNode = sizeof(OperatorNode);
+    this->sizeOfNode = sizeof(OperatorNode<double>);
 
     MRCPP_INIT_OMP_LOCK();
 }
 
-template <int D, typename T> NodeAllocator<D, T>::NodeAllocator(OperatorTree *tree, SharedMemory<T> *mem, int coefsPerNode, int nodesPerChunk) {
+template <int D, typename T> NodeAllocator<D, T>::NodeAllocator(OperatorTree<T> *tree, SharedMemory<T> *mem, int coefsPerNode, int nodesPerChunk) {
     (void)tree;
     (void)mem;
     (void)coefsPerNode;
     (void)nodesPerChunk;
     NOT_REACHED_ABORT;
+}
+
+template <>
+NodeAllocator<2, ComplexDouble>::NodeAllocator(OperatorTree<ComplexDouble> *tree, SharedMemory<ComplexDouble> *mem, int coefsPerNode, int nodesPerChunk)
+        : coefsPerNode(coefsPerNode)
+        , maxNodesPerChunk(nodesPerChunk)
+        , tree_p(tree)
+        , shmem_p(mem) {
+    this->nodeChunks.reserve(100);
+    this->coefChunks.reserve(100);
+
+    OperatorNode<ComplexDouble> tmp;
+    this->cvptr = *(char **)(&tmp);
+    this->sizeOfNode = sizeof(OperatorNode<ComplexDouble>);
+
+    MRCPP_INIT_OMP_LOCK();
 }
 
 template <int D, typename T> NodeAllocator<D, T>::~NodeAllocator() {

--- a/src/trees/NodeAllocator.h
+++ b/src/trees/NodeAllocator.h
@@ -42,7 +42,7 @@ namespace mrcpp {
 
 template <int D, typename T> class NodeAllocator final {
 public:
-    NodeAllocator(OperatorTree *tree, SharedMemory<T> *mem, int coefsPerNode, int nodesPerChunk);
+    NodeAllocator(OperatorTree<T> *tree, SharedMemory<T> *mem, int coefsPerNode, int nodesPerChunk);
     NodeAllocator(FunctionTree<D, T> *tree, SharedMemory<T> *mem, int coefsPerNode, int nodesPerChunk);
     NodeAllocator(const NodeAllocator<D, T> &tree) = delete;
     NodeAllocator<D, T> &operator=(const NodeAllocator<D, T> &tree) = delete;

--- a/src/trees/OperatorNode.cpp
+++ b/src/trees/OperatorNode.cpp
@@ -29,6 +29,8 @@
 #include "utils/Printer.h"
 #include "utils/math_utils.h"
 
+#include <type_traits>
+
 using namespace Eigen;
 
 namespace mrcpp {
@@ -65,12 +67,12 @@ template <typename T> double OperatorNode<T>::calcComponentNorm(int i) const {
     int kp1_d = this->getKp1_d();
     const Eigen::Matrix<T, Eigen::Dynamic, 1> comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
 
-    // matrix_norm_1, _inf and _2 are all entrywise (colwise/rowwise lpNorm<1>
-    // and lpNorm<2>), so taking the moduli first leaves every one of them
-    // unchanged: signs and phases never enter these particular bounds. A
-    // complex kernel whose imaginary part is zero therefore thresholds exactly
-    // as the real tree does. Note _2 is Frobenius here, not the spectral norm,
-    // which is what makes this exact rather than merely conservative.
+    // All three bounds depend only on coefficient magnitudes: matrix_norm_1
+    // and matrix_norm_inf are absolute column and row sums, and matrix_norm_2
+    // is Eigen's lpNorm<2>, i.e. Frobenius rather than the spectral norm.
+    // Replacing a complex component by its entrywise moduli therefore leaves
+    // every bound unchanged, and a kernel with zero imaginary part thresholds
+    // exactly as the corresponding real tree does.
     MatrixXd comp_mat;
     if constexpr (std::is_same<T, ComplexDouble>::value) {
         comp_mat = Eigen::Map<const MatrixXcd>(comp_vec.data(), kp1, kp1).cwiseAbs();

--- a/src/trees/OperatorNode.cpp
+++ b/src/trees/OperatorNode.cpp
@@ -67,12 +67,8 @@ template <typename T> double OperatorNode<T>::calcComponentNorm(int i) const {
     int kp1_d = this->getKp1_d();
     const Eigen::Matrix<T, Eigen::Dynamic, 1> comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
 
-    // All three bounds depend only on coefficient magnitudes: matrix_norm_1
-    // and matrix_norm_inf are absolute column and row sums, and matrix_norm_2
-    // is Eigen's lpNorm<2>, i.e. Frobenius rather than the spectral norm.
-    // Replacing a complex component by its entrywise moduli therefore leaves
-    // every bound unchanged, and a kernel with zero imaginary part thresholds
-    // exactly as the corresponding real tree does.
+    // The bounds below use absolute row/column sums and the Frobenius norm,
+    // so they can be evaluated on the entrywise modulus.
     MatrixXd comp_mat;
     if constexpr (std::is_same<T, ComplexDouble>::value) {
         comp_mat = Eigen::Map<const MatrixXcd>(comp_vec.data(), kp1, kp1).cwiseAbs();

--- a/src/trees/OperatorNode.cpp
+++ b/src/trees/OperatorNode.cpp
@@ -33,7 +33,7 @@ using namespace Eigen;
 
 namespace mrcpp {
 
-void OperatorNode::dealloc() {
+template <typename T> void OperatorNode<T>::dealloc() {
     int sIdx = this->serialIx;
     this->serialIx = -1;
     this->parentSerialIx = -1;
@@ -53,18 +53,26 @@ void OperatorNode::dealloc() {
  * (TODO: needs to be more presiced).
  *
  */
-double OperatorNode::calcComponentNorm(int i) const {
-    int depth = getDepth();
+template <typename T> double OperatorNode<T>::calcComponentNorm(int i) const {
+    int depth = this->getDepth();
     double prec = getOperTree().getNormPrecision();
     double thrs = std::max(MachinePrec, prec / (8.0 * (1 << depth)));
 
-    VectorXd coef_vec;
+    Eigen::Matrix<T, Eigen::Dynamic, 1> coef_vec;
     this->getCoefs(coef_vec);
 
     int kp1 = this->getKp1();
     int kp1_d = this->getKp1_d();
-    const VectorXd &comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
-    const MatrixXd comp_mat = MatrixXd::Map(comp_vec.data(), kp1, kp1); // one can use MatrixXd OperatorNode::getComponent(int i)
+    const Eigen::Matrix<T, Eigen::Dynamic, 1> comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
+
+    // Bounds are taken on the moduli, so they are unchanged when the imaginary
+    // part is zero -- a real kernel thresholds exactly as it did before.
+    MatrixXd comp_mat;
+    if constexpr (std::is_same<T, ComplexDouble>::value) {
+        comp_mat = Eigen::Map<const MatrixXcd>(comp_vec.data(), kp1, kp1).cwiseAbs();
+    } else {
+        comp_mat = Eigen::Map<const MatrixXd>(comp_vec.data(), kp1, kp1);
+    }
 
     double norm = 0.0;
     double vecNorm = comp_vec.norm();
@@ -93,17 +101,17 @@ double OperatorNode::calcComponentNorm(int i) const {
  * For example, \f$ \alpha_l^n = \text{getComponent}(3) \f$.
  *
  */
-MatrixXd OperatorNode::getComponent(int i) {
-    VectorXd coef_vec;
+template <typename T> Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> OperatorNode<T>::getComponent(int i) {
+    Eigen::Matrix<T, Eigen::Dynamic, 1> coef_vec;
     this->getCoefs(coef_vec);
 
     int kp1 = this->getKp1();
     int kp1_d = this->getKp1_d();
-    const VectorXd &comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
-    return MatrixXd::Map(comp_vec.data(), kp1, kp1);
+    const Eigen::Matrix<T, Eigen::Dynamic, 1> comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
+    return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(comp_vec.data(), kp1, kp1);
 }
 
-void OperatorNode::createChildren(bool coefs) {
+template <typename T> void OperatorNode<T>::createChildren(bool coefs) {
     if (this->isBranchNode()) MSG_ABORT("Node already has children");
     auto &allocator = this->getOperTree().getNodeAllocator();
 
@@ -141,14 +149,17 @@ void OperatorNode::createChildren(bool coefs) {
     this->clearIsEndNode();
 }
 
-void OperatorNode::genChildren() {
+template <typename T> void OperatorNode<T>::genChildren() {
     this->createChildren(true);
     this->giveChildrenCoefs();
 }
 
-void OperatorNode::deleteChildren() {
-    MWNode<2>::deleteChildren();
+template <typename T> void OperatorNode<T>::deleteChildren() {
+    MWNode<2, T>::deleteChildren();
     this->setIsEndNode();
 }
+
+template class OperatorNode<double>;
+template class OperatorNode<ComplexDouble>;
 
 } // namespace mrcpp

--- a/src/trees/OperatorNode.cpp
+++ b/src/trees/OperatorNode.cpp
@@ -65,8 +65,12 @@ template <typename T> double OperatorNode<T>::calcComponentNorm(int i) const {
     int kp1_d = this->getKp1_d();
     const Eigen::Matrix<T, Eigen::Dynamic, 1> comp_vec = coef_vec.segment(i * kp1_d, kp1_d);
 
-    // Bounds are taken on the moduli, so they are unchanged when the imaginary
-    // part is zero -- a real kernel thresholds exactly as it did before.
+    // matrix_norm_1, _inf and _2 are all entrywise (colwise/rowwise lpNorm<1>
+    // and lpNorm<2>), so taking the moduli first leaves every one of them
+    // unchanged: signs and phases never enter these particular bounds. A
+    // complex kernel whose imaginary part is zero therefore thresholds exactly
+    // as the real tree does. Note _2 is Frobenius here, not the spectral norm,
+    // which is what makes this exact rather than merely conservative.
     MatrixXd comp_mat;
     if constexpr (std::is_same<T, ComplexDouble>::value) {
         comp_mat = Eigen::Map<const MatrixXcd>(comp_vec.data(), kp1, kp1).cwiseAbs();
@@ -101,7 +105,7 @@ template <typename T> double OperatorNode<T>::calcComponentNorm(int i) const {
  * For example, \f$ \alpha_l^n = \text{getComponent}(3) \f$.
  *
  */
-template <typename T> Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> OperatorNode<T>::getComponent(int i) {
+template <typename T> Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> OperatorNode<T>::getComponent(int i) const {
     Eigen::Matrix<T, Eigen::Dynamic, 1> coef_vec;
     this->getCoefs(coef_vec);
 

--- a/src/trees/OperatorNode.h
+++ b/src/trees/OperatorNode.h
@@ -30,37 +30,55 @@
 
 namespace mrcpp {
 
-class OperatorNode final : public MWNode<2> {
+/** @class OperatorNode
+ *
+ * @brief Node of an operator tree, holding one block of the non-standard form.
+ *
+ * @details Templated on the coefficient type alongside `OperatorTree`.
+ */
+template <typename T = double> class OperatorNode final : public MWNode<2, T> {
 public:
-    OperatorTree &getOperTree() { return static_cast<OperatorTree &>(*this->tree); }
-    OperatorNode &getOperParent() { return static_cast<OperatorNode &>(*this->parent); }
-    OperatorNode &getOperChild(int i) { return static_cast<OperatorNode &>(*this->children[i]); }
+    OperatorTree<T> &getOperTree() { return static_cast<OperatorTree<T> &>(*this->tree); }
+    OperatorNode<T> &getOperParent() { return static_cast<OperatorNode<T> &>(*this->parent); }
+    OperatorNode<T> &getOperChild(int i) { return static_cast<OperatorNode<T> &>(*this->children[i]); }
 
-    const OperatorTree &getOperTree() const { return static_cast<const OperatorTree &>(*this->tree); }
-    const OperatorNode &getOperParent() const { return static_cast<const OperatorNode &>(*this->parent); }
-    const OperatorNode &getOperChild(int i) const { return static_cast<const OperatorNode &>(*this->children[i]); }
+    const OperatorTree<T> &getOperTree() const { return static_cast<const OperatorTree<T> &>(*this->tree); }
+    const OperatorNode<T> &getOperParent() const { return static_cast<const OperatorNode<T> &>(*this->parent); }
+    const OperatorNode<T> &getOperChild(int i) const { return static_cast<const OperatorNode<T> &>(*this->children[i]); }
 
     void createChildren(bool coefs) override;
     void genChildren() override;
     void deleteChildren() override;
 
-    friend class OperatorTree;
-    friend class NodeAllocator<2>;
+    /** @brief Matrix elements of the non-standard form.
+     *
+     * @param[in] i: index enumerating the matrix type in the non-standard form
+     * @returns A \f$ (k + 1) \times (k + 1) \f$ submatrix of the non-standard form.
+     *
+     * @details An operator node is uniquely associated with a scale \f$ n \f$
+     * and a translation \f$ l = -2^n + 1, \ldots, 2^n - 1 \f$. The
+     * non-standard form defines matrices \f$ \sigma_l^n, \beta_l^n,
+     * \gamma_l^n, \alpha_l^n \f$ for that pair, selected by
+     * \f$ i = 0, 1, 2, 3 \f$ respectively.
+     */
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> getComponent(int i);
+
+    friend class OperatorTree<T>;
+    friend class NodeAllocator<2, T>;
 
 protected:
     OperatorNode()
-            : MWNode<2>(){};
-    OperatorNode(MWTree<2> *tree, int rIdx)
-            : MWNode<2>(tree, rIdx){};
-    OperatorNode(MWNode<2> *parent, int cIdx)
-            : MWNode<2>(parent, cIdx){};
-    OperatorNode(const OperatorNode &node) = delete;
-    OperatorNode &operator=(const OperatorNode &node) = delete;
+            : MWNode<2, T>(){};
+    OperatorNode(MWTree<2, T> *tree, int rIdx)
+            : MWNode<2, T>(tree, rIdx){};
+    OperatorNode(MWNode<2, T> *parent, int cIdx)
+            : MWNode<2, T>(parent, cIdx){};
+    OperatorNode(const OperatorNode<T> &node) = delete;
+    OperatorNode<T> &operator=(const OperatorNode<T> &node) = delete;
     ~OperatorNode() = default;
 
     void dealloc() override;
     double calcComponentNorm(int i) const override;
-    Eigen::MatrixXd getComponent(int i);
 };
 
 } // namespace mrcpp

--- a/src/trees/OperatorNode.h
+++ b/src/trees/OperatorNode.h
@@ -61,7 +61,7 @@ public:
      * \gamma_l^n, \alpha_l^n \f$ for that pair, selected by
      * \f$ i = 0, 1, 2, 3 \f$ respectively.
      */
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> getComponent(int i);
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> getComponent(int i) const;
 
     friend class OperatorTree<T>;
     friend class NodeAllocator<2, T>;

--- a/src/trees/OperatorTree.cpp
+++ b/src/trees/OperatorTree.cpp
@@ -27,6 +27,7 @@
 #include "BandWidth.h"
 #include "NodeAllocator.h"
 #include "OperatorNode.h"
+#include "OperatorNode.h"
 #include "TreeIterator.h"
 #include "utils/Printer.h"
 #include "utils/tree_utils.h"
@@ -35,22 +36,24 @@ using namespace Eigen;
 
 namespace mrcpp {
 
-OperatorTree::OperatorTree(const MultiResolutionAnalysis<2> &mra, double np, const std::string &name)
-        : MWTree<2>(mra, name)
+template <typename T>
+OperatorTree<T>::OperatorTree(const MultiResolutionAnalysis<2> &mra, double np, const std::string &name)
+        : MWTree<2, T>(mra, name)
         , normPrec(np)
         , bandWidth(nullptr)
         , nodePtrStore(nullptr)
         , nodePtrAccess(nullptr) {
     if (this->normPrec < 0.0) MSG_ABORT("Negative prec");
 
-    int nodesPerChunk = 1024;
+    // Chunk footprint scales with sizeof(T), so hold it fixed across scalars.
+    int nodesPerChunk = 1024 * sizeof(double) / sizeof(T);
     int coefsPerNode = this->getTDim() * this->getKp1_d();
-    this->nodeAllocator_p = std::make_unique<NodeAllocator<2>>(this, nullptr, coefsPerNode, nodesPerChunk);
+    this->nodeAllocator_p = std::make_unique<NodeAllocator<2, T>>(this, nullptr, coefsPerNode, nodesPerChunk);
     this->allocRootNodes();
     this->resetEndNodeTable();
 }
 
-void OperatorTree::allocRootNodes() {
+template <typename T> void OperatorTree<T>::allocRootNodes() {
     auto &allocator = this->getNodeAllocator();
     auto &rootbox = this->getRootBox();
 
@@ -61,10 +64,10 @@ void OperatorTree::allocRootNodes() {
     auto *coef_p = allocator.getCoef_p(sIdx);
     auto *root_p = allocator.getNode_p(sIdx);
 
-    MWNode<2> **roots = rootbox.getNodes();
+    MWNode<2, T> **roots = rootbox.getNodes();
     for (int rIdx = 0; rIdx < nRoots; rIdx++) {
         // construct into allocator memory
-        new (root_p) OperatorNode(this, rIdx);
+        new (root_p) OperatorNode<T>(this, rIdx);
         roots[rIdx] = root_p;
 
         root_p->serialIx = sIdx;
@@ -87,13 +90,13 @@ void OperatorTree::allocRootNodes() {
     }
 }
 
-OperatorTree::~OperatorTree() {
+template <typename T> OperatorTree<T>::~OperatorTree() {
     clearOperNodeCache();
     clearBandWidth();
     this->deleteRootNodes();
 }
 
-void OperatorTree::clearBandWidth() {
+template <typename T> void OperatorTree<T>::clearBandWidth() {
     if (this->bandWidth != nullptr) delete this->bandWidth;
     this->bandWidth = nullptr;
 }
@@ -106,9 +109,9 @@ void OperatorTree::clearBandWidth() {
  * considerable value while keeping increasing \f$ l \f$, that stands for the distance to the diagonal.
  *
  */
-void OperatorTree::calcBandWidth(double prec) {
+template <typename T> void OperatorTree<T>::calcBandWidth(double prec) {
     if (this->bandWidth == nullptr) clearBandWidth();
-    this->bandWidth = new BandWidth(getDepth());
+    this->bandWidth = new BandWidth(this->getDepth());
 
     VectorXi max_transl;
     getMaxTranslations(max_transl);
@@ -119,7 +122,7 @@ void OperatorTree::calcBandWidth(double prec) {
         bool done = false;
         while (not done) {
             done = true;
-            MWNode<2> &node = getNode(depth, l);
+            const MWNode<2, T> &node = this->getNode(depth, l);
             double thrs = std::max(MachinePrec, prec / (8.0 * (1 << depth)));
             for (int k = 0; k < 4; k++) {
                 if (node.getComponentNorm(k) > thrs) {
@@ -142,7 +145,7 @@ void OperatorTree::calcBandWidth(double prec) {
  * @returns True if \b oTransl is outside of the band and False otherwise.
  *
  */
-bool OperatorTree::isOutsideBand(int oTransl, int o_depth, int idx) {
+template <typename T> bool OperatorTree<T>::isOutsideBand(int oTransl, int o_depth, int idx) {
     return abs(oTransl) > this->bandWidth->getWidth(o_depth, idx);
 }
 
@@ -159,9 +162,9 @@ bool OperatorTree::isOutsideBand(int oTransl, int o_depth, int idx) {
  * and as a result spread further up to the root with mwTransform.
  *
  */
-void OperatorTree::removeRoughScaleNoise(int trust_scale) {
-    MWNode<2> *p_rubbish;     // possibly inexact end node
-    MWNode<2> *p_counterpart; // exact branch node
+template <typename T> void OperatorTree<T>::removeRoughScaleNoise(int trust_scale) {
+    MWNode<2, T> *p_rubbish;     // possibly inexact end node
+    MWNode<2, T> *p_counterpart; // exact branch node
     for (int n = (this->getDepth() - 2 < trust_scale) ? this->getDepth() - 2 : trust_scale; n > this->getRootScale(); n--) {
         int N = 1 << n;
         for (int m = 0; m < N; m++)
@@ -179,10 +182,10 @@ void OperatorTree::removeRoughScaleNoise(int trust_scale) {
     }
 }
 
-void OperatorTree::getMaxTranslations(VectorXi &maxTransl) {
+template <typename T> void OperatorTree<T>::getMaxTranslations(VectorXi &maxTransl) {
     int nScales = this->nodesAtDepth.size();
     maxTransl = VectorXi::Zero(nScales);
-    TreeIterator<2> it(*this);
+    TreeIterator<2, T> it(*this);
     while (it.next()) {
         int n = it.getNode().getDepth();
         const NodeIndex<2> &l = it.getNode().getNodeIndex();
@@ -197,11 +200,11 @@ void OperatorTree::getMaxTranslations(VectorXi &maxTransl) {
  * be called within a parallel region, or all hell will break loose. This is
  * not really a problem, but you have been warned.
  */
-void OperatorTree::setupOperNodeCache() {
+template <typename T> void OperatorTree<T>::setupOperNodeCache() {
     int nScales = this->nodesAtDepth.size();
     int rootScale = this->getRootScale();
-    this->nodePtrStore = new OperatorNode **[nScales];
-    this->nodePtrAccess = new OperatorNode **[nScales];
+    this->nodePtrStore = new OperatorNode<T> **[nScales];
+    this->nodePtrAccess = new OperatorNode<T> **[nScales];
     VectorXi max_transl;
     getMaxTranslations(max_transl);
     for (int n = 0; n < nScales; n++) {
@@ -209,12 +212,12 @@ void OperatorTree::setupOperNodeCache() {
         int n_transl = max_transl[n];
         int n_nodes = 2 * n_transl + 1;
 
-        auto **nodes = new OperatorNode *[n_nodes];
+        auto **nodes = new OperatorNode<T> *[n_nodes];
         int j = 0;
         for (int i = n_transl; i >= 0; i--) {
             NodeIndex<2> idx(scale, {0, i});
             // Generated OperatorNodes are still OperatorNodes
-            if (auto *oNode = dynamic_cast<OperatorNode *>(&MWTree<2>::getNode(idx))) {
+            if (auto *oNode = dynamic_cast<OperatorNode<T> *>(&MWTree<2, T>::getNode(idx))) {
                 nodes[j] = oNode;
                 j++;
             } else {
@@ -223,7 +226,7 @@ void OperatorTree::setupOperNodeCache() {
         }
         for (int i = 1; i <= n_transl; i++) {
             NodeIndex<2> idx(scale, {i, 0});
-            if (auto *oNode = dynamic_cast<OperatorNode *>(&MWTree<2>::getNode(idx))) {
+            if (auto *oNode = dynamic_cast<OperatorNode<T> *>(&MWTree<2, T>::getNode(idx))) {
                 nodes[j] = oNode;
                 j++;
             } else {
@@ -237,9 +240,9 @@ void OperatorTree::setupOperNodeCache() {
     this->resetEndNodeTable();
 }
 
-void OperatorTree::clearOperNodeCache() {
+template <typename T> void OperatorTree<T>::clearOperNodeCache() {
     if (this->nodePtrStore != nullptr) {
-        for (int i = 0; i < getDepth(); i++) { delete[] this->nodePtrStore[i]; }
+        for (int i = 0; i < this->getDepth(); i++) { delete[] this->nodePtrStore[i]; }
         delete[] this->nodePtrStore;
         delete[] this->nodePtrAccess;
     }
@@ -251,14 +254,14 @@ void OperatorTree::clearOperNodeCache() {
  * Reimplementation of MWTree::mwTransform() without OMP, as calculation
  * of OperatorNorm is done using random vectors, which is non-deterministic
  * in parallel. FunctionTrees should be fine. */
-void OperatorTree::mwTransformUp() {
-    std::vector<MWNodeVector<2>> nodeTable;
+template <typename T> void OperatorTree<T>::mwTransformUp() {
+    std::vector<MWNodeVector<2, T>> nodeTable;
     tree_utils::make_node_table(*this, nodeTable);
     int start = nodeTable.size() - 2;
     for (int n = start; n >= 0; n--) {
         int nNodes = nodeTable[n].size();
         for (int i = 0; i < nNodes; i++) {
-            MWNode<2> &node = *nodeTable[n][i];
+            MWNode<2, T> &node = *nodeTable[n][i];
             if (node.isBranchNode()) { node.reCompress(); }
         }
     }
@@ -270,21 +273,24 @@ void OperatorTree::mwTransformUp() {
  * Reimplementation of MWTree::mwTransform() without OMP, as calculation
  * of OperatorNorm is done using random vectors, which is non-deterministic
  * in parallel. FunctionTrees should be fine. */
-void OperatorTree::mwTransformDown(bool overwrite) {
-    std::vector<MWNodeVector<2>> nodeTable;
+template <typename T> void OperatorTree<T>::mwTransformDown(bool overwrite) {
+    std::vector<MWNodeVector<2, T>> nodeTable;
     tree_utils::make_node_table(*this, nodeTable);
     for (auto &n : nodeTable) {
         int n_nodes = n.size();
         for (int i = 0; i < n_nodes; i++) {
-            MWNode<2> &node = *n[i];
+            MWNode<2, T> &node = *n[i];
             if (node.isBranchNode()) { node.giveChildrenCoefs(overwrite); }
         }
     }
 }
 
-std::ostream &OperatorTree::print(std::ostream &o) const {
+template <typename T> std::ostream &OperatorTree<T>::print(std::ostream &o) const {
     o << std::endl << "*OperatorTree: " << this->name << std::endl;
-    return MWTree<2>::print(o);
+    return MWTree<2, T>::print(o);
 }
+
+template class OperatorTree<double>;
+template class OperatorTree<ComplexDouble>;
 
 } // namespace mrcpp

--- a/src/trees/OperatorTree.cpp
+++ b/src/trees/OperatorTree.cpp
@@ -27,7 +27,6 @@
 #include "BandWidth.h"
 #include "NodeAllocator.h"
 #include "OperatorNode.h"
-#include "OperatorNode.h"
 #include "TreeIterator.h"
 #include "utils/Printer.h"
 #include "utils/tree_utils.h"
@@ -110,7 +109,9 @@ template <typename T> void OperatorTree<T>::clearBandWidth() {
  *
  */
 template <typename T> void OperatorTree<T>::calcBandWidth(double prec) {
-    if (this->bandWidth == nullptr) clearBandWidth();
+    // clearBandWidth() is a no-op when there is nothing to free, so calling it
+    // unconditionally is what keeps a rebuild from leaking the previous one.
+    this->clearBandWidth();
     this->bandWidth = new BandWidth(this->getDepth());
 
     VectorXi max_transl;

--- a/src/trees/OperatorTree.h
+++ b/src/trees/OperatorTree.h
@@ -34,11 +34,7 @@ namespace mrcpp {
  *
  * @brief Non-standard form of a separable operator.
  *
- * @details Templated on the coefficient type the same way `FunctionTree` is:
- * real for Poisson, Helmholtz, the derivative operators and identity, complex
- * for the Schrodinger semigroup. A caller holds whichever matches the kernel,
- * so a real operator keeps real storage and only time evolution pays for being
- * complex.
+ * @tparam T Coefficient type, `double` or `ComplexDouble`.
  */
 template <typename T = double> class OperatorTree : public MWTree<2, T> {
 public:

--- a/src/trees/OperatorTree.h
+++ b/src/trees/OperatorTree.h
@@ -30,12 +30,22 @@
 
 namespace mrcpp {
 
-class OperatorTree : public MWTree<2> {
+/** @class OperatorTree
+ *
+ * @brief Non-standard form of a separable operator.
+ *
+ * @details Templated on the coefficient type the same way `FunctionTree` is:
+ * real for Poisson, Helmholtz, the derivative operators and identity, complex
+ * for the Schrodinger semigroup. A caller holds whichever matches the kernel,
+ * so a real operator keeps real storage and only time evolution pays for being
+ * complex.
+ */
+template <typename T = double> class OperatorTree : public MWTree<2, T> {
 public:
     OperatorTree(const MultiResolutionAnalysis<2> &mra, double np, const std::string &name = "nn");
-    OperatorTree(const OperatorTree &tree) = delete;
-    OperatorTree &operator=(const OperatorTree &tree) = delete;
-    virtual ~OperatorTree() override;
+    OperatorTree(const OperatorTree<T> &tree) = delete;
+    OperatorTree<T> &operator=(const OperatorTree<T> &tree) = delete;
+    ~OperatorTree() override;
 
     double getNormPrecision() const { return this->normPrec; }
 
@@ -50,23 +60,23 @@ public:
     BandWidth &getBandWidth() { return *this->bandWidth; }
     const BandWidth &getBandWidth() const { return *this->bandWidth; }
 
-    OperatorNode &getNode(int n, int l) {
+    OperatorNode<T> &getNode(int n, int l) {
         return *nodePtrAccess[n][l];
     } ///< TODO: It has to be specified more.
       ///< \b l is distance to the diagonal.
-    const OperatorNode &getNode(int n, int l) const { return *nodePtrAccess[n][l]; }
+    const OperatorNode<T> &getNode(int n, int l) const { return *nodePtrAccess[n][l]; }
 
     void mwTransformDown(bool overwrite) override;
     void mwTransformUp() override;
 
-    using MWTree<2>::getNode;
-    using MWTree<2>::findNode;
+    using MWTree<2, T>::getNode;
+    using MWTree<2, T>::findNode;
 
 protected:
     const double normPrec;
     BandWidth *bandWidth;
-    OperatorNode ***nodePtrStore;  ///< Avoids tree lookups
-    OperatorNode ***nodePtrAccess; ///< Center (l=0) of node list
+    OperatorNode<T> ***nodePtrStore;  ///< Avoids tree lookups
+    OperatorNode<T> ***nodePtrAccess; ///< Center (l=0) of node list
 
     void allocRootNodes();
     void getMaxTranslations(Eigen::VectorXi &maxTransl);

--- a/tests/operators/helmholtz_operator.cpp
+++ b/tests/operators/helmholtz_operator.cpp
@@ -101,7 +101,7 @@ TEST_CASE("Helmholtz' kernel", "[init_helmholtz], [helmholtz_operator], [mw_oper
                     FunctionTree<1> &kern_tree = get_func(K, i);
                     CrossCorrelationCalculator calculator(kern_tree);
 
-                    auto oper_tree = std::make_unique<OperatorTree>(oper_mra, ccc_prec);
+                    auto oper_tree = std::make_unique<OperatorTree<double>>(oper_mra, ccc_prec);
                     builder.build(*oper_tree, calculator, adaptor, -1);
                     oper_tree->setupOperNodeCache();
 

--- a/tests/operators/identity_convolution.cpp
+++ b/tests/operators/identity_convolution.cpp
@@ -83,7 +83,7 @@ TEST_CASE("Initialize identity convolution operator", "[init_identity], [identit
                 OperatorAdaptor adaptor(ccc_prec, oper_mra.getMaxScale());
                 CrossCorrelationCalculator calculator(kern_tree);
 
-                OperatorTree oper_tree(oper_mra, ccc_prec);
+                OperatorTree<double> oper_tree(oper_mra, ccc_prec);
                 builder.build(oper_tree, calculator, adaptor, -1);
                 oper_tree.setupOperNodeCache();
 

--- a/tests/operators/poisson_operator.cpp
+++ b/tests/operators/poisson_operator.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Initialize Poisson operator", "[init_poisson], [poisson_operator], [m
                     FunctionTree<1> &kern_tree = get_func(kern_vec, i);
                     CrossCorrelationCalculator calculator(kern_tree);
 
-                    auto oper_tree = std::make_unique<OperatorTree>(oper_mra, ccc_prec);
+                    auto oper_tree = std::make_unique<OperatorTree<double>>(oper_mra, ccc_prec);
                     builder.build(*oper_tree, calculator, adaptor, -1);
                     oper_tree->setupOperNodeCache();
 

--- a/tests/operators/schrodinger_evolution_operator.cpp
+++ b/tests/operators/schrodinger_evolution_operator.cpp
@@ -27,6 +27,8 @@
 
 #include "factory_functions.h"
 
+#include <cmath>
+
 #include "functions/special_functions.h"
 #include "operators/MWOperator.h"
 #include "operators/TimeEvolutionOperator.h"
@@ -75,8 +77,19 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     double tolerance = prec * prec / 25.0;
     REQUIRE(error.getSquareNorm() == Catch::Approx(0.0).margin(tolerance));
 
-    // The kernel really is complex: a real-valued tree would leave this at zero
-    REQUIRE(Exp.getComponentCplx(0, 0).getSquareNorm() > 0.0);
+    // The kernel is genuinely complex, not a real tree in complex storage:
+    // propagating a purely real state has to generate an imaginary part.
+    auto real_in = [sigma, x0](const mrcpp::Coord<1> &r) -> ComplexDouble {
+        double dx = r[0] - x0;
+        return {std::exp(-dx * dx / (2.0 * sigma)), 0.0};
+    };
+    mrcpp::FunctionTree<1, ComplexDouble> real_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, real_tree, real_in);
+    REQUIRE(real_tree.Imag()->getSquareNorm() == Catch::Approx(0.0).margin(1.0e-20));
+
+    mrcpp::FunctionTree<1, ComplexDouble> real_out(MRA);
+    mrcpp::apply<1, ComplexDouble>(prec, real_out, Exp, real_tree, -1, false);
+    REQUIRE(real_out.Imag()->getSquareNorm() > 1.0e-12);
 }
 
 TEST_CASE("Apply Schrodinger's evolution operator on a uniform grid", "[apply_schrodinger_uniform], [schrodinger_evolution_operator], [mw_operator]") {

--- a/tests/operators/schrodinger_evolution_operator.cpp
+++ b/tests/operators/schrodinger_evolution_operator.cpp
@@ -42,8 +42,6 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     const auto order = 4;
     const auto prec = 1.0e-7;
 
-    int finest_scale = 7;
-
     double t1 = 0.001;
     double delta_t = 0.03;
     double t2 = delta_t + t1;
@@ -52,8 +50,9 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     auto world = mrcpp::BoundingBox<1>(min_scale);
     auto MRA = mrcpp::MultiResolutionAnalysis<1>(world, basis, max_depth);
 
-    // One operator holding the whole semigroup as a complex operator tree
-    mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t, finest_scale);
+    // One operator holding the whole semigroup as a complex operator tree,
+    // built adaptively from the precision as every convolution operator is
+    mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t);
     REQUIRE(Exp.iscomplex());
 
     double sigma = 0.001;
@@ -78,6 +77,44 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
 
     // The kernel really is complex: a real-valued tree would leave this at zero
     REQUIRE(Exp.getComponentCplx(0, 0).getSquareNorm() > 0.0);
+}
+
+TEST_CASE("Apply Schrodinger's evolution operator on a uniform grid", "[apply_schrodinger_uniform], [schrodinger_evolution_operator], [mw_operator]") {
+    const auto min_scale = 0;
+    const auto max_depth = 25;
+    const auto order = 4;
+    const auto prec = 1.0e-7;
+
+    double t1 = 0.001;
+    double delta_t = 0.03;
+    double t2 = delta_t + t1;
+
+    auto basis = mrcpp::LegendreBasis(order);
+    auto world = mrcpp::BoundingBox<1>(min_scale);
+    auto MRA = mrcpp::MultiResolutionAnalysis<1>(world, basis, max_depth);
+
+    // The fixed-scale overload, bypassing the adaptive build
+    mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t, 7);
+    REQUIRE(Exp.iscomplex());
+
+    double sigma = 0.001;
+    double x0 = 0.5;
+
+    auto f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> ComplexDouble { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma); };
+    auto g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> ComplexDouble { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma); };
+
+    mrcpp::FunctionTree<1, ComplexDouble> f_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, f_tree, f);
+    mrcpp::FunctionTree<1, ComplexDouble> g_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, g_tree, g);
+
+    mrcpp::FunctionTree<1, ComplexDouble> fout_tree(MRA);
+    mrcpp::apply<1, ComplexDouble>(prec, fout_tree, Exp, f_tree, -1, false);
+
+    mrcpp::FunctionTree<1, ComplexDouble> error(MRA);
+    mrcpp::add<1, ComplexDouble>(prec, error, {1.0, 0.0}, fout_tree, {-1.0, 0.0}, g_tree, -1, false, false);
+    double tolerance = prec * prec / 25.0;
+    REQUIRE(error.getSquareNorm() == Catch::Approx(0.0).margin(tolerance));
 }
 
 } // namespace schrodinger_evolution_operator

--- a/tests/operators/schrodinger_evolution_operator.cpp
+++ b/tests/operators/schrodinger_evolution_operator.cpp
@@ -27,12 +27,11 @@
 
 #include "factory_functions.h"
 
-#include "functions/GaussFunc.h"
 #include "functions/special_functions.h"
 #include "operators/MWOperator.h"
 #include "operators/TimeEvolutionOperator.h"
 #include "treebuilders/add.h"
-#include "treebuilders/complex_apply.h"
+#include "treebuilders/apply.h"
 #include "treebuilders/project.h"
 
 namespace schrodinger_evolution_operator {
@@ -40,79 +39,45 @@ namespace schrodinger_evolution_operator {
 TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolution], [schrodinger_evolution_operator], [mw_operator]") {
     const auto min_scale = 0;
     const auto max_depth = 25;
-
     const auto order = 4;
     const auto prec = 1.0e-7;
 
-    int finest_scale = 7; // for time evolution operator construction (not recommended to use more than 10)
-    // int max_Jpower = 20;  //the amount of J integrals to be used in construction (20 should be enough)
+    int finest_scale = 7;
 
-    // Time moments:
-    double t1 = 0.001;        // initial time moment (not recommended to use more than 0.001)
-    double delta_t = 0.03;    // time step (not recommended to use less than 0.001)
-    double t2 = delta_t + t1; // final time moment
+    double t1 = 0.001;
+    double delta_t = 0.03;
+    double t2 = delta_t + t1;
 
-    // Initialize world in the unit cube [0,1]
     auto basis = mrcpp::LegendreBasis(order);
     auto world = mrcpp::BoundingBox<1>(min_scale);
     auto MRA = mrcpp::MultiResolutionAnalysis<1>(world, basis, max_depth);
 
-    // Time evolution operatror Exp(delta_t)
-    mrcpp::TimeEvolutionOperator<1> ReExp(MRA, prec, delta_t, finest_scale, false);
-    mrcpp::TimeEvolutionOperator<1> ImExp(MRA, prec, delta_t, finest_scale, true);
+    // One operator holding the whole semigroup as a complex operator tree
+    mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t, finest_scale);
+    REQUIRE(Exp.iscomplex());
 
-    // Analytical solution parameters for psi(x, t)
     double sigma = 0.001;
     double x0 = 0.5;
 
-    // Functions f(x) = psi(x, t1) and g(x) = psi(x, t2)
-    auto Re_f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).real(); };
-    auto Im_f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).imag(); };
-    auto Re_g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).real(); };
-    auto Im_g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> double { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma).imag(); };
+    auto f = [sigma, x0, t = t1](const mrcpp::Coord<1> &r) -> ComplexDouble { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma); };
+    auto g = [sigma, x0, t = t2](const mrcpp::Coord<1> &r) -> ComplexDouble { return mrcpp::free_particle_analytical_solution(r[0], x0, t, sigma); };
 
-    // Projecting functions
-    mrcpp::FunctionTree<1> Re_f_tree(MRA);
-    mrcpp::project<1, double>(prec, Re_f_tree, Re_f);
-    mrcpp::FunctionTree<1> Im_f_tree(MRA);
-    mrcpp::project<1, double>(prec, Im_f_tree, Im_f);
-    mrcpp::FunctionTree<1> Re_g_tree(MRA);
-    mrcpp::project<1, double>(prec, Re_g_tree, Re_g);
-    mrcpp::FunctionTree<1> Im_g_tree(MRA);
-    mrcpp::project<1, double>(prec, Im_g_tree, Im_g);
+    mrcpp::FunctionTree<1, ComplexDouble> f_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, f_tree, f);
+    mrcpp::FunctionTree<1, ComplexDouble> g_tree(MRA);
+    mrcpp::project<1, ComplexDouble>(prec, g_tree, g);
 
-    // Output function trees
-    mrcpp::FunctionTree<1> Re_fout_tree(MRA);
-    mrcpp::FunctionTree<1> Im_fout_tree(MRA);
+    mrcpp::FunctionTree<1, ComplexDouble> fout_tree(MRA);
+    mrcpp::apply<1, ComplexDouble>(prec, fout_tree, Exp, f_tree, -1, false);
 
-    // Complex objects for use in apply()
-    mrcpp::ComplexObject<mrcpp::ConvolutionOperator<1>> E(ReExp, ImExp);
-    mrcpp::ComplexObject<mrcpp::FunctionTree<1>> input(Re_f_tree, Im_f_tree);
-    mrcpp::ComplexObject<mrcpp::FunctionTree<1>> output(Re_fout_tree, Im_fout_tree);
+    // Agreement with the analytic solution at the later time
+    mrcpp::FunctionTree<1, ComplexDouble> error(MRA);
+    mrcpp::add<1, ComplexDouble>(prec, error, {1.0, 0.0}, fout_tree, {-1.0, 0.0}, g_tree, -1, false, false);
+    double tolerance = prec * prec / 25.0;
+    REQUIRE(error.getSquareNorm() == Catch::Approx(0.0).margin(tolerance));
 
-    // Apply operator Exp(delta_t) f(x)
-    mrcpp::apply(prec, output, E, input);
-
-    // Check g(x) = Exp(delta_t) f(x)
-    mrcpp::FunctionTree<1> Re_error(MRA); // = Re_fout_tree - Re_g_tree
-    mrcpp::FunctionTree<1> Im_error(MRA); // = Im_fout_tree - Im_g_tree
-
-    // Re_error = Re_fout_tree - Re_g_tree
-    mrcpp::add(prec, Re_error, 1.0, Re_fout_tree, -1.0, Re_g_tree);
-    auto Re_sq_norm = Re_error.getSquareNorm(); // 1.7e-16
-
-    // Im_error = Im_fout_tree - Im_g_tree
-    mrcpp::add(prec, Im_error, 1.0, Im_fout_tree, -1.0, Im_g_tree);
-    auto Im_sq_norm = Im_error.getSquareNorm(); // 1.7e-17
-
-    double tolerance = prec * prec / 50.0; // 2.0e-16
-
-    // std::cout << "Re_sq_norm = " << Re_sq_norm << std::endl;
-    // std::cout << "Im_sq_norm = " << Im_sq_norm << std::endl;
-    // std::cout << "tolerance = " << tolerance << std::endl;
-
-    REQUIRE(Re_sq_norm == Catch::Approx(0.0).margin(tolerance));
-    REQUIRE(Im_sq_norm == Catch::Approx(0.0).margin(tolerance));
+    // The kernel really is complex: a real-valued tree would leave this at zero
+    REQUIRE(Exp.getComponentCplx(0, 0).getSquareNorm() > 0.0);
 }
 
 } // namespace schrodinger_evolution_operator

--- a/tests/operators/schrodinger_evolution_operator.cpp
+++ b/tests/operators/schrodinger_evolution_operator.cpp
@@ -28,6 +28,7 @@
 #include "factory_functions.h"
 
 #include <cmath>
+#include <memory>
 
 #include "functions/special_functions.h"
 #include "operators/MWOperator.h"
@@ -85,11 +86,18 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     };
     mrcpp::FunctionTree<1, ComplexDouble> real_tree(MRA);
     mrcpp::project<1, ComplexDouble>(prec, real_tree, real_in);
-    REQUIRE(real_tree.Imag()->getSquareNorm() == Catch::Approx(0.0).margin(1.0e-20));
+
+    // Real() and Imag() hand back a newly allocated tree, so own the result
+    std::unique_ptr<mrcpp::FunctionTree<1, double>> in_imag(real_tree.Imag());
+    REQUIRE(in_imag->getSquareNorm() == Catch::Approx(0.0).margin(1.0e-20));
 
     mrcpp::FunctionTree<1, ComplexDouble> real_out(MRA);
     mrcpp::apply<1, ComplexDouble>(prec, real_out, Exp, real_tree, -1, false);
-    REQUIRE(real_out.Imag()->getSquareNorm() > 1.0e-12);
+
+    std::unique_ptr<mrcpp::FunctionTree<1, double>> out_imag(real_out.Imag());
+    // The input carries no imaginary part, so anything here came from the
+    // kernel. Well clear of projection noise at prec = 1e-7.
+    REQUIRE(out_imag->getSquareNorm() > 1.0e-12);
 }
 
 TEST_CASE("Apply Schrodinger's evolution operator on a uniform grid", "[apply_schrodinger_uniform], [schrodinger_evolution_operator], [mw_operator]") {

--- a/tests/operators/schrodinger_evolution_operator.cpp
+++ b/tests/operators/schrodinger_evolution_operator.cpp
@@ -53,8 +53,7 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     auto world = mrcpp::BoundingBox<1>(min_scale);
     auto MRA = mrcpp::MultiResolutionAnalysis<1>(world, basis, max_depth);
 
-    // One operator holding the whole semigroup as a complex operator tree,
-    // built adaptively from the precision as every convolution operator is
+    // One operator holding the whole semigroup as a complex operator tree
     mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t);
     REQUIRE(Exp.iscomplex());
 
@@ -78,8 +77,7 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     double tolerance = prec * prec / 25.0;
     REQUIRE(error.getSquareNorm() == Catch::Approx(0.0).margin(tolerance));
 
-    // The kernel is genuinely complex, not a real tree in complex storage:
-    // propagating a purely real state has to generate an imaginary part.
+    // This propagator generates an imaginary component from a real state.
     auto real_in = [sigma, x0](const mrcpp::Coord<1> &r) -> ComplexDouble {
         double dx = r[0] - x0;
         return {std::exp(-dx * dx / (2.0 * sigma)), 0.0};
@@ -87,7 +85,7 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     mrcpp::FunctionTree<1, ComplexDouble> real_tree(MRA);
     mrcpp::project<1, ComplexDouble>(prec, real_tree, real_in);
 
-    // Real() and Imag() hand back a newly allocated tree, so own the result
+    // The caller owns the trees returned by Real() and Imag()
     std::unique_ptr<mrcpp::FunctionTree<1, double>> in_imag(real_tree.Imag());
     REQUIRE(in_imag->getSquareNorm() == Catch::Approx(0.0).margin(1.0e-20));
 
@@ -95,8 +93,7 @@ TEST_CASE("Apply Schrodinger's evolution operator", "[apply_schrodinger_evolutio
     mrcpp::apply<1, ComplexDouble>(prec, real_out, Exp, real_tree, -1, false);
 
     std::unique_ptr<mrcpp::FunctionTree<1, double>> out_imag(real_out.Imag());
-    // The input carries no imaginary part, so anything here came from the
-    // kernel. Well clear of projection noise at prec = 1e-7.
+    // Above the projection-noise level for this prec
     REQUIRE(out_imag->getSquareNorm() > 1.0e-12);
 }
 


### PR DESCRIPTION
I was making templates for native complex TimeEvolution and then updating TimeEvolution to be natively complex. Now instead of 2 trees for real and imaginary we have one complex tree. I also added other changes - I changed MSG_ERROR to MSG_ABORT because MSG_ERROR did not stop the process on error, it just printed the error and then executed return *this->oper_exp[i][d];.

 !GENERAL RULE: before it was like this:
 
mrcpp::TimeEvolutionOperator<1> ReExp(MRA, prec, delta_t, finest_scale, false);
mrcpp::TimeEvolutionOperator<1> ImExp(MRA, prec, delta_t, finest_scale, true);

auto Re_f = [&](const mrcpp::Coord<1> &r) -> double { return psi(r[0], t).real(); };
auto Im_f = [&](const mrcpp::Coord<1> &r) -> double { return psi(r[0], t).imag(); };

mrcpp::FunctionTree<1> Re_f_tree(MRA), Im_f_tree(MRA);
mrcpp::project<1, double>(prec, Re_f_tree, Re_f);
mrcpp::project<1, double>(prec, Im_f_tree, Im_f);
mrcpp::FunctionTree<1> Re_out(MRA), Im_out(MRA);

mrcpp::ComplexObject<mrcpp::ConvolutionOperator<1>> E(ReExp, ImExp);
mrcpp::ComplexObject<mrcpp::FunctionTree<1>> input(Re_f_tree, Im_f_tree);
mrcpp::ComplexObject<mrcpp::FunctionTree<1>> output(Re_out, Im_out);

mrcpp::apply(prec, output, E, input); 

Now it will become like this:

mrcpp::TimeEvolutionOperator<1> Exp(MRA, prec, delta_t, finest_scale);

auto f = [&](const mrcpp::Coord<1> &r) -> ComplexDouble { return psi(r[0], t); };

mrcpp::FunctionTree<1, ComplexDouble> f_tree(MRA), out(MRA);
mrcpp::project<1, ComplexDouble>(prec, f_tree, f);

mrcpp::apply<1, ComplexDouble>(prec, out, Exp, f_tree);

!NOTE FOR BACKWARD COMPATIBILITY: if you still need to access real or imaginary parts, use this: 
std::unique_ptr<mrcpp::FunctionTree<1, double>> re(out.Real());
std::unique_ptr<mrcpp::FunctionTree<1, double>> im(out.Imag());